### PR TITLE
Enhance publications page and add reference extraction

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -23,29 +23,28 @@ permalink: /publications/
     <script type="text/javascript"  src="https://cdn.datatables.net/buttons/2.2.3/js/buttons.print.min.js"></script>
   <!--set sort order in table header finish-->
   <style>
+    :root {
+      --primary-color: #520049;
+      --secondary-color: #f5f5f5;
+      --text-color: #333;
+      --border-radius: 8px;
+      --transition: all 0.3s ease;
+      --box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
     body {
-    padding-top: 0px;
-}
-    .box_style {
-    background: #fff;
-}
-    .header_box {
-    border: none;
-    background: #efefef;
-    font-size:24px
-  }
-  h2{
-    font-size:20px;
-    font-weight: bold
-  }
-/* 按钮容器样式 */
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.7;
+      color: var(--text-color);
+      font-size: 16px;
+      letter-spacing: 0.3px;
+      padding-top: 0px;
+    }
     .button-container {
       display: flex;
       justify-content: left;
       align-items: center;
       height: 50px;
     }
-    /* 按钮样式 */
     .button {
       display: block;
       padding: 10px;
@@ -58,75 +57,57 @@ permalink: /publications/
       border: 1px solid #005826;
       border-radius: 5px;
     }
-    /* 鼠标悬停样式 */
     .button:hover {
       background-color: #999;
       cursor: pointer;
     }
-    /* 样式表格 */
-    .table-style1 {
-        border: 2px solid #ffffff;
-        border: 2px solid #ffffff;
-		    border: 2px solid #ffffff;
-		    border-radius: 5px;
-		    background-color: #fff;
-		    border-radius: 5px;
-        }
-		  .table-style1 th {
-        background-color: #520049;
-        background-color: #520049;
-        background-color: #520049;
-        color: rgba(255,255,255,0.9);
-		    cursor: pointer;
-        }
-		  .table-style1 td {
-		    background-color: #ffffff;
-		    background-color: #f9f9f9;
-		    background-color: #f9f9f9;
-		    }		
-		  .table-style1 th, .table-style1 td {
-		  padding: 10px 10px;
-		}
-    table.dataTable.no-footer {
-  border-bottom: 1px solid rgba(0, 0, 0, 0);
-}
-    /* 隐藏所有 sheet */
-    .sheet {
-      display: none;
+    .button.clicked {
+      background-color: #999;
     }
-    /* Style the search box */
-  #searchBox {
-    padding: 10px;
-    font-size: 16px;
-    border: 2px solid #ccc;
-    border-radius: 1px;
-    width: 300px;
-  }
-  /* Style the search box when it has focus */
-  #searchBox:focus {
-    outline: none;
-    border-color: #efefef;
-  }
-  /* Style the placeholder text */
-  #searchBox::placeholder {
-    font-size: 16px;
-  }
-  button, input, optgroup, select, textarea {
-    color: #000000;
-    font: inherit;
-    /* font-weight: bold; */
-    margin: 0;
-}
-  /* 搜索框和下载框水平布局 */
+    .table-style1 {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 20px 0;
+      background: white;
+      border-radius: var(--border-radius);
+      overflow: hidden;
+      box-shadow: var(--box-shadow);
+    }
+    .table-style1 th {
+      background: var(--primary-color);
+      color: white;
+      padding: 12px;
+      text-align: left;
+    }
+    .table-style1 td {
+      padding: 12px;
+      border-bottom: 1px solid #e8e8e8;
+    }
+    .table-style1 tbody tr:nth-child(even) {
+      background: rgba(245, 245, 245, 0.5);
+    }
+    .table-style1 tbody tr:hover {
+      background: rgba(82, 0, 73, 0.05);
+    }
+    #searchBox {
+      padding: 10px;
+      font-size: 16px;
+      border: 2px solid #ccc;
+      border-radius: 4px;
+      width: 300px;
+    }
+    #searchBox:focus {
+      outline: none;
+      border-color: #efefef;
+    }
     .form-container {
       display: flex;
       align-items: center;
-      overflow:auto
+      overflow: auto;
     }
     .form-container input {
       margin-right: 10px;
     }
-    /* 下载框位置设置 */
     .form-container select {
       margin-left: auto;
       padding: 10px;
@@ -135,9 +116,6 @@ permalink: /publications/
       border-radius: 4px;
       width: 300px;
     }
-    .button.clicked {
-    background-color: #999;
-}
   </style>
 </head>
 
@@ -4473,6 +4451,8 @@ var tables = [];
      $(document).ready(function() {
     $.noConflict();
     tables.push($('#reviewtable').DataTable({
+      responsive: true,
+      pageLength: 25,
       dom: 'Bfrtip',
       buttons: [
         'copy', 'csv', 'excel', 'pdf', 'print'
@@ -4480,6 +4460,8 @@ var tables = [];
     }));
 
     tables.push($('#researchtable').DataTable({
+      responsive: true,
+      pageLength: 25,
       dom: 'Bfrtip',
       buttons: [
         'copy', 'csv', 'excel', 'pdf', 'print'
@@ -4487,6 +4469,8 @@ var tables = [];
     }));
 
     tables.push($('#rnapretable').DataTable({
+      responsive: true,
+      pageLength: 25,
       dom: 'Bfrtip',
       buttons: [
         'copy', 'csv', 'excel', 'pdf', 'print'

--- a/combinedRef.json
+++ b/combinedRef.json
@@ -1,0 +1,8326 @@
+[
+  {
+    "pmid": "9310370",
+    "publication": {
+      "pmid": "9310370",
+      "year": "1997",
+      "authors": "Urvil, P. T., Kakiuchi, N., Zhou, D. M., Shimotohno, K.",
+      "title": "Selection of RNA aptamers that bind specifically to the NS3 protease of hepatitis C virus",
+      "journal": "European journal of biochemistry"
+    },
+    "posts": [
+      "_posts/10G-1-aptamer.md",
+      "_posts/G9-II-aptamer.md",
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9356339",
+    "publication": {
+      "pmid": "9356339",
+      "year": "1997",
+      "authors": "Kumar, P. K., Machida, K., Urvil, P. T., Kakiuchi, N., Vishnuvardhan, D.",
+      "title": "Isolation of RNA aptamers specific to the NS3 protein of hepatitis C virus from a pool of completely random RNA",
+      "journal": "Virology"
+    },
+    "posts": [
+      "_posts/10G-1-aptamer.md",
+      "_posts/G9-II-aptamer.md",
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10848986",
+    "publication": {
+      "pmid": "10848986",
+      "year": "2000",
+      "authors": "Fukuda, K., Vishnuvardhan, D., Sekiya, S., Hwang, J., Kakiuchi, N.",
+      "title": "Isolation and characterization of RNA aptamers specific for the hepatitis C virus nonstructural protein 3 protease",
+      "journal": "European journal of biochemistry"
+    },
+    "posts": [
+      "_posts/10G-1-aptamer.md",
+      "_posts/G9-II-aptamer.md",
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11118325",
+    "publication": {
+      "pmid": "11118325",
+      "year": "2000",
+      "authors": "Hwang, J., Fauzi, H., Fukuda, K., Sekiya, S., Kakiuchi, N., Shimotohno, K., Taira, K., Kusakabe, I., & Nishikawa, S.",
+      "title": "The RNA aptamer-binding site of hepatitis C virus NS3 protease",
+      "journal": "Biochemical and biophysical research communications"
+    },
+    "posts": [
+      "_posts/10G-1-aptamer.md",
+      "_posts/G9-II-aptamer.md",
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12655010",
+    "publication": {
+      "pmid": "12655010",
+      "year": "2003",
+      "authors": "Nishikawa, F., Kakiuchi, N., Funaji, K., Fukuda, K., Sekiya, S., & Nishikawa, S.",
+      "title": "Inhibition of HCV NS3 protease by RNA aptamers in cells",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/10G-1-aptamer.md",
+      "_posts/G9-II-aptamer.md",
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15541341",
+    "publication": {
+      "pmid": "15541341",
+      "year": "2004",
+      "authors": "Fukuda, K., Umehara, T., Sekiya, S., Kunio, K., Hasegawa, T., & Nishikawa, S.",
+      "title": "An RNA ligand inhibits hepatitis C virus NS3 protease and helicase activities",
+      "journal": "Biochemical and biophysical research communications"
+    },
+    "posts": [
+      "_posts/10G-1-aptamer.md",
+      "_posts/G9-II-aptamer.md",
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22814430",
+    "publication": {
+      "pmid": "22814430",
+      "year": "2012",
+      "authors": "Vaughan, R., Li, Y., Fan, B., Ranjith-Kumar, C. T., & Kao, C. C.",
+      "title": "RNA binding by the NS3 protease of the hepatitis C virus",
+      "journal": "Virus research"
+    },
+    "posts": [
+      "_posts/10G-1-aptamer.md",
+      "_posts/G9-II-aptamer.md",
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7505429",
+    "publication": {
+      "pmid": "7505429",
+      "year": "1993",
+      "authors": "Giver, L., Bartel, D., Zapp, M., Pawul, A., Green, M., & Ellington, A. D.",
+      "title": "Selective optimization of the Rev-binding element of HIV-1",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-REV-peptide-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md",
+      "_posts/59-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7506689",
+    "publication": {
+      "pmid": "7506689",
+      "year": "1993",
+      "authors": "Giver, L., Bartel, D. P., Zapp, M. L., Green, M. R., & Ellington, A. D.",
+      "title": "Selection and design of high-affinity RNA ligands for HIV-1 Rev",
+      "journal": "Gene"
+    },
+    "posts": [
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md",
+      "_posts/59-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7664035",
+    "publication": {
+      "pmid": "7664035",
+      "year": "1994",
+      "authors": "Leclerc, F., Cedergren, R., & Ellington, A. D.",
+      "title": "A three-dimensional model of the Rev-binding element of HIV-1 derived from analyses of aptamers",
+      "journal": "Nature structural biology"
+    },
+    "posts": [
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md",
+      "_posts/59-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8523524",
+    "publication": {
+      "pmid": "8523524",
+      "year": "1996",
+      "authors": "Symensma, T. L., Giver, L., Zapp, M., Takle, G. B., & Ellington, A. D.",
+      "title": "RNA aptamers selected to bind human immunodeficiency virus type 1 Rev in vitro are Rev responsive in vivo",
+      "journal": "Journal of virology"
+    },
+    "posts": [
+      "_posts/C52-aptamer.md",
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md",
+      "_posts/59-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9713975",
+    "publication": {
+      "pmid": "9713975",
+      "year": "1998",
+      "authors": "Konopka, K., Düzgüneş, N., Rossi, J., & Lee, N. S.",
+      "title": "Receptor ligand-facilitated cationic liposome delivery of anti-HIV-1 Rev-binding aptamer and ribozyme DNAs",
+      "journal": "Journal of drug targeting"
+    },
+    "posts": [
+      "_posts/C52-aptamer.md",
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md",
+      "_posts/59-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15610009",
+    "publication": {
+      "pmid": "15610009",
+      "year": "2004",
+      "authors": "Wilkinson, T. A., Zhu, L., Hu, W., & Chen, Y.",
+      "title": "Retention of conformational flexibility in HIV-1 Rev-RNA complexes",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/C52-aptamer.md",
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md",
+      "_posts/59-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30017564",
+    "publication": {
+      "pmid": "30017564",
+      "year": "2018",
+      "authors": "Dearborn, A. D., Eren, E., Watts, N. R., Palmer, I. W.",
+      "title": "Structure of an RNA Aptamer that Can Inhibit HIV-1 by Blocking Rev-Cognate RNA (RRE) Binding and Rev-Rev Association",
+      "journal": "Structure"
+    },
+    "posts": [
+      "_posts/C52-aptamer.md",
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md",
+      "_posts/59-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11907208",
+    "publication": {
+      "pmid": "11907208",
+      "year": "2002",
+      "authors": "Biroccio, A., Hamm, J., Incitti, I., De Francesco, R., & Tomei, L.",
+      "title": "Selection of RNA aptamers that are specific and high-affinity ligands of the hepatitis C virus RNA-dependent RNA polymerase",
+      "journal": "Journal of virology"
+    },
+    "posts": [
+      "_posts/HCV-NS5BΔC55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12667800",
+    "publication": {
+      "pmid": "12667800",
+      "year": "2003",
+      "authors": "Vo, N. V., Oh, J. W., & Lai, M. M.",
+      "title": "Identification of RNA ligands that bind hepatitis C virus polymerase selectively and inhibit its RNA synthesis from the natural viral RNA templates",
+      "journal": "Virology"
+    },
+    "posts": [
+      "_posts/HCV-NS5BΔC55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22163979",
+    "publication": {
+      "pmid": "22163979",
+      "year": "2011",
+      "authors": "Roh, C., Kim, S. E., & Jo, S. K.",
+      "title": "Label free inhibitor screening of hepatitis C virus (HCV) NS5B viral protein using RNA oligonucleotide",
+      "journal": "Sensors"
+    },
+    "posts": [
+      "_posts/HCV-NS5BΔC55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23596299",
+    "publication": {
+      "pmid": "23596299",
+      "year": "2013",
+      "authors": "Lee, C. H., Lee, Y. J., Kim, J. H., Lim, J. H.",
+      "title": "Inhibition of hepatitis C virus (HCV) replication by specific RNA aptamers against HCV NS5B RNA replicase",
+      "journal": "Journal of virology"
+    },
+    "posts": [
+      "_posts/HCV-NS5BΔC55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26440598",
+    "publication": {
+      "pmid": "26440598",
+      "year": "2015",
+      "authors": "Lee, C. H., Lee, S. H., Kim, J. H., Noh, Y. H.",
+      "title": "Pharmacokinetics of a Cholesterol-conjugated Aptamer Against the Hepatitis C Virus (HCV) NS5B Protein",
+      "journal": "Molecular therapy. Nucleic acids"
+    },
+    "posts": [
+      "_posts/HCV-NS5BΔC55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38027068",
+    "publication": {
+      "pmid": "38027068",
+      "year": "2023",
+      "authors": "Kim, T. H., & Lee, S. W.",
+      "title": "Generation of hepatitis C virus-resistant liver cells by genome editing-mediated stable expression of RNA aptamer",
+      "journal": "Molecular therapy. Methods & clinical development"
+    },
+    "posts": [
+      "_posts/HCV-NS5BΔC55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8755498",
+    "publication": {
+      "pmid": "8755498",
+      "year": "1996",
+      "authors": "Xu, W., & Ellington, A. D.",
+      "title": "Anti-peptide aptamers recognize amino acid sequence and bind a protein epitope",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/C52-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8946856",
+    "publication": {
+      "pmid": "8946856",
+      "year": "1996",
+      "authors": "Ye, X., Gorin, A., Ellington, A. D., & Patel, D. J.",
+      "title": "Deep penetration of an alpha-helix into a widened RNA major groove in the HIV-1 rev peptide-RNA aptamer complex",
+      "journal": "Nature structural biology"
+    },
+    "posts": [
+      "_posts/C52-aptamer.md",
+      "_posts/RBA-14-aptamer.md",
+      "_posts/HIV-1-REV-peptide-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8841594",
+    "publication": {
+      "pmid": "8841594",
+      "year": "1995",
+      "authors": "Yamamoto, R., Toyoda, S., Viljanen, P., Machida, K.",
+      "title": "In vitro selection of RNA aptamers that can bind specifically to Tat protein of HIV-1",
+      "journal": "Nucleic acids symposium series"
+    },
+    "posts": [
+      "_posts/Clone-31-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10886365",
+    "publication": {
+      "pmid": "10886365",
+      "year": "2000",
+      "authors": "Yamamoto, R., Katahira, M., Nishikawa, S., Baba, T.",
+      "title": "A novel RNA motif that binds efficiently and specifically to the Ttat protein of HIV and inhibits the trans-activation by Tat of transcription in vitro and in vivo",
+      "journal": "Genes to cells : devoted to molecular & cellular mechanisms"
+    },
+    "posts": [
+      "_posts/Clone-31-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11132628",
+    "publication": {
+      "pmid": "11132628",
+      "year": "2000",
+      "authors": "Kawakami, J., Imanaka, H., Yokota, Y., & Sugimoto, N.",
+      "title": "In vitro selection of aptamers that act with Zn2+",
+      "journal": "Journal of inorganic biochemistry"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "12737819",
+    "publication": {
+      "pmid": "12737819",
+      "year": "2003",
+      "authors": "Matsugami, A., Kobayashi, S., Ouhashi, K., Uesugi, S., Yamamoto, R., Taira, K., Nishikawa, S., Kumar, P. K., & Katahira, M.",
+      "title": "Structural basis of the highly efficient trapping of the HIV Tat protein by an RNA aptamer",
+      "journal": "Structure (London"
+    },
+    "posts": [
+      "_posts/Clone-31-aptamer.md",
+      "_posts/HIV-Tat-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28620664",
+    "publication": {
+      "pmid": "28620664",
+      "year": "2017",
+      "authors": "Yamaoki, Y., Nagata, T., Mashima, T., & Katahira, M.",
+      "title": "Development of an RNA aptamer that acquires binding capacity against HIV-1 Tat protein via G-quadruplex formation in response to potassium ions",
+      "journal": "Chemical communications"
+    },
+    "posts": [
+      "_posts/Clone-31-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31707021",
+    "publication": {
+      "pmid": "31707021",
+      "year": "2020",
+      "authors": "Caglayan, M. O., & Üstündağ, Z.",
+      "title": "Spectrophotometric ellipsometry based Tat-protein RNA-aptasensor for HIV-1 diagnosis",
+      "journal": "Spectrochimica acta. Part A"
+    },
+    "posts": [
+      "_posts/Clone-31-aptamer.md",
+      "_posts/HIV-Tat-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37240414",
+    "publication": {
+      "pmid": "37240414",
+      "year": "2023",
+      "authors": "Eladl, O., Yamaoki, Y., Kondo, K., Nagata, T., & Katahira, M.",
+      "title": "Complex Formation of an RNA Aptamer with a Part of HIV-1 Tat through Induction of Base Triples in Living Human Cells Proven by In-Cell NMR",
+      "journal": "International journal of molecular sciences"
+    },
+    "posts": [
+      "_posts/Clone-31-aptamer.md",
+      "_posts/HIV-Tat-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15247433",
+    "publication": {
+      "pmid": "15247433",
+      "year": "2004",
+      "authors": "Hwang, B., Cho, J. S., Yeo, H. J., Kim, J. H., Chung, K. M.",
+      "title": "Isolation of specific and high-affinity RNA aptamers against NS3 helicase domain of hepatitis C virus",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/G6-16-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "1379730",
+    "publication": {
+      "pmid": "1379730",
+      "year": "1992",
+      "authors": "Tuerk, C., MacDougal, S., & Gold, L.",
+      "title": "RNA pseudoknots that inhibit human immunodeficiency virus type 1 reverse transcriptase",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/ligand-1.1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10751399",
+    "publication": {
+      "pmid": "10751399",
+      "year": "2000",
+      "authors": "Kensch, O., Connolly, B. A., Steinhoff, H. J., McGregor, A., Goody, R. S., & Restle, T.",
+      "title": "HIV-1 reverse transcriptase-pseudoknot RNA aptamer interaction has a binding affinity in the low picomolar range coupled with high specificity",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/ligand-1.1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12050367",
+    "publication": {
+      "pmid": "12050367",
+      "year": "2002",
+      "authors": "Joshi, P., & Prasad, V. R.",
+      "title": "Potent inhibition of human immunodeficiency virus type 1 replication by template analog reverse transcriptase inhibitors derived by SELEX (systematic evolution of ligands by exponential enrichment)",
+      "journal": "Journal of virology"
+    },
+    "posts": [
+      "_posts/ligand-1.1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25073457",
+    "publication": {
+      "pmid": "25073457",
+      "year": "2014",
+      "authors": "Aeksiri, N., Songtawee, N., Gleeson, M. P., Hannongbua, S., & Choowongkomon, K.",
+      "title": "Insight into HIV-1 reverse transcriptase-aptamer interaction from molecular dynamics simulations",
+      "journal": "Journal of molecular modeling"
+    },
+    "posts": [
+      "_posts/ligand-1.1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31943114",
+    "publication": {
+      "pmid": "31943114",
+      "year": "2020",
+      "authors": "Nguyen, P. D. M., Zheng, J., Gremminger, T. J., Qiu, L.",
+      "title": "Binding interface and impact on protease cleavage for an RNA aptamer to HIV-1 reverse transcriptase",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/ligand-1.1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32732393",
+    "publication": {
+      "pmid": "32732393",
+      "year": "2020",
+      "authors": "Gruenke, P. R., Alam, K. K., Singh, K., & Burke, D. H.",
+      "title": "2'-fluoro-modified pyrimidines enhance affinity of RNA oligonucleotides to HIV-1 reverse transcriptase",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/ligand-1.1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7778267",
+    "publication": {
+      "pmid": "7778267",
+      "year": "1995",
+      "authors": "Allen, P., Worland, S., & Gold, L.",
+      "title": "Isolation of high-affinity RNA ligands to HIV-1 integrase from a random pool",
+      "journal": "Virology"
+    },
+    "posts": [
+      "_posts/HIV-1-integrase-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7489503",
+    "publication": {
+      "pmid": "7489503",
+      "year": "1995",
+      "authors": "Tian, Y., Adya, N., Wagner, S., Giam, C. Z., Green, M. R., & Ellington, A. D.",
+      "title": "Dissecting protein:protein interactions between transcription factors with an RNA aptamer",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/YT1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16246910",
+    "publication": {
+      "pmid": "16246910",
+      "year": "2005",
+      "authors": "Bryant, K. F., Cox, J. C., Wang, H., Hogle, J. M., Ellington, A. D., & Coen, D. M.",
+      "title": "Binding of herpes simplex virus-1 US11 to specific RNA sequences",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/HSV-1-US11-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19684916",
+    "publication": {
+      "pmid": "19684916",
+      "year": "2009",
+      "authors": "Ahn, D. G., Jeon, I. J., Kim, J. D., Song, M. S.",
+      "title": "RNA aptamer-based sensitive detection of SARS coronavirus nucleocapsid protein",
+      "journal": "The Analyst"
+    },
+    "posts": [
+      "_posts/SARS-CoV-N-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35018437",
+    "publication": {
+      "pmid": "35018437",
+      "year": "2022",
+      "authors": "Gruenke, P. R., Aneja, R., Welbourn, S., Ukah, O. B.",
+      "title": "Selection and identification of an RNA aptamer that specifically binds the HIV-1 capsid lattice and inhibits viral replication",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/HIV-1-CA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15913532",
+    "publication": {
+      "pmid": "15913532",
+      "year": "2005",
+      "authors": "Misono, T. S., & Kumar, P. K.",
+      "title": "Selection of RNA aptamers against human influenza virus hemagglutinin using surface plasmon resonance",
+      "journal": "Analytical biochemistry"
+    },
+    "posts": [
+      "_posts/Hemagglutinin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21565620",
+    "publication": {
+      "pmid": "21565620",
+      "year": "2011",
+      "authors": "Toscano-Garibay, J. D., Benítez-Hess, M. L., & Alvarez-Salas, L. M.",
+      "title": "Isolation and characterization of an RNA aptamer for the HPV-16 E7 oncoprotein",
+      "journal": "Archives of medical research"
+    },
+    "posts": [
+      "_posts/HPV-16-E7-oncoprotein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22943666",
+    "publication": {
+      "pmid": "22943666",
+      "year": "2012",
+      "authors": "Hwang, S. D., Midorikawa, N., Punnarak, P., Kikuchi, Y., Kondo, H.",
+      "title": "Inhibition of Hirame rhabdovirus growth by RNA aptamers",
+      "journal": "Journal of fish diseases"
+    },
+    "posts": [
+      "_posts/HIRRV-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16476969",
+    "publication": {
+      "pmid": "16476969",
+      "year": "2006",
+      "authors": "Gopinath, S. C. B., Misono, T. S., Kawasaki, K., Mizuno, T., Imai, M.",
+      "title": "An RNA aptamer that distinguishes between closely related human influenza viruses and inhibits haemagglutinin-mediated membrane fusion",
+      "journal": "The Journal of general virology"
+    },
+    "posts": [
+      "_posts/H3N2-aptamer.md",
+      "_posts/HCV-NS5B-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25689224",
+    "publication": {
+      "pmid": "25689224",
+      "year": "2015",
+      "authors": "Duclair, S., Gautam, A., Ellington, A., & Prasad, V. R.",
+      "title": "High-affinity RNA Aptamers Against the HIV-1 Protease Inhibit Both In Vitro Protease Activity and Late Events of Viral Replication",
+      "journal": "Molecular therapy. Nucleic acids"
+    },
+    "posts": [
+      "_posts/HIV-1-PR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22125633",
+    "publication": {
+      "pmid": "22125633",
+      "year": "2011",
+      "authors": "Feng, H., Beck, J., Nassal, M., & Hu, K. H.",
+      "title": "A SELEX-screened aptamer of human hepatitis B virus RNA encapsidation signal suppresses viral replication",
+      "journal": "PloS one"
+    },
+    "posts": [
+      "_posts/HBV-P-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30303958",
+    "publication": {
+      "pmid": "30303958",
+      "year": "2018",
+      "authors": "Pan, Q., Law, C. O., Yung, M. M., Han, K. C.",
+      "title": "Novel RNA aptamers targeting gastrointestinal cancer biomarkers CEA, CA50 and CA72-4 with superior affinity and specificity",
+      "journal": "PLoS One"
+    },
+    "posts": [
+      "_posts/Gastrointestinal-carcinoembryonic-antigen-(CEA)-aptamer.md",
+      "_posts/Gastrointestinal-cancer-antigen-50-aptamer.md",
+      "_posts/Cancer-antigen-72–4(CA72-4)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29103909",
+    "publication": {
+      "pmid": "29103909",
+      "year": "2018",
+      "authors": "Fülle, L., Steiner, N., Funke, M., Gondorf, F., Pfeiffer, F.",
+      "title": "RNA aptamers recognizing murine CCL17 inhibit T cell chemotaxis and reduce contact hypersensitivity in vivo",
+      "journal": "Molecular Therapy"
+    },
+    "posts": [
+      "_posts/Chemokine-CCL17-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24334484",
+    "publication": {
+      "pmid": "24334484",
+      "year": "2014",
+      "authors": "Hanazato, M., Nakato, G., Nishikawa, F., Hase, K., Nishikawa, S., & Ohno, H",
+      "title": "Selection of an aptamer against mouse GP2 by SELEX",
+      "journal": "Cell structure and function"
+    },
+    "posts": [
+      "_posts/Glycoprotein-2-(GP2)-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24835440",
+    "publication": {
+      "pmid": "24835440",
+      "year": "2014",
+      "authors": "Kwon, H. M., Lee, K. H., Han, B. W., Han, M. R.",
+      "title": "An RNA aptamer that specifically binds to the glycosylated hemagglutinin of avian influenza virus and suppresses viral infection in cells",
+      "journal": "PloS one"
+    },
+    "posts": [
+      "_posts/Hemagglutinin-(HA)-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26383776",
+    "publication": {
+      "pmid": "26383776",
+      "year": "2015",
+      "authors": "Mittelberger, F., Meyer, C., Waetzig, G. H., Zacharias, M.",
+      "title": "RAID3-An interleukin-6 receptor-binding aptamer with post-selective modification-resistant affinity",
+      "journal": "RNA biology"
+    },
+    "posts": [
+      "_posts/Interleukin-6-receptor-domain-3-(IL-6R-D3)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26184872",
+    "publication": {
+      "pmid": "26184872",
+      "year": "2015",
+      "authors": "Mondragón, E., & Maher III, L. J.",
+      "title": "RNA aptamer inhibitors of a restriction endonuclease",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Restriction-endonucleases-(REases)-KpnI-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27930845",
+    "publication": {
+      "pmid": "27930845",
+      "year": "2017",
+      "authors": "Lee, J. H., & Lee, M. J.",
+      "title": "Isolation and Characterization of RNA Aptamers against a Proteasome‐Associated Deubiquitylating Enzyme UCH37",
+      "journal": "ChemBioChem"
+    },
+    "posts": [
+      "_posts/Ubiquitin-carboxyl-terminal-hydrolase37-(UCH37)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22484812",
+    "publication": {
+      "pmid": "22484812",
+      "year": "2012",
+      "authors": "Ray, P., Rialon-Guevara, KL., Veras, E., Sullenger, BA., & White, RR.",
+      "title": "Comparing human pancreatic cell secretomes by in vitro aptamer selection identifies cyclophilin B as a candidate pancreatic cancer biomarker",
+      "journal": "Journal of Clinical Investgation"
+    },
+    "posts": [
+      "_posts/CypB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24152208",
+    "publication": {
+      "pmid": "24152208",
+      "year": "2013",
+      "authors": "Ray, P., Sullenger, BA., & White, RR.",
+      "title": "Further characterization of the target of a potential aptamer biomarker for pancreatic cancer: cyclophilin B and its posttranslational modifications",
+      "journal": "Nucleic Acid Therapeutics"
+    },
+    "posts": [
+      "_posts/CypB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24588102",
+    "publication": {
+      "pmid": "24588102",
+      "year": "2014",
+      "authors": "Xu, D., Chatakonda, VK., Kourtidis, A., Conklin, DS., & Shi, H.",
+      "title": "In search of novel drug target sites on estrogen receptors using RNA aptamers",
+      "journal": "Nucleic Acid Therapeutics"
+    },
+    "posts": [
+      "_posts/ERα-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22166202",
+    "publication": {
+      "pmid": "22166202",
+      "year": "2012",
+      "authors": "Lee, YJ., Han, SR., Maeng, JS., Cho, YJ., & Lee, SW.",
+      "title": "In vitro selection of Escherichia coli O157:H7-specific RNA aptamer",
+      "journal": "Biochemical and Biophysical Research Communications"
+    },
+    "posts": [
+      "_posts/Escherichia-coli-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24374323",
+    "publication": {
+      "pmid": "24374323",
+      "year": "2014",
+      "authors": "Suenaga, E., & Kumar, PK.",
+      "title": "An aptamer that binds efficiently to the hemagglutinins of highly pathogenic avian influenza viruses (H5N1 and H7N7) and inhibits hemagglutinin-glycan interactions",
+      "journal": "Acta Biomaterialia"
+    },
+    "posts": [
+      "_posts/HPAI-H5N1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20967861",
+    "publication": {
+      "pmid": "20967861",
+      "year": "2011",
+      "authors": "Ishiguro, A., Akiyama, T., Adachi, H., Inoue, J., & Nakamura, Y.",
+      "title": "Therapeutic potential of anti-interleukin-17A aptamer: suppression of interleukin-17A signaling and attenuation of autoimmunity in two mouse models",
+      "journal": "Arthritis Rheum"
+    },
+    "posts": [
+      "_posts/IL-17A-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23113766",
+    "publication": {
+      "pmid": "23113766",
+      "year": "2013",
+      "authors": "Pratico, ED., Sullenger, BA., & Nair, SK.",
+      "title": "Identification and characterization of an agonistic aptamer against the T cell costimulatory receptor, OX40",
+      "journal": "Nucleic Acid Therapeutics"
+    },
+    "posts": [
+      "_posts/OX40-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21203916",
+    "publication": {
+      "pmid": "21203916",
+      "year": "2010",
+      "authors": "Huang, Z., Wang, X., & Gao, G.",
+      "title": "Analyses of SELEX-derived ZAP-binding RNA aptamers suggest that the binding specificity is determined by both structure and sequence of the RNA",
+      "journal": "Protein Cell"
+    },
+    "posts": [
+      "_posts/ZAP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10908352",
+    "publication": {
+      "pmid": "10908352",
+      "year": "2000",
+      "authors": "Tok, J. B., Cho, J., & Rando, R. R.",
+      "title": "RNA aptamers that specifically bind to a 16S ribosomal RNA decoding region construct",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/16S-rRNA-decoding-region-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10449422",
+    "publication": {
+      "pmid": "10449422",
+      "year": "1999",
+      "authors": "Scarabino, D., Crisari, A., Lorenzini, S., Williams, K., & Tocchini-Valentini, G. P.",
+      "title": "tRNA prefers to kiss",
+      "journal": "The EMBO journal"
+    },
+    "posts": [
+      "_posts/tRNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7504300",
+    "publication": {
+      "pmid": "7504300",
+      "year": "1993",
+      "authors": "Jellinek, D., Lynott, C. K., Rifkin, D. B., & Janjić, N.",
+      "title": "High-affinity RNA ligands to basic fibroblast growth factor inhibit receptor binding",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/bFGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9222504",
+    "publication": {
+      "pmid": "9222504",
+      "year": "1997",
+      "authors": "Cho, B., Taylor, D. C., Nicholas, H. B., Jr, & Schmidt, F. J.",
+      "title": "Interacting RNA species identified by combinatorial selection",
+      "journal": "Bioorganic & medicinal chemistry"
+    },
+    "posts": [
+      "_posts/RNA-loop-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20729797",
+    "publication": {
+      "pmid": "20729797",
+      "year": "2010",
+      "authors": "Horii, K., Omi, K., Yoshida, Y., Imai, Y., Sakai, N.",
+      "title": "Development of a sphingosylphosphorylcholine detection system using RNA aptamers",
+      "journal": "Molecules"
+    },
+    "posts": [
+      "_posts/SPC-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9343239",
+    "publication": {
+      "pmid": "9343239",
+      "year": "1997",
+      "authors": "Weiss, S., Proske, D., Neumann, M., Groschup, M. H.",
+      "title": "RNA aptamers specifically interact with the prion protein PrP",
+      "journal": "Journal of virology"
+    },
+    "posts": [
+      "_posts/Prion-protein1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28513534",
+    "publication": {
+      "pmid": "28513534",
+      "year": "2017",
+      "authors": "Macedo, B., & Cordeiro, Y.",
+      "title": "Unraveling Prion Protein Interactions with Aptamers and Other PrP-Binding Nucleic Acids",
+      "journal": "International journal of molecular sciences"
+    },
+    "posts": [
+      "_posts/Prion-protein1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35970037",
+    "publication": {
+      "pmid": "35970037",
+      "year": "2004",
+      "authors": "Hirao, I., Harada, Y., Nojima, T., Osawa, Y., Masaki, H., & Yokoyama, S.",
+      "title": "In vitro selection of RNA aptamers that bind to colicin E3 and structurally resemble the decoding site of 16S ribosomal RNA",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/Colicin-E3-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16799875",
+    "publication": {
+      "pmid": "16799875",
+      "year": "2006",
+      "authors": "Mercey, R., Lantier, I., Maurel, M. C., Grosclaude, J., Lantier, F., & Marc, D.",
+      "title": "Fast, reversible interaction of prion protein with RNA aptamers containing specific sequence patterns",
+      "journal": "Archives of virology"
+    },
+    "posts": [
+      "_posts/Prion-protein2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16189080",
+    "publication": {
+      "pmid": "16189080",
+      "year": "2005",
+      "authors": "Pan, Q., Zhang, X. L., Wu, H. Y., He, P. W., Wang, F.",
+      "title": "Aptamers that preferentially bind type IVB pili and inhibit human monocytic-cell invasion by Salmonella enterica serovar typhi",
+      "journal": "Antimicrobial agents and chemotherapy"
+    },
+    "posts": [
+      "_posts/Type-IVB-Pili-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10348914",
+    "publication": {
+      "pmid": "10348914",
+      "year": "1999",
+      "authors": "Takeno, H., Yamamoto, S., Tanaka, T., Sakano, Y., & Kikuchi, Y.",
+      "title": "Selection of an RNA molecule that specifically inhibits the protease activity of subtilisin",
+      "journal": "Journal of biochemistry"
+    },
+    "posts": [
+      "_posts/Subtilisin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9192624",
+    "publication": {
+      "pmid": "9192624",
+      "year": "1997",
+      "authors": "Klug, S. J., Hüttenhofer, A., Kromayer, M., & Famulok, M.",
+      "title": "In vitro and in vivo characterization of novel mRNA motifs that bind special elongation factor SelB",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Elongation-factor-SelB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10496219",
+    "publication": {
+      "pmid": "10496219",
+      "year": "1999",
+      "authors": "Klug, S. J., Hüttenhofer, A., & Famulok, M.",
+      "title": "In vitro selection of RNA aptamers that bind special elongation factor SelB, a protein with multiple RNA-binding sites, reveals one major interaction domain at the carboxyl terminus",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Elongation-factor-SelB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9603938",
+    "publication": {
+      "pmid": "9603938",
+      "year": "1998",
+      "authors": "Bell, S. D., Denu, J. M., Dixon, J. E., & Ellington, A. D.",
+      "title": "RNA molecules that bind to and inhibit the active site of a tyrosine phosphatase",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/Protein-tyrosine-phosphatases-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16131593",
+    "publication": {
+      "pmid": "16131593",
+      "year": "2005",
+      "authors": "Dubey, A. K., Baker, C. S., Romeo, T., & Babitzke, P.",
+      "title": "RNA sequence and secondary structure participate in high-affinity CsrA-RNA interaction",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/CsrA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11904188",
+    "publication": {
+      "pmid": "11904188",
+      "year": "2002",
+      "authors": "Szkaradkiewicz, K., Nanninga, M., Nesper-Brock, M.",
+      "title": "RNA aptamers directed against release factor 1 from Thermus thermophilus",
+      "journal": "FEBS letters"
+    },
+    "posts": [
+      "_posts/Peptide-release-factor-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15294895",
+    "publication": {
+      "pmid": "15294895",
+      "year": "2004",
+      "authors": "Ferrer-Orta,& Verdaguer, N.",
+      "title": "Structure of foot-and-mouth disease virus RNA-dependent RNA polymerase and its complex with a template-primer RNA",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "17588619",
+    "publication": {
+      "pmid": "17588619",
+      "year": "2007",
+      "authors": "Du, M., Ulrich, H., Zhao, X., Aronowski, J., & Jayaraman, V.",
+      "title": "Water soluble RNA based antagonist of AMPA receptors",
+      "journal": "Neuropharmacology"
+    },
+    "posts": [
+      "_posts/AMPA-receptors-Aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16888322",
+    "publication": {
+      "pmid": "16888322",
+      "year": "2006",
+      "authors": "Rentmeister, & Famulok, M.",
+      "title": "RNA aptamers selectively modulate protein recruitment to the cytoplasmic domain of beta-secretase BACE1 in vitro",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/B1-CT-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17030508",
+    "publication": {
+      "pmid": "17030508",
+      "year": "2006",
+      "authors": "Gopinath, S. C., Balasundaresan, D., Akitomi, J., & Mizuno, H.",
+      "title": "An RNA aptamer that discriminates bovine factor IX from human factor IX",
+      "journal": "Journal of biochemistry"
+    },
+    "posts": [
+      "_posts/Bovine-factor-IX-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16707660",
+    "publication": {
+      "pmid": "16707660",
+      "year": "2006",
+      "authors": "Gening, L. V., & Miller, H.",
+      "title": "RNA aptamers selected against DNA polymerase beta inhibit the polymerase activities of DNA polymerases beta and kappa",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/polβ-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16540230",
+    "publication": {
+      "pmid": "16540230",
+      "year": "2006",
+      "authors": "Ohuchi, S. P., Ohtsu, T., & Nakamura, Y.",
+      "title": "Selection of RNA aptamers against recombinant transforming growth factor-beta type III receptor displayed on cell surface",
+      "journal": "Biochimie"
+    },
+    "posts": [
+      "_posts/TbRIII-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17079480",
+    "publication": {
+      "pmid": "17079480",
+      "year": "2006",
+      "authors": "Lee, H. K., & Jeong, S.",
+      "title": "Modulation of oncogenic transcription and alternative splicing by beta-catenin and an RNA aptamer in colon cancer cells",
+      "journal": "Cancer research"
+    },
+    "posts": [
+      "_posts/pUC19-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "3097327",
+    "publication": {
+      "pmid": "3097327",
+      "year": "1986",
+      "authors": "Satow Y, Cohen GH, Padlan EA, Davies DR",
+      "title": "Phosphocholine binding immunoglobulin Fab McPC603. An X-ray diffraction study at 2.7 A",
+      "journal": "Journal of molecular biology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "12163074",
+    "publication": {
+      "pmid": "12163074",
+      "year": "2002",
+      "authors": "Carola Hunte 1, Hartmut Michel.",
+      "title": "Crystallisation of membrane proteins mediated by antibody fragments",
+      "journal": "Current opinion in structural biology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "17952087",
+    "publication": {
+      "pmid": "17952087",
+      "year": "2007",
+      "authors": "Day PW, Rasmussen SG, Parnot C, Fung JJ, Masood A",
+      "title": "A monoclonal antibody for G protein-coupled receptor crystallography",
+      "journal": "Nature methods"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "19477632",
+    "publication": {
+      "pmid": "19477632",
+      "year": "2009",
+      "authors": "Koide S.",
+      "title": "Engineering of recombinant crystallization chaperones",
+      "journal": "Current opinion in structural biology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "21798953",
+    "publication": {
+      "pmid": "21798953",
+      "year": "2011",
+      "authors": "Paige, J. S., Wu, K. Y., & Jaffrey, S. R.",
+      "title": "RNA mimics of green fluorescent protein",
+      "journal": "Science"
+    },
+    "posts": [
+      "_posts/Chili-aptamer.md",
+      "_posts/Spinach-RNA-aptamer.md",
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21151117",
+    "publication": {
+      "pmid": "21151117",
+      "year": "2011",
+      "authors": "Koldobskaya Y, Duguid EM, Shechner DM, Suslov NB, Ye J",
+      "title": "A portable RNA sequence whose recognition by a synthetic antibody facilitates structural determination",
+      "journal": "Nature structural & molecular biology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "24952597",
+    "publication": {
+      "pmid": "24952597",
+      "year": "2014",
+      "authors": "Huang H, Suslov NB, Li NS, Shelke SA, Evans ME",
+      "title": "A G-quadruplex-containing RNA activates fluorescence in a GFP-like fluorophore",
+      "journal": "Nat Chem Biol"
+    },
+    "posts": [
+      "_posts/Spinach-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25940073",
+    "publication": {
+      "pmid": "25940073",
+      "year": "2015",
+      "authors": "DasGupta, S., Shelke, S. A., Li, N. S., & Piccirilli, J. A.",
+      "title": "Spinach RNA aptamer detects lead(II) with high selectivity",
+      "journal": "Chemical communications"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "27305425",
+    "publication": {
+      "pmid": "27305425",
+      "year": "2016",
+      "authors": "Kikuchi, N., & Kolpashchikov, D. M.",
+      "title": "Split Spinach Aptamer for Highly Selective Recognition of DNA and RNA at Ambient Temperatures",
+      "journal": "Chembiochem : a European journal of chemical biology"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29309709",
+    "publication": {
+      "pmid": "29309709",
+      "year": "2018",
+      "authors": "Koirala D, Shelke SA, Dupont M, Ruiz S, DasGupta S",
+      "title": "Affinity maturation of a portable Fab-RNA module for chaperone-assisted RNA crystallography",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Spinach-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33795733",
+    "publication": {
+      "pmid": "33795733",
+      "year": "2021",
+      "authors": "Dao, N. T., Haselsberger, R., Khuc, M. T., Phan, A. T.",
+      "title": "Photophysics of DFHBI bound to RNA aptamer Baby Spinach",
+      "journal": "Scientific reports"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32763306",
+    "publication": {
+      "pmid": "32763306",
+      "year": "2022",
+      "authors": "Zon G",
+      "title": "Recent advances in aptamer applications for analytical biochemistry",
+      "journal": "Anal Biochem"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "35351813",
+    "publication": {
+      "pmid": "35351813",
+      "year": "2022",
+      "authors": "Anisuzzaman, S., Geraskin, I. M., Ilgu, M., Bendickson, L.",
+      "title": "Ligands with polyfluorophenyl moieties promote a local structural rearrangement in the Spinach2 and Broccoli aptamers that increases ligand affinities",
+      "journal": "RNA"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "35267109",
+    "publication": {
+      "pmid": "35267109",
+      "year": "2022",
+      "authors": "Yu, Z., Wang, Y., Mei, F., Yan, H., Jin, Z., Zhang, P.",
+      "title": "Spinach-based RNA mimicking GFP in plant cells",
+      "journal": "Functional & integrative genomics"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "15055546",
+    "publication": {
+      "pmid": "15055546",
+      "year": "2004",
+      "authors": "Lee SY, Jeong S.",
+      "title": "In vitro selection and characterization of TCF-1 binding RNA aptamers",
+      "journal": "Mol Cells"
+    },
+    "posts": [
+      "_posts/TCF-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15629461",
+    "publication": {
+      "pmid": "15629461",
+      "year": "2005",
+      "authors": "Lee SK, Park MW, Yang EG, Yu J, Jeong S.",
+      "title": "An RNA aptamer that binds to the beta-catenin interaction domain of TCF-1 protein",
+      "journal": "Biochem Biophys Res Commun"
+    },
+    "posts": [
+      "_posts/TCF-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15781225",
+    "publication": {
+      "pmid": "15781225",
+      "year": "2005",
+      "authors": "Park MW, Choi KH, Jeong S.",
+      "title": "Inhibition of the DNA binding by the TCF-1 binding RNA aptamer",
+      "journal": "Biochem Biophys Res Commun"
+    },
+    "posts": [
+      "_posts/TCF-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16985077",
+    "publication": {
+      "pmid": "16985077",
+      "year": "2006",
+      "authors": "Choi KH, Park MW, Lee SY, Jeon MY, Kim MY, Lee HK",
+      "title": "Intracellular expression of the T-cell factor-1 RNA aptamer as an intramer",
+      "journal": "Mol Cancer Ther"
+    },
+    "posts": [
+      "_posts/TCF-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12874383",
+    "publication": {
+      "pmid": "12874383",
+      "year": "2003",
+      "authors": "Chen CH, Chernis GA, Hoang VQ, Landgraf R.",
+      "title": "Inhibition of heregulin signaling by an aptamer that preferentially binds to the oligomeric form of human epidermal growth factor receptor-3",
+      "journal": "Proc Natl Acad Sci U S A"
+    },
+    "posts": [
+      "_posts/A30-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29499944",
+    "publication": {
+      "pmid": "29499944",
+      "year": "2017",
+      "authors": "Yu X, Ghamande S, Liu H, Xue L, Zhao S, Tan W",
+      "title": "Targeting EGFR/HER2/HER3 with a Three-in-One Aptamer-siRNA Chimera Confers Superior Activity against HER2+ Breast Cancer",
+      "journal": "Mol Ther Nucleic Acids"
+    },
+    "posts": [
+      "_posts/A30-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15562003",
+    "publication": {
+      "pmid": "15562003",
+      "year": "2004",
+      "authors": "Mori T, Oguro A, Ohtsu T, Nakamura Y.",
+      "title": "RNA aptamers selected against the receptor activator of NF-kappaB acquire general affinity to proteins of the tumor necrosis factor receptor family",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": [
+      "_posts/RANK-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15277685",
+    "publication": {
+      "pmid": "15277685",
+      "year": "2004",
+      "authors": "Theis MG, Knorre A, Kellersch B, Moelleken J, Wieland F, Kolanus W, Famulok M.",
+      "title": "Discriminatory aptamer reveals serum response element transcription regulated by cytohesin-2",
+      "journal": "Proc Natl Acad Sci U S A"
+    },
+    "posts": [
+      "_posts/Cytohesin-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19854646",
+    "publication": {
+      "pmid": "19854646",
+      "year": "2009",
+      "authors": "Mayer G, Lohberger A, Butzen S, Pofahl M, Blind M, Heckel A.",
+      "title": "From selection to caged aptamers: identification of light-dependent ssDNA aptamers targeting cytohesin",
+      "journal": "Bioorg Med Chem Lett"
+    },
+    "posts": [
+      "_posts/Cytohesin-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23757206",
+    "publication": {
+      "pmid": "23757206",
+      "year": "2013",
+      "authors": "Niebel B, Wosnitza CI, Famulok M.",
+      "title": "RNA-aptamers that modulate the RhoGEF activity of Tiam1",
+      "journal": "Bioorg Med Chem"
+    },
+    "posts": [
+      "_posts/Cytohesin-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12649492",
+    "publication": {
+      "pmid": "12649492",
+      "year": "2003",
+      "authors": "Oguro A, Ohtsu T, Svitkin YV, Sonenberg N, Nakamura Y.",
+      "title": "RNA aptamers to initiation factor 4A helicase hinder cap-dependent translation by blocking ATP hydrolysis",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/eIF4A-aptamer.md",
+      "_posts/No.21-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16940549",
+    "publication": {
+      "pmid": "16940549",
+      "year": "2006",
+      "authors": "Miyakawa S, Oguro A, Ohtsu T, Imataka H, Sonenberg N, Nakamura Y.",
+      "title": "RNA aptamers to mammalian initiation factor 4G inhibit cap-dependent translation by blocking the formation of initiation factor complexes",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/No.21-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15359119",
+    "publication": {
+      "pmid": "15359119",
+      "year": "2004",
+      "authors": "Cho JS, Lee YJ, Shin KS, Jeong S, Park J, Lee SW.",
+      "title": "In vitro selection of specific RNA aptamers for the NFAT DNA binding domain",
+      "journal": "Mol Cells"
+    },
+    "posts": [
+      "_posts/NFAT-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12408978",
+    "publication": {
+      "pmid": "12408978",
+      "year": "2002",
+      "authors": "Bae SJ, Oum JH, Sharma S, Park J, Lee SW.",
+      "title": "In vitro selection of specific RNA inhibitors of NFATc",
+      "journal": "Biochem Biophys Res Commun"
+    },
+    "posts": [
+      "_posts/NFAT-aptamer.md",
+      "_posts/Activated-T-Cells-Nuclear-Factor-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26350736",
+    "publication": {
+      "pmid": "26350736",
+      "year": "2015",
+      "authors": "Malsagova KA, Ivanov YD, Pleshakova TO, Kozlov AF, Krohin NV",
+      "title": "[SOI-nanowire biosensor for the detection of D-NFAT 1 protein]",
+      "journal": "Biomed Khim"
+    },
+    "posts": [
+      "_posts/NFAT-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31451750",
+    "publication": {
+      "pmid": "31451750",
+      "year": "2021",
+      "authors": "Yun Y, Zhang Y, Zhang C, Huang L, Tan S, Wang P, Vilariño-Gúell C",
+      "title": "Regulator of calcineurin 1 is a novel RNA-binding protein to regulate neuronal apoptosis",
+      "journal": "Mol Psychiatry"
+    },
+    "posts": [
+      "_posts/NFAT-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16199752",
+    "publication": {
+      "pmid": "16199752",
+      "year": "2005",
+      "authors": "Plummer KA, Carothers JM, Yoshimura M, Szostak JW, Verdine GL.",
+      "title": "In vitro selection of RNA aptamers against a composite small molecule-protein surface",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "15629041",
+    "publication": {
+      "pmid": "15629041",
+      "year": "2004",
+      "authors": "Yan X, Gao X, Zhang Z.",
+      "title": "Isolation and characterization of 2'-amino-modified RNA aptamers for human TNFalpha",
+      "journal": "Genomics Proteomics Bioinformatics"
+    },
+    "posts": [
+      "_posts/hTNF-α-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15971588",
+    "publication": {
+      "pmid": "15971588",
+      "year": "2003",
+      "authors": "Guo KT, Yan XR, Huang GJ, Xu CX, Chai YS, Zhang ZQ.",
+      "title": "[Screening and characterization of DNA aptamers with hTNF-alpha binding and neutralizing activity]",
+      "journal": "Sheng Wu Gong Cheng Xue Bao"
+    },
+    "posts": [
+      "_posts/hTNF-α-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31989789",
+    "publication": {
+      "pmid": "31989789",
+      "year": "2020",
+      "authors": "Mashayekhi K, Ganji A, Sankian M.",
+      "title": "Designing a new dimerized anti human TNF-α aptamer with blocking activity",
+      "journal": "Biotechnol Prog"
+    },
+    "posts": [
+      "_posts/hTNF-α-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12557236",
+    "publication": {
+      "pmid": "12557236",
+      "year": "2003",
+      "authors": "Liu X, Zhang D, Cao G, Yang G, Ding H",
+      "title": "RNA aptamers specific for bovine thrombin",
+      "journal": "J Mol Recognit"
+    },
+    "posts": [
+      "_posts/Bovine-thrombin-aptamer.md",
+      "_posts/Thrombin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12885412",
+    "publication": {
+      "pmid": "12885412",
+      "year": "2003",
+      "authors": "Hwang B, Han K, Lee SW.",
+      "title": "Prevention of passively transferred experimental autoimmune myasthenia gravis by an in vitro selected RNA aptamer",
+      "journal": "FEBS Lett"
+    },
+    "posts": [
+      "_posts/tMG-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11785949",
+    "publication": {
+      "pmid": "11785949",
+      "year": "2002",
+      "authors": "Hwang B, Lee SW.",
+      "title": "Improvement of RNA aptamer activity against myasthenic autoantibodies by extended sequence selection",
+      "journal": "Biochem Biophys Res Commun"
+    },
+    "posts": [
+      "_posts/tMG-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23196060",
+    "publication": {
+      "pmid": "23196060",
+      "year": "2013",
+      "authors": "Shigdar, S., Qiao, L., Zhou, S. F., Xiang, D., Wang, T., Li, Y.",
+      "title": "RNA aptamers targeting cancer stem cell marker CD133",
+      "journal": "Cancer letters"
+    },
+    "posts": [
+      "_posts/CD133-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16467303",
+    "publication": {
+      "pmid": "16467303",
+      "year": "2006",
+      "authors": "Yang, C., Yan, N., Parish, J., Wang, X., Shi, Y., & Xue, D.",
+      "title": "RNA aptamers targeting the cell death inhibitor CED-9 induce cell killing in Caenorhabditis elegans",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/CED-9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7528207",
+    "publication": {
+      "pmid": "7528207",
+      "year": "1994",
+      "authors": "Conrad, R., Keranen, L. M., Ellington, A. D., & Newton, A. C.",
+      "title": "Isozyme-specific inhibition of protein kinase C by RNA aptamers",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/PKC-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8937571",
+    "publication": {
+      "pmid": "8937571",
+      "year": "1996",
+      "authors": "Conrad, R., & Ellington, A. D.",
+      "title": "Detecting immobilized protein kinase C isozymes with RNA aptamers",
+      "journal": "Analytical biochemistry"
+    },
+    "posts": [
+      "_posts/PKC-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29666232",
+    "publication": {
+      "pmid": "29666232",
+      "year": "2018",
+      "authors": "Powell Gray, B., Kelly, L., Ahrens, D. P., Barry, A. P., Kratschmer, C.",
+      "title": "Tunable cytotoxic aptamer-drug conjugates for the treatment of prostate cancer",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/E3-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26221481",
+    "publication": {
+      "pmid": "26221481",
+      "year": "2015",
+      "authors": "Moosavian, S. A., Jaafari, M. R., Taghdisi, S. M., Mosaffa, F.",
+      "title": "Development of RNA aptamers as molecular probes for HER2(+) breast cancer study using cell-SELEX",
+      "journal": "Iranian journal of basic medical sciences"
+    },
+    "posts": [
+      "_posts/HER2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27648925",
+    "publication": {
+      "pmid": "27648925",
+      "year": "2016",
+      "authors": "Iaboni, M., Fontanella, R., Rienzo, A., Capuozzo, M., Nuzzo, S.",
+      "title": "Targeting Insulin Receptor with a Novel Internalizing Aptamer",
+      "journal": "Molecular therapy. Nucleic acids"
+    },
+    "posts": [
+      "_posts/GL56-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18557632",
+    "publication": {
+      "pmid": "18557632",
+      "year": "2008",
+      "authors": "Goers, E. S., Voelker, R. B., Gates, D. P., & Berglund, J. A.",
+      "title": "RNA binding specificity of Drosophila muscleblind",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/Mbl-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12024047",
+    "publication": {
+      "pmid": "12024047",
+      "year": "2002",
+      "authors": "Bhattacharyya, S. N., Chatterjee, S., & Adhya, S.",
+      "title": "Mitochondrial RNA import in Leishmania tropica: aptamers homologous to multiple tRNA domains that interact cooperatively or antagonistically at the inner membrane",
+      "journal": "Molecular and cellular biology"
+    },
+    "posts": [
+      "_posts/Mitochondrion-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20348443",
+    "publication": {
+      "pmid": "20348443",
+      "year": "2010",
+      "authors": "Kolesnikova, O., Kazakova, H., Comte, C., Steinberg, S., Kamenski, P.",
+      "title": "Selection of RNA aptamers imported into yeast and human mitochondria",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Mitochondrion-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25087963",
+    "publication": {
+      "pmid": "25087963",
+      "year": "2014",
+      "authors": "Tawaraya, Y., Hyodo, M., Ara, M. N., Yamada, Y., & Harashima, H.",
+      "title": "RNA aptamers for targeting mitochondria using a mitochondria-based SELEX method",
+      "journal": "Biological & pharmaceutical bulletin"
+    },
+    "posts": [
+      "_posts/Mitochondrion-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27056631",
+    "publication": {
+      "pmid": "27056631",
+      "year": "2016",
+      "authors": "Yamada, Y., Furukawa, R., & Harashima, H.",
+      "title": "A Dual-Ligand Liposomal System Composed of a Cell-Penetrating Peptide and a Mitochondrial RNA Aptamer Synergistically Facilitates Cellular Uptake and Mitochondrial Targeting",
+      "journal": "Journal of pharmaceutical sciences"
+    },
+    "posts": [
+      "_posts/Mitochondrion-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9586110",
+    "publication": {
+      "pmid": "9586110",
+      "year": "1997",
+      "authors": "Hirao, I., Yoshinari, S., Yokoyama, S., Endo, Y., & Ellington, A. D.",
+      "title": "In vitro selection of aptamers that bind to ribosome-inactivating toxins",
+      "journal": "Nucleic acids symposium series"
+    },
+    "posts": [
+      "_posts/Pepocin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10671532",
+    "publication": {
+      "pmid": "10671532",
+      "year": "2000",
+      "authors": "Hirao, I., Madin, K., Endo, Y., Yokoyama, S., & Ellington, A. D.",
+      "title": "RNA aptamers that bind to and inhibit the ribosome-inactivating protein, pepocin",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/Pepocin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12903331",
+    "publication": {
+      "pmid": "12903331",
+      "year": "2000",
+      "authors": "Fukusho, S., Furusawa, H., & Okahata, Y.",
+      "title": "In vitro selection and analysis of RNA aptamer recognize arginine-rich motif (ARM) model peptide on a QCM",
+      "journal": "Nucleic acids symposium series"
+    },
+    "posts": [
+      "_posts/R5-helix-peptide-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12120324",
+    "publication": {
+      "pmid": "12120324",
+      "year": "2002",
+      "authors": "Fukusho, S., Furusawa, H., & Okahata, Y.",
+      "title": "In vitro selection and evaluation of RNA aptamers that recognize arginine-rich-motif model peptide on a quartz-crystal microbalance",
+      "journal": "Chemical communications"
+    },
+    "posts": [
+      "_posts/R5-helix-peptide-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24623705",
+    "publication": {
+      "pmid": "24623705",
+      "year": "2014",
+      "authors": "Furusawa, H., Fukusho, S., & Okahata, Y.",
+      "title": "Arginine arrangement of bacteriophage λ N-peptide plays a role as a core motif in GNRA tetraloop RNA binding",
+      "journal": "Chembiochem : a European journal of chemical biology"
+    },
+    "posts": [
+      "_posts/R5-helix-peptide-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9111335",
+    "publication": {
+      "pmid": "9111335",
+      "year": "1997",
+      "authors": "Shi, H., Hoffman, B. E., & Lis, J. T.",
+      "title": "A specific RNA hairpin loop structure binds the RNA recognition motifs of the Drosophila SR protein B52",
+      "journal": "Molecular and cellular biology"
+    },
+    "posts": [
+      "_posts/B52-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10468557",
+    "publication": {
+      "pmid": "10468557",
+      "year": "1999",
+      "authors": "Shi, H., Hoffman, B. E., & Lis, J. T.",
+      "title": "RNA aptamers as effective protein antagonists in a multicellular organism",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/B52-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12655012",
+    "publication": {
+      "pmid": "12655012",
+      "year": "2003",
+      "authors": "Kim, S., Shi, H., Lee, D. K., & Lis, J. T.",
+      "title": "Specific SR protein-dependent splicing substrates identified through genomic SELEX",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/B52-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19380374",
+    "publication": {
+      "pmid": "19380374",
+      "year": "2009",
+      "authors": "Xu, D., & Shi, H.",
+      "title": "Composite RNA aptamers as functional mimics of proteins",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/B52-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "2200121",
+    "publication": {
+      "pmid": "2200121",
+      "year": "1990",
+      "authors": "Tuerk, C., & Gold, L.",
+      "title": "Systematic evolution of ligands by exponential enrichment: RNA ligands to bacteriophage T4 DNA polymerase",
+      "journal": "Science"
+    },
+    "posts": [
+      "_posts/Gp43-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32222697",
+    "publication": {
+      "pmid": "32222697",
+      "year": "2020",
+      "authors": "Camorani, S., Granata, I., Collina, F., Leonetti, F., Cantile, M., Botti, G.",
+      "title": "Novel Aptamers Selected on Living Cells for Specific Recognition of Triple-Negative Breast Cancer",
+      "journal": "iScience"
+    },
+    "posts": [
+      "_posts/TNBC-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10198434",
+    "publication": {
+      "pmid": "10198434",
+      "year": "1999",
+      "authors": "Homann, M., & Göringer, H. U.",
+      "title": "Combinatorial selection of high affinity RNA ligands to live African trypanosomes",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Trypanosome-VSG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11557345",
+    "publication": {
+      "pmid": "11557345",
+      "year": "2001",
+      "authors": "Homann, M., & Göringer, H. U.",
+      "title": "Uptake and intracellular transport of RNA aptamers in African trypanosomes suggest therapeutic \"piggy-back\" approach",
+      "journal": "Bioorganic & medicinal chemistry"
+    },
+    "posts": [
+      "_posts/Trypanosome-VSG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12582125",
+    "publication": {
+      "pmid": "12582125",
+      "year": "2003",
+      "authors": "Lorger, M., Engstler, M., Homann, M., & Göringer, H. U.",
+      "title": "Targeting the variable surface of African trypanosomes with variant surface glycoprotein-specific, serum-stable RNA aptamers",
+      "journal": "Eukaryotic cell"
+    },
+    "posts": [
+      "_posts/Trypanosome-VSG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16925510",
+    "publication": {
+      "pmid": "16925510",
+      "year": "2006",
+      "authors": "Homann, M., Lorger, M., Engstler, M., Zacharias, M., & Göringer, H. U.",
+      "title": "Serum-stable RNA aptamers to an invariant surface domain of live African trypanosomes",
+      "journal": "Combinatorial chemistry & high throughput screening"
+    },
+    "posts": [
+      "_posts/Trypanosome-VSG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16594626",
+    "publication": {
+      "pmid": "16594626",
+      "year": "2006",
+      "authors": "Göringer, H. U., Homann, M., Zacharias, M., & Adler, A.",
+      "title": "RNA aptamers as potential pharmaceuticals against infections with African trypanosomes",
+      "journal": "Handbook of experimental pharmacology"
+    },
+    "posts": [
+      "_posts/Trypanosome-VSG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18220540",
+    "publication": {
+      "pmid": "18220540",
+      "year": "2008",
+      "authors": "Adler, A., Forster, N., Homann, M., & Göringer, H. U.",
+      "title": "Post-SELEX chemical optimization of a trypanosome-specific RNA aptamer",
+      "journal": "Combinatorial chemistry & high throughput screening"
+    },
+    "posts": [
+      "_posts/Trypanosome-VSG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23017685",
+    "publication": {
+      "pmid": "23017685",
+      "year": "2013",
+      "authors": "Zelada-Guillén, G. A., Tweed-Kent, A., Niemann, M., Göringer, H. U",
+      "title": "Ultrasensitive and real-time detection of proteins in blood using a potentiometric carbon-nanotube aptasensor",
+      "journal": "Biosensors & bioelectronics"
+    },
+    "posts": [
+      "_posts/Trypanosome-VSG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7520755",
+    "publication": {
+      "pmid": "7520755",
+      "year": "1994",
+      "authors": "Jellinek, D., Green, L. S., Bell, C., & Janjić, N.",
+      "title": "Inhibition of receptor binding by high-affinity RNA ligands to vascular endothelial growth factor",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9383475",
+    "publication": {
+      "pmid": "9383475",
+      "year": "1995",
+      "authors": "Green, L. S., Jellinek, D., Bell, C., Beebe, L. A., Feistner, B. D., Gill, S. C.",
+      "title": "Nuclease-resistant nucleic acid ligands to vascular permeability factor/vascular endothelial growth factor",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md",
+      "_posts/Vascular-endothelial-growth-factor-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9685413",
+    "publication": {
+      "pmid": "9685413",
+      "year": "1998",
+      "authors": "Ruckman, J., Green, L. S., Beeson, J., Waugh, S., Gillette, W. L.",
+      "title": "2'-Fluoropyrimidine RNA-based aptamers to the 165-amino acid form of vascular endothelial growth factor (VEGF165). Inhibition of receptor binding and VEGF-induced vascular permeability through interactions requiring the exon 7-encoded domain",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10548435",
+    "publication": {
+      "pmid": "10548435",
+      "year": "1999",
+      "authors": "Bell, C., Lynam, E., Landfair, D. J., Janjic, N., & Wiles, M. E.",
+      "title": "Oligonucleotide NX1838 inhibits VEGF165-mediated cellular responses in vitro",
+      "journal": "In vitro cellular & developmental biology. Animal"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10517237",
+    "publication": {
+      "pmid": "10517237",
+      "year": "1999",
+      "authors": "Tucker, C. E., Chen, L. S., Judkins, M. B., Farmer, J. A., Gill, S. C.",
+      "title": "Detection and plasma pharmacokinetics of an anti-vascular endothelial growth factor oligonucleotide-aptamer (NX1838) in rhesus monkeys",
+      "journal": "Journal of chromatography. B"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15625332",
+    "publication": {
+      "pmid": "15625332",
+      "year": "2004",
+      "authors": "Gragoudas, E. S., Adamis, A. P., Cunningham, E. T., Jr, Feinsod, M.",
+      "title": "Pegaptanib for neovascular age-related macular degeneration",
+      "journal": "The New England journal of medicine"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16357200",
+    "publication": {
+      "pmid": "16357200",
+      "year": "2005",
+      "authors": "Lee, J. H., Canny, M. D., De Erkenez, A., Krilleke, D., Ng, Y. S.",
+      "title": "A therapeutic aptamer inhibits angiogenesis by specifically targeting the heparin binding domain of VEGF165",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16518379",
+    "publication": {
+      "pmid": "16518379",
+      "year": "2006",
+      "authors": "Ng, E. W., Shima, D. T., Calias, P., Cunningham, E. T.",
+      "title": "Pegaptanib, a targeted anti-VEGF aptamer for ocular vascular disease",
+      "journal": "Nature reviews. Drug discovery"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19668516",
+    "publication": {
+      "pmid": "19668516",
+      "year": "2007",
+      "authors": "Trujillo, C. A., Nery, A. A., Alves, J. M., Martins, A. H., & Ulrich, H.",
+      "title": "Development of the anti-VEGF aptamer to a therapeutic agent for clinical ophthalmology",
+      "journal": "Clinical ophthalmology"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18951306",
+    "publication": {
+      "pmid": "18951306",
+      "year": "2008",
+      "authors": "Deissler, H. L., & Lang, G. E.",
+      "title": "Wirkung von VEGF165 und dem VEGF-Aptamer Pegaptanib (Macugen) auf die Zusammensetzung der Tight Junctions mikrovaskulärer Endothelzellen aus der Retina [Effect of VEGF165 and the VEGF aptamer pegaptanib (Macugen) on the protein composition of tight junctions in microvascular endothelial cells of the retina]",
+      "journal": "Klinische Monatsblatter fur Augenheilkunde"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18154762",
+    "publication": {
+      "pmid": "18154762",
+      "year": "2008",
+      "authors": "Lanzl, I. M., Maier, M., Feucht, N., Lohmann, C. P., & Kotliar, K. E.",
+      "title": "Intraocular pressure effects of pegaptanib (macugen) injections in patients with and without glaucoma",
+      "journal": "American journal of ophthalmology"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18156376",
+    "publication": {
+      "pmid": "18156376",
+      "year": "2008",
+      "authors": "Calvo-González, C., Reche-Frutos, J., Donate-López, J., García-Feijoó, J.",
+      "title": "Combined Pegaptanib sodium (Macugen) and photodynamic therapy in predominantly classic juxtafoveal choroidal neovascularisation in age related macular degeneration",
+      "journal": "The British journal of ophthalmology"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28352569",
+    "publication": {
+      "pmid": "28352569",
+      "year": "2015",
+      "authors": "Lönne, M., Bolten, S., Lavrentieva, A., Stahl, F., Scheper, T., & Walter, J. G.",
+      "title": "Development of an aptamer-based affinity purification method for vascular endothelial growth factor",
+      "journal": "Biotechnology reports"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25733800",
+    "publication": {
+      "pmid": "25733800",
+      "year": "2015",
+      "authors": "Basile, A. S., Hutmacher, M. M., Kowalski, K. G., Gandelman, K. Y.",
+      "title": "Population pharmacokinetics of pegaptanib sodium (Macugen(®)) in patients with diabetic macular edema",
+      "journal": "Clinical ophthalmology"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27189805",
+    "publication": {
+      "pmid": "27189805",
+      "year": "2016",
+      "authors": "Huang, D., Zhao, C., Ju, R., Kumar, A., Tian, G., Huang, L.",
+      "title": "VEGF-B inhibits hyperglycemia- and Macugen-induced retinal apoptosis",
+      "journal": "Scientific reports"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33363367",
+    "publication": {
+      "pmid": "33363367",
+      "year": "2020",
+      "authors": "Man, J., Dong, J., Wang, Y., He, L., Yu, S., Yu, F., Wang, J.",
+      "title": "Simultaneous Detection of VEGF and CEA by Time-Resolved Chemiluminescence Enzyme-Linked Aptamer Assay",
+      "journal": "International journal of nanomedicine"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34562647",
+    "publication": {
+      "pmid": "34562647",
+      "year": "2021",
+      "authors": "Zhao, P., Tang, Z. W., Lin, H. C., Djuanda, D., Zhu, Z., Niu, Q.",
+      "title": "VEGF aptamer/i-motif-based drug co-delivery system for combined chemotherapy and photodynamic therapy",
+      "journal": "Photodiagnosis and photodynamic therapy"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36625560",
+    "publication": {
+      "pmid": "36625560",
+      "year": "2023",
+      "authors": "Kalathingal, M., & Rhee, Y. M.",
+      "title": "Molecular mechanism of binding between a therapeutic RNA aptamer and its protein target VEGF: A molecular dynamics study",
+      "journal": "Journal of computational chemistry"
+    },
+    "posts": [
+      "_posts/VEGF-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11259376",
+    "publication": {
+      "pmid": "11259376",
+      "year": "2001",
+      "authors": "Jo, D. G., Kim, M. J., Choi, Y. H., Kim, I. K.",
+      "title": "Pro-apoptotic function of calsenilin/DREAM/KChIP3",
+      "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology"
+    },
+    "posts": [
+      "_posts/The-protein-calsenilin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11535596",
+    "publication": {
+      "pmid": "11535596",
+      "year": "2001",
+      "authors": "Osawa, M., Tong, K. I., Lilliehook, C., Wasco, W.",
+      "title": "Calcium-regulated DNA binding and oligomerization of the neuronal calcium-sensing protein, calsenilin/DREAM/KChIP3",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/The-protein-calsenilin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11788589",
+    "publication": {
+      "pmid": "11788589",
+      "year": "2002",
+      "authors": "Craig, T. A., Benson, L. M., Venyaminov, S. Y., Klimtchuk, E. S.",
+      "title": "The metal-binding properties of DREAM: evidence for calcium-mediated changes in DREAM structure",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/The-protein-calsenilin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12732196",
+    "publication": {
+      "pmid": "12732196",
+      "year": "2003",
+      "authors": "Jo, D. G., Chang, J. W., Hong, H. S., Mook-Jung, I., & Jung, Y. K.",
+      "title": "Contribution of presenilin/gamma-secretase to calsenilin-mediated apoptosis",
+      "journal": "Biochemical and biophysical research communications"
+    },
+    "posts": [
+      "_posts/The-protein-calsenilin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15590057",
+    "publication": {
+      "pmid": "15590057",
+      "year": "2004",
+      "authors": "Bhattacharya, S., Bunick, C. G., & Chazin, W. J.",
+      "title": "Target selectivity in EF-hand calcium binding proteins",
+      "journal": "Biochimica et biophysica acta"
+    },
+    "posts": [
+      "_posts/The-protein-calsenilin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17904852",
+    "publication": {
+      "pmid": "17904852",
+      "year": "2007",
+      "authors": "Lee, K. H., Jeong, S., Yang, E. G., Park, Y. K., & Yu, J.",
+      "title": "An RNA aptamer that recognizes a specific conformation of the protein calsenilin",
+      "journal": "Bioorganic & medicinal chemistry"
+    },
+    "posts": [
+      "_posts/The-protein-calsenilin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "3893430",
+    "publication": {
+      "pmid": "3893430",
+      "year": "1985",
+      "authors": "Gejyo, F., Yamada, T., Odani, S., Nakagawa, Y. Shirahama, T.",
+      "title": "new form of amyloid protein associated with chronic hemodialysis was identified as beta 2-microglobulin",
+      "journal": "Biochemical and biophysical research communications"
+    },
+    "posts": [
+      "_posts/WL-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "2871446",
+    "publication": {
+      "pmid": "2871446",
+      "year": "1986",
+      "authors": "Chanard, J., Lavaud, S., Toupance, O., Melin, J. P.",
+      "title": "Beta 2-microglobulin-associated amyloidosis in chronic haemodialysis patients",
+      "journal": "Lancet"
+    },
+    "posts": [
+      "_posts/WL-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9356260",
+    "publication": {
+      "pmid": "9356260",
+      "year": "1997",
+      "authors": "Sunde, M., Serpell, L. C., Bartlam, M., Fraser, P. E.",
+      "title": "Common core structure of amyloid fibrils by synchrotron X-ray diffraction",
+      "journal": "Journal of molecular biology"
+    },
+    "posts": [
+      "_posts/WL-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11818542",
+    "publication": {
+      "pmid": "11818542",
+      "year": "2002",
+      "authors": "O'Nuallain, B., & Wetzel, R.",
+      "title": "Conformational Abs recognizing a generic amyloid fibril epitope",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/WL-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11820803",
+    "publication": {
+      "pmid": "11820803",
+      "year": "2002",
+      "authors": "Ylera, F., Lurz, R., Erdmann, V. A., & Fürste, J. P.",
+      "title": "Selection of RNA aptamers to the Alzheimer's disease amyloid peptide",
+      "journal": "Biochemical and biophysical research communications"
+    },
+    "posts": [
+      "_posts/WL-2-aptamer.md",
+      "_posts/Aβ42-aptamer.md",
+      "_posts/β55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17878167",
+    "publication": {
+      "pmid": "17878167",
+      "year": "2007",
+      "authors": "Bunka, D. H., Mantle, B. J., Morten, I. J., Tennent, G. A.",
+      "title": "Production and characterization of RNA aptamers specific for amyloid fibril epitopes",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/WL-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "6320006",
+    "publication": {
+      "pmid": "6320006",
+      "year": "1984",
+      "authors": "Nowak, L., Bregestovski, P., Ascher, P., Herbet, A., & Prochiantz, A.",
+      "title": "Magnesium gates glutamate-activated channels in mouse central neurones",
+      "journal": "Nature"
+    },
+    "posts": [
+      "_posts/AN58-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11848921",
+    "publication": {
+      "pmid": "11848921",
+      "year": "1998",
+      "authors": "Oivanen, M., Kuusela, S., & Lönnberg, H.",
+      "title": "Kinetics and Mechanisms for the Cleavage and Isomerization of the Phosphodiester Bonds of RNA by Brønsted Acids and Bases",
+      "journal": "Chemical reviews"
+    },
+    "posts": [
+      "_posts/AN58-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14567697",
+    "publication": {
+      "pmid": "14567697",
+      "year": "2003",
+      "authors": "Li, G., Pei, W., & Niu, L.",
+      "title": "Channel-opening kinetics of GluR2Q(flip) AMPA receptor: a laser-pulse photolysis study",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/AN58-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16540562",
+    "publication": {
+      "pmid": "16540562",
+      "year": "2006",
+      "authors": "Mayer, M. L., Ghosal, A., Dolman, N. P., & Jane, D. E.",
+      "title": "Crystal structures of the kainate receptor GluR5 ligand binding core dimer with novel GluR5-selective antagonists",
+      "journal": "The Journal of neuroscience : the official journal of the Society for Neuroscience"
+    },
+    "posts": [
+      "_posts/AN58-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17929944",
+    "publication": {
+      "pmid": "17929944",
+      "year": "2007",
+      "authors": "Huang, Z., Pei, W., Jayaseelan, S., Shi, H., & Niu, L.",
+      "title": "RNA aptamers selected against the GluR2 glutamate receptor channel",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md",
+      "_posts/AN58-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28872832",
+    "publication": {
+      "pmid": "28872832",
+      "year": "2017",
+      "authors": "Huang, Z., Wen, W., Wu, A., & Niu, L.",
+      "title": "Chemically Modified, α-Amino-3-hydroxy-5-methyl-4-isoxazole (AMPA) Receptor RNA Aptamers Designed for in Vivo Use",
+      "journal": "ACS chemical neuroscience"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md",
+      "_posts/AN58-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7781920",
+    "publication": {
+      "pmid": "7781920",
+      "year": "1995",
+      "authors": "Premont, R. T., Inglese, J., & Lefkowitz, R. J.",
+      "title": "Protein kinases that phosphorylate activated G protein-coupled receptors",
+      "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "8691724",
+    "publication": {
+      "pmid": "8691724",
+      "year": "1996",
+      "authors": "Lohse, M. J., Krasel, C., Winstel, R., & Mayor, F. Jr",
+      "title": "G-protein-coupled receptor kinases",
+      "journal": "Kidney international"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "9325250",
+    "publication": {
+      "pmid": "9325250",
+      "year": "1997",
+      "authors": "Peppel, K., Boekhoff, I., McDonald, P., Breer, H.",
+      "title": "G protein-coupled receptor kinase 3 (GRK3) gene disruption leads to loss of odorant receptor desensitization",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "16339447",
+    "publication": {
+      "pmid": "16339447",
+      "year": "2005",
+      "authors": "Tesmer, V. M., Kawano, T., Shankaranarayanan, A., Kozasa, T.",
+      "title": "Snapshot of activated G proteins at the membrane: the Galphaq-GRK2-Gbetagamma complex",
+      "journal": "Science"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "18230760",
+    "publication": {
+      "pmid": "18230760",
+      "year": "2008",
+      "authors": "Mayer, G., Wulffen, B., Huber, C., Brockmann, J., Flicke, B.",
+      "title": "An RNA molecule that specifically inhibits G-protein-coupled receptor kinase 2 in vitro",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/GRK2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "6300098",
+    "publication": {
+      "pmid": "6300098",
+      "year": "1983",
+      "authors": "Klausner, R. D., Van Renswoude, J., Ashwell, G., Kempf, C.",
+      "title": "Receptor-mediated endocytosis of transferrin in K562 cells",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/TfR-ECD-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "6300903",
+    "publication": {
+      "pmid": "6300903",
+      "year": "1983",
+      "authors": "Dautry-Varsat, A., Ciechanover, A., & Lodish, H. F.",
+      "title": "pH and the recycling of transferrin during receptor-mediated endocytosis",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/TfR-ECD-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "3681112",
+    "publication": {
+      "pmid": "3681112",
+      "year": "1987",
+      "authors": "Bernstein S. E.",
+      "title": "Hereditary hypotransferrinemia with hemosiderosis, a murine disorder resembling human atransferrinemia",
+      "journal": "The Journal of laboratory and clinical medicine"
+    },
+    "posts": [
+      "_posts/TfR-ECD-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9546397",
+    "publication": {
+      "pmid": "9546397",
+      "year": "1998",
+      "authors": "Lebrón, J. A., Bennett, M. J., Vaughn, D. E., Chirino, A. J.",
+      "title": "Crystal structure of the hemochromatosis protein HFE and characterization of its interaction with transferrin receptor",
+      "journal": "Cell"
+    },
+    "posts": [
+      "_posts/TfR-ECD-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14617356",
+    "publication": {
+      "pmid": "14617356",
+      "year": "2003",
+      "authors": "Parton, R. G., & Richards, A. A.",
+      "title": "Lipid rafts and caveolae as portals for endocytosis: new insights and common mechanisms",
+      "journal": "Traffic"
+    },
+    "posts": [
+      "_posts/TfR-ECD-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18838694",
+    "publication": {
+      "pmid": "18838694",
+      "year": "2008",
+      "authors": "Chen, C. H., Dellamaggiore, K. R., Ouellette, C. P., Sedano, C. D.",
+      "title": "Aptamer-based endocytosis of a lysosomal enzyme",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/TfR-ECD-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10704308",
+    "publication": {
+      "pmid": "10704308",
+      "year": "2000",
+      "authors": "Huang, T. H., Yang, D. S., Plaskos, N. P.",
+      "title": "Structural studies of soluble oligomers of the Alzheimer beta-amyloid peptide",
+      "journal": "ournal of molecular biology"
+    },
+    "posts": [
+      "_posts/E2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12176077",
+    "publication": {
+      "pmid": "12176077",
+      "year": "2002",
+      "authors": "Klein W. L.",
+      "title": "Abeta toxicity in Alzheimer's disease: globular oligomers (ADDLs) as new vaccine and drug targets",
+      "journal": "Neurochemistry international"
+    },
+    "posts": [
+      "_posts/E2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15919759",
+    "publication": {
+      "pmid": "15919759",
+      "year": "2005",
+      "authors": "Arimon, M., Díez-Pérez, I., Kogan, M. J., Durany, N.",
+      "title": "Fine structure study of Abeta1-42 fibrillogenesis with atomic force microscopy",
+      "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology"
+    },
+    "posts": [
+      "_posts/E2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17008022",
+    "publication": {
+      "pmid": "17008022",
+      "year": "2006",
+      "authors": "Güntert, A., Döbeli, H., & Bohrmann, B.",
+      "title": "High sensitivity analysis of amyloid-beta peptide composition in amyloid deposits from human and PS2APP mouse brain",
+      "journal": "Neuroscience"
+    },
+    "posts": [
+      "_posts/E2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19668864",
+    "publication": {
+      "pmid": "19668864",
+      "year": "2009",
+      "authors": "Takahashi, T., Tada, K., & Mihara, H.",
+      "title": "RNA aptamers selected against amyloid beta-peptide (Abeta) inhibit the aggregation of Abeta",
+      "journal": "Molecular bioSystems"
+    },
+    "posts": [
+      "_posts/E2-aptamer.md",
+      "_posts/β55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "3930479",
+    "publication": {
+      "pmid": "3930479",
+      "year": "1985",
+      "authors": "Hekman, C. M., & Loskutoff, D. J.",
+      "title": "Endothelial cells produce a latent inhibitor of plasminogen activators that can be activated by denaturants",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/PAI-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "2459123",
+    "publication": {
+      "pmid": "2459123",
+      "year": "1988",
+      "authors": "Declerck, P. J., De Mol, M., Alessi, M. C., Baudner, S.",
+      "title": "Purification and characterization of a plasminogen activator inhibitor 1 binding protein from human plasma. Identification as a multimeric form of S protein (vitronectin)",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/PAI-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8662688",
+    "publication": {
+      "pmid": "8662688",
+      "year": "1996",
+      "authors": "Deng, G., Royle, G., Wang, S., Crain, K., & Loskutoff, D. J.",
+      "title": "Structural and functional analysis of the plasminogen activator inhibitor-1 binding motif in the somatomedin B domain of vitronectin",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/PAI-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9168821",
+    "publication": {
+      "pmid": "9168821",
+      "year": "1997",
+      "authors": "Kjøller, L., Kanse, S. M., Kirkegaard, T., Rodenburg, K. W.",
+      "title": "Plasminogen activator inhibitor-1 represses integrin- and vitronectin-mediated cell migration independently of its function as an inhibitor of plasminogen activation",
+      "journal": "Experimental cell research"
+    },
+    "posts": [
+      "_posts/PAI-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15138609",
+    "publication": {
+      "pmid": "15138609",
+      "year": "2004",
+      "authors": "Chorostowska-Wynimko, J., Skrzypczak-Jankun, E., & Jankun, J.",
+      "title": "Plasminogen activator inhibitor type-1: its structure, biological activity and role in tumorigenesis (Review)",
+      "journal": "International journal of molecular medicine"
+    },
+    "posts": [
+      "_posts/PAI-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19284310",
+    "publication": {
+      "pmid": "19284310",
+      "year": "2009",
+      "authors": "Blake, C. M., Sullenger, B. A., Lawrence, D. A., & Fortenberry, Y. M.",
+      "title": "Antimetastatic potential of PAI-1-specific RNA aptamers",
+      "journal": "Oligonucleotides"
+    },
+    "posts": [
+      "_posts/PAI-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19271740",
+    "publication": {
+      "pmid": "19271740",
+      "year": "2009",
+      "authors": "Li, N., Ebright, J. N., Stovall, G. M., Chen, X., Nguyen, H. H.",
+      "title": "Technical and biological issues relevant to cell typing with aptamers",
+      "journal": "Journal of proteome research"
+    },
+    "posts": [
+      "_posts/J18-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20572251",
+    "publication": {
+      "pmid": "20572251",
+      "year": "2010",
+      "authors": "Townshend, B., Aubry, I., Marcellus, R. C., Gehring, K.",
+      "title": "An RNA aptamer that selectively inhibits the enzymatic activity of protein tyrosine phosphatase 1B in vitro",
+      "journal": "Chembiochem : a European journal of chemical biology"
+    },
+    "posts": [
+      "_posts/PTP1B-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29711918",
+    "publication": {
+      "pmid": "29711918",
+      "year": "2000",
+      "authors": "Piganeau, N., Jenne, A., Thuillier, V., & Famulok, M.",
+      "title": "An Allosteric Ribozyme Regulated by Doxycyline",
+      "journal": "Angewandte Chemie (International ed. in English)"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "11705996",
+    "publication": {
+      "pmid": "11705996",
+      "year": "2002",
+      "authors": "Meli, M., Vergne, J., Décout, J. L., & Maurel, M. C.",
+      "title": "Adenine-aptamer complexes: a bipartite RNA site that binds the adenine nucleic base",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "9384530",
+    "publication": {
+      "pmid": "9384530",
+      "year": "1997",
+      "authors": "Burke, D. H., Hoffman, D. C., Brown, A., Hansen, M.",
+      "title": "RNA aptamers to the peptidyl transferase inhibitor chloramphenicol",
+      "journal": "Chemistry & biology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "21839787",
+    "publication": {
+      "pmid": "21839787",
+      "year": "2011",
+      "authors": "Mehta, J., Van Dorst, B., Rouah-Martin, E., Herrebout, W.",
+      "title": "In vitro selection and characterization of DNA aptamers recognizing chloramphenicol",
+      "journal": "Journal of biotechnology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "10913311",
+    "publication": {
+      "pmid": "10913311",
+      "year": "2000",
+      "authors": "Koizumi, M., & Breaker, R. R.",
+      "title": "Molecular recognition of cAMP by an RNA aptamer",
+      "journal": "Biochemistry"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "9425088",
+    "publication": {
+      "pmid": "9425088",
+      "year": "1998",
+      "authors": "Hamasaki, K., Killian, J., Cho, J., & Rando, R. R.",
+      "title": "Minimal RNA constructs that specifically bind aminoglycoside antibiotics with high affinities",
+      "journal": "Biochemistry"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "11101810",
+    "publication": {
+      "pmid": "11101810",
+      "year": "2000",
+      "authors": "Jhaveri, S., Rajendran, M., & Ellington, A. D.",
+      "title": "In vitro selection of signaling aptamers",
+      "journal": "Nature biotechnology"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "9238640",
+    "publication": {
+      "pmid": "9238640",
+      "year": "1996",
+      "authors": "Lato, S. M., & Ellington, A. D.",
+      "title": "Screening chemical libraries for nucleic-acid-binding drugs by in vitro selection: a test case with lividomycin",
+      "journal": "Molecular diversity"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "9512549",
+    "publication": {
+      "pmid": "9512549",
+      "year": "1998",
+      "authors": "Kiga, D., Futamura, Y., Sakamoto, K., & Yokoyama, S.",
+      "title": "An RNA aptamer to the xanthine/guanine base with a distinctive mode of purine recognition",
+      "journal": "Nucleic acids research"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "18726014",
+    "publication": {
+      "pmid": "18726014",
+      "year": "2008",
+      "authors": "Sando, S., Narita, A., Hayami, M., & Aoyama, Y.",
+      "title": "Transcription monitoring using fused RNA with a dye-binding light-up aptamer as a tag: a blue fluorescent RNA",
+      "journal": "Chemical communications"
+    },
+    "posts": [
+      "_posts/II-mini3-4-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38783134",
+    "publication": {
+      "pmid": "38783134",
+      "year": "2024",
+      "authors": "Zuo, F., Jiang, L., Su, N., Zhang, Y., Bao, B.",
+      "title": "Imaging the dynamics of messenger RNA with a bright and stable green fluorescent RNA",
+      "journal": "Nature chemical biology"
+    },
+    "posts": [
+      "_posts/Okra-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37723244",
+    "publication": {
+      "pmid": "37723244",
+      "year": "2023",
+      "authors": "Jiang, L., Xie, X., Su, N., Zhang, D., Chen, X.",
+      "title": "Large Stokes shift fluorescent RNAs for dual-emission fluorescence and bioluminescence imaging in live cells",
+      "journal": "Nature methods"
+    },
+    "posts": [
+      "_posts/Chili-aptamer.md",
+      "_posts/Clivias-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38816645",
+    "publication": {
+      "pmid": "38816645",
+      "year": "2024",
+      "authors": "Huang, K., Song, Q., Fang, M., Yao, D.",
+      "title": "Structural basis of a small monomeric Clivia fluorogenic RNA with a large Stokes shift",
+      "journal": "Nature chemical biology"
+    },
+    "posts": [
+      "_posts/Clivias-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8650187",
+    "publication": {
+      "pmid": "8650187",
+      "year": "1996",
+      "authors": "O'Connell, D., Koenig, A., Jennings, S., Hicke, B., Han, H. L.",
+      "title": "Calcium-dependent oligonucleotide antagonists specific for L-selectin",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/L-selectin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12692304",
+    "publication": {
+      "pmid": "12692304",
+      "year": "2003",
+      "authors": "White, R. R., Shan, S., Rusconi, C. P., Shetty, G.",
+      "title": "Inhibition of rat corneal angiogenesis by a nuclease-resistant RNA aptamer specific for angiopoietin-2",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Angiopoietin-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9883908",
+    "publication": {
+      "pmid": "9883908",
+      "year": "1998",
+      "authors": "Kimoto, M., Sakamoto, K., Shirouzu, M., Hirao, I.",
+      "title": "RNA aptamers that specifically bind to the Ras-binding domain of Raf-1",
+      "journal": "FEBS letters"
+    },
+    "posts": [
+      "_posts/Raf-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10101203",
+    "publication": {
+      "pmid": "10101203",
+      "year": "1999",
+      "authors": "Triqueneaux, G., Velten, M., Franzon, P., Dautry, F.",
+      "title": "RNA binding specificity of Unr, a protein with five cold shock domains",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Upstream-of-N-Ras-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9546673",
+    "publication": {
+      "pmid": "9546673",
+      "year": "1998",
+      "authors": "Gal, S. W., Amontov, S., Urvil, P. T., Vishnuvardhan, D.",
+      "title": "Selection of a RNA aptamer that binds to human activated protein C and inhibits its protease function",
+      "journal": "European journal of biochemistry"
+    },
+    "posts": [
+      "_posts/Human-activated-protein-C-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8946842",
+    "publication": {
+      "pmid": "8946842",
+      "year": "1996",
+      "authors": "Ishizaki, J., Nevins, J. R., & Sullenger, B. A.",
+      "title": "Inhibition of cell proliferation by an RNA ligand that selectively blocks E2F function",
+      "journal": "Nature medicine"
+    },
+    "posts": [
+      "_posts/E2F1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12054450",
+    "publication": {
+      "pmid": "12054450",
+      "year": "2002",
+      "authors": "Daniels, D. A., Sohal, A. K., Rees, S., & Grisshammer, R.",
+      "title": "Generation of RNA aptamers to the G-protein-coupled receptor for neurotensin, NTS-1",
+      "journal": "Analytical biochemistry"
+    },
+    "posts": [
+      "_posts/Neurotensin-receptor-NTS-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9873529",
+    "publication": {
+      "pmid": "9873529",
+      "year": "1998",
+      "authors": "Jhaveri, S., Olwin, B., & Ellington, A. D.",
+      "title": "In vitro selection of phosphorothiolated aptamers",
+      "journal": "Bioorganic & medicinal chemistry letters"
+    },
+    "posts": [
+      "_posts/Basic-fibroblast-growth-factor-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11329270",
+    "publication": {
+      "pmid": "11329270",
+      "year": "2001",
+      "authors": "Zhai, G., Iskandar, M., Barilla, K., & Romaniuk, P. J.",
+      "title": "Characterization of RNA aptamer binding by the Wilms' tumor suppressor protein WT1",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/Wilms-tumor-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10097084",
+    "publication": {
+      "pmid": "10097084",
+      "year": "1999",
+      "authors": "Blind, M., Kolanus, W., & Famulok, M.",
+      "title": "Cytoplasmic RNA modulators of an inside-out signal-transduction cascade",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Integrin-beta-chain-2-(CD18)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12490703",
+    "publication": {
+      "pmid": "12490703",
+      "year": "2002",
+      "authors": "Lee, J. H., Kim, H., Ko, J., & Lee, Y.",
+      "title": "Interaction of C5 protein with RNA aptamers selected by SELEX",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Complement-component-5-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9889155",
+    "publication": {
+      "pmid": "9889155",
+      "year": "1998",
+      "authors": "Holeman, L. A., Robinson, S. L., Szostak, J. W., & Wilson, C.",
+      "title": "Isolation and characterization of fluorophore-binding RNA aptamers",
+      "journal": "Folding & design"
+    },
+    "posts": [
+      "_posts/FB-1-aptamer.md",
+      "_posts/SRB-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19303859",
+    "publication": {
+      "pmid": "19303859",
+      "year": "2009",
+      "authors": "Werner, A., Konarev, P. V., Svergun, D. I., & Hahn, U.",
+      "title": "Characterization of a fluorophore binding RNA aptamer by fluorescence correlation spectroscopy and small angle X-ray scattering",
+      "journal": "Analytical biochemistry"
+    },
+    "posts": [
+      "_posts/SRB-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24133044",
+    "publication": {
+      "pmid": "24133044",
+      "year": "2013",
+      "authors": "Sunbul, M., & Jäschke, A.",
+      "title": "Contact-Mediated Quenching for RNA Imaging in Bacteria with  a Fluorophore-Binding Aptamer",
+      "journal": "Angewandte Chemie"
+    },
+    "posts": [
+      "_posts/SRB-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26175046",
+    "publication": {
+      "pmid": "26175046",
+      "year": "2015",
+      "authors": "Arora, A., Sunbul, M., & Jäschke, A.",
+      "title": "Dual-colour imaging of RNAs using quencher- and fluorophore-binding aptamers",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/SRB-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29931157",
+    "publication": {
+      "pmid": "29931157",
+      "year": "2018",
+      "authors": "Sunbul, M., & Jäschke, A.",
+      "title": "SRB-2: a promiscuous rainbow aptamer for live-cell RNA imaging",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/SRB-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31636432",
+    "publication": {
+      "pmid": "31636432",
+      "year": "2020",
+      "authors": "Bouhedda, F., Fam, K. T., Collot, M., Autour, A.",
+      "title": "A dimerization-based fluorogenic dye-aptamer module for RNA imaging in live cells",
+      "journal": "Nature chemical biology"
+    },
+    "posts": [
+      "_posts/SRB-2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25337688",
+    "publication": {
+      "pmid": "25337688",
+      "year": "2014",
+      "authors": "Filonov, G. S., Moon, J. D., Svensen, N., & Jaffrey, S. R.",
+      "title": "Broccoli: rapid selection of an RNA mimic of green fluorescent protein by fluorescence-based selection and directed evolution",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md",
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26000751",
+    "publication": {
+      "pmid": "26000751",
+      "year": "2015",
+      "authors": "Filonov, G. S., Kam, C. W., Song, W., & Jaffrey, S. R.",
+      "title": "In-gel imaging of RNA processing using broccoli reveals optimal aptamer expression strategies",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md",
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26995352",
+    "publication": {
+      "pmid": "26995352",
+      "year": "2016",
+      "authors": "Filonov, G. S., & Jaffrey, S. R.",
+      "title": "RNA imaging with dimeric Broccoli in live bacterial and mammalian cells",
+      "journal": "Current protocols in chemical biology"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26877022",
+    "publication": {
+      "pmid": "26877022",
+      "year": "2016",
+      "authors": "Svensen, N., & Jaffrey, S. R.",
+      "title": "Fluorescent RNA aptamers as a tool to study RNA-modifying enzymes",
+      "journal": "Cell chemical biology"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27467146",
+    "publication": {
+      "pmid": "27467146",
+      "year": "2016",
+      "authors": "Ageely, E. A., Kartje, Z. J., Rohilla, K. J., Barkau, C. L., & Gagnon, K. T.",
+      "title": "Quadruplex-flanking stem structures modulate the stability and metal ion preferences of RNA mimics of GFP",
+      "journal": "ACS chemical biology"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28180326",
+    "publication": {
+      "pmid": "28180326",
+      "year": "2017",
+      "authors": "Okuda, M., Fourmy, D., & Yoshizawa, S.",
+      "title": "Use of baby Spinach and Broccoli for imaging of structured cellular RNAs",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md",
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28548488",
+    "publication": {
+      "pmid": "28548488",
+      "year": "2017",
+      "authors": "Alam, K. K., Tawiah, K. D., Lichte, M. F., Porciani, D., & Burke, D. H.",
+      "title": "A fluorescent split aptamer for visualizing RNA-RNA assembly in vivo",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28991414",
+    "publication": {
+      "pmid": "28991414",
+      "year": "2018",
+      "authors": "Wang, Z., Luo, Y., Xie, X., Hu, X., Song, H., Zhao, Y., Shi, J.",
+      "title": "In situ spatial complementation of aptamer-mediated recognition enables live-cell imaging of native RNA transcripts in real time",
+      "journal": "Angewandte Chemie"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30513826",
+    "publication": {
+      "pmid": "30513826",
+      "year": "2018",
+      "authors": "Chandler, M., Lyalina, T., Halman, J., Rackley, L., Lee, L.",
+      "title": "Broccoli fluorets: split aptamers as a user-friendly fluorescent toolkit for dynamic RNA nanotechnology",
+      "journal": "Molecules"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30962542",
+    "publication": {
+      "pmid": "30962542",
+      "year": "2019",
+      "authors": "Litke, J. L., & Jaffrey, S. R.",
+      "title": "Highly efficient expression of circular RNA aptamers in cells using autocatalytic transcripts",
+      "journal": "Nature biotechnology"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31850609",
+    "publication": {
+      "pmid": "31850609",
+      "year": "2020",
+      "authors": "Li, X., Kim, H., Litke, J. L., Wu, J., & Jaffrey, S. R.",
+      "title": "Fluorophore-promoted RNA folding and photostability enables imaging of single broccoli-tagged mRNAs in live mammalian cells",
+      "journal": "Angewandte Chemie"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32698574",
+    "publication": {
+      "pmid": "32698574",
+      "year": "2020",
+      "authors": "Li, X., Mo, L., Litke, J. L., Dey, S. K., Suter, S. R., & Jaffrey, S. R.",
+      "title": "Imaging intracellular S-adenosyl methionine dynamics in live mammalian cells with a genetically encoded red fluorescent RNA-based sensor",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33303627",
+    "publication": {
+      "pmid": "33303627",
+      "year": "2021",
+      "authors": "Kartje, Z. J., Janis, H. I., Mukhopadhyay, S., & Gagnon, K. T.",
+      "title": "Revisiting T7 RNA polymerase transcription in vitro with the Broccoli RNA aptamer as a simplified real-time fluorescent reporter",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33342694",
+    "publication": {
+      "pmid": "33342694",
+      "year": "2021",
+      "authors": "Zhang, T., Zhou, W., Lin, X., Khan, M. R., Deng, S.",
+      "title": "Light-up RNA aptamer signaling-CRISPR-cas13a-based mix-and-read assays for profiling viable pathogenic bacteria",
+      "journal": "Biosensors & bioelectronics"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34490956",
+    "publication": {
+      "pmid": "34490956",
+      "year": "2021",
+      "authors": "Li, X., Wu, J., & Jaffrey, S. R.",
+      "title": "Engineering fluorophore recycling in a fluorogenic RNA aptamer",
+      "journal": "Angewandte Chemie"
+    },
+    "posts": [
+      "_posts/DFHBI-1T-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25101481",
+    "publication": {
+      "pmid": "25101481",
+      "year": "2014",
+      "authors": "Dolgosheina, E. V., Jeng, S. C., Panchapakesan, S. S.",
+      "title": "RNA mango aptamer-fluorophore: a bright, high-affinity complex for RNA labeling and tracking",
+      "journal": "ACS chemical biology"
+    },
+    "posts": [
+      "_posts/Mango-III-aptamer(YO3).md",
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28553947",
+    "publication": {
+      "pmid": "28553947",
+      "year": "2017",
+      "authors": "Trachman, R. J., 3rd, Demeshkina, N. A., Lau, M. W. L.",
+      "title": "Structural basis for high-affinity fluorophore binding and activation by RNA Mango",
+      "journal": "Nature chemical biology"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29440634",
+    "publication": {
+      "pmid": "29440634",
+      "year": "2018",
+      "authors": "Autour, A., C Y Jeng, S., D Cawte, A., Abdolahzadeh, A., Galli, A.",
+      "title": "Fluorogenic RNA Mango aptamers for imaging small non-coding RNAs in mammalian cells",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29768001",
+    "publication": {
+      "pmid": "29768001",
+      "year": "2018",
+      "authors": "Trachman, R. J., 3rd, Abdolahzadeh, A., Andreoni, A., Cojocaru, R.",
+      "title": "Crystal structures of the Mango-II RNA aptamer reveal heterogeneous fluorophore binding and guide engineering of variants with improved selectivity and brightness",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30992561",
+    "publication": {
+      "pmid": "30992561",
+      "year": "2019",
+      "authors": "Trachman, R. J., 3rd, Autour, A., Jeng, S. C. Y., Abdolahzadeh, A.",
+      "title": "Structure and functional reselection of the Mango-III fluorogenic RNA aptamer",
+      "journal": "Nature chemical biology"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32152311",
+    "publication": {
+      "pmid": "32152311",
+      "year": "2020",
+      "authors": "Cawte, A. D., Unrau, P. J., & Rueda, D. S.",
+      "title": "Live cell imaging of single RNA molecules with fluorogenic Mango II arrays",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32386573",
+    "publication": {
+      "pmid": "32386573",
+      "year": "2020",
+      "authors": "Trachman, R. J., 3rd, Cojocaru, R., Wu, D., Piszczek, G.",
+      "title": "Structure-guided engineering of the homodimeric Mango-IV fluorescence turn-on aptamer yields an RNA FRET pair",
+      "journal": "Structure"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33674421",
+    "publication": {
+      "pmid": "33674421",
+      "year": "2021",
+      "authors": "Kong, K. Y. S., Jeng, S. C. Y., Rayyan, B., & Unrau, P. J.",
+      "title": "RNA Peach and Mango: Orthogonal two-color fluorogenic aptamers distinguish nearly identical ligands",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34971617",
+    "publication": {
+      "pmid": "34971617",
+      "year": "2022",
+      "authors": "Harish, B., Wang, J., Hayden, E. J., Grabe, B., Hiller, W.",
+      "title": "Hidden intermediates in Mango III RNA aptamer folding revealed by pressure perturbation",
+      "journal": "Biophysical journal"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36120549",
+    "publication": {
+      "pmid": "36120549",
+      "year": "2022",
+      "authors": "Yang, X., Liu, C., Kuo, Y. A., Yeh, H. C., & Ren, P.",
+      "title": "Computational study on the binding of Mango-II RNA aptamer and fluorogen using the polarizable force field AMOEBA",
+      "journal": "Frontiers in molecular biosciences"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36840712",
+    "publication": {
+      "pmid": "36840712",
+      "year": "2023",
+      "authors": "Bychenko, O. S., Khrulev, A. A., Svetlova, J. I., Tsvetkov, V. B.",
+      "title": "Red light-emitting short Mango-based system enables tracking a mycobacterial small noncoding RNA in infected macrophages",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Mango-aptamer(TO1-biotin).md",
+      "_posts/Mango-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28644615",
+    "publication": {
+      "pmid": "28644615",
+      "year": "2017",
+      "authors": "Tan, X., Constantin, T. P., Sloane, K. L., Waggoner, A. S.",
+      "title": "Fluoromodules consisting of a promiscuous RNA aptamer and red or blue fluorogenic cyanine dyes: Selection, characterization, and bioimaging",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/DIR2s-apt-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30382099",
+    "publication": {
+      "pmid": "30382099",
+      "year": "2018",
+      "authors": "Shelke, S. A., Shao, Y., Laski, A., Koirala, D., Weissman, B. P.",
+      "title": "Structural basis for activation of fluorogenic dyes by an RNA aptamer lacking a G-quadruplex motif",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/DIR2s-apt-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28945233",
+    "publication": {
+      "pmid": "28945233",
+      "year": "2017",
+      "authors": "Song, W., Filonov, G. S., Kim, H., Hirsch, M., Li, X.",
+      "title": "Imaging RNA polymerase III transcription using a photostable RNA-fluorophore complex",
+      "journal": "Nature chemical biology"
+    },
+    "posts": [
+      "_posts/Corn-aptamer.md",
+      "_posts/Beetroot-aptamer.md",
+      "_posts/Beetroot-aptamer(ThT).md"
+    ]
+  },
+  {
+    "pmid": "31178406",
+    "publication": {
+      "pmid": "31178406",
+      "year": "2019",
+      "authors": "Sjekloća, L., & Ferré-D'Amaré, A. R.",
+      "title": "Binding between G quadruplexes at the homodimer interface of the corn RNA aptamer strongly activates thioflavin T fluorescence",
+      "journal": "Cell chemical biology"
+    },
+    "posts": [
+      "_posts/Corn-aptamer.md",
+      "_posts/Beetroot-aptamer.md",
+      "_posts/Beetroot-aptamer(ThT).md"
+    ]
+  },
+  {
+    "pmid": "37221204",
+    "publication": {
+      "pmid": "37221204",
+      "year": "2023",
+      "authors": "Passalacqua, L. F. M., Starich, M. R., Link, K. A.",
+      "title": "Co-crystal structures of the fluorogenic aptamer Beetroot show that close homology may not predict similar RNA architecture",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/Corn-aptamer.md",
+      "_posts/Beetroot-aptamer.md",
+      "_posts/Beetroot-aptamer(ThT).md",
+      "_posts/Beetroot-aptamer(DFAME).md"
+    ]
+  },
+  {
+    "pmid": "30485561",
+    "publication": {
+      "pmid": "30485561",
+      "year": "2019",
+      "authors": "Steinmetzger, C., Palanisamy, N., Gore, K. R., & Höbartner, C.",
+      "title": "A multicolor large stokes shift fluorogen-activating RNA aptamer with cationic chromophores",
+      "journal": "Chemistry"
+    },
+    "posts": [
+      "_posts/Chili-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31740962",
+    "publication": {
+      "pmid": "31740962",
+      "year": "2019",
+      "authors": "Steinmetzger, C., Bessi, I., Lenz, A. K., & Höbartner, C.",
+      "title": "Structure-fluorescence activation relationships of a large Stokes shift fluorogenic RNA aptamer",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Chili-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34112799",
+    "publication": {
+      "pmid": "34112799",
+      "year": "2021",
+      "authors": "Mieczkowski, M., Steinmetzger, C., Bessi, I., Lenz, A. K.",
+      "title": "Large Stokes shift fluorescence activation in an RNA aptamer by intermolecular proton transfer to guanine",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/Chili-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20159999",
+    "publication": {
+      "pmid": "20159999",
+      "year": "2010",
+      "authors": "Carothers, J. M., Goler, J. A., Kapoor, Y., Lara, L., & Keasling, J. D.",
+      "title": "Selecting RNA aptamers for synthetic biology: investigating magnesium dependence and predicting binding affinity",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27730489",
+    "publication": {
+      "pmid": "27730489",
+      "year": "2017",
+      "authors": "Duchardt-Ferner, E., Juen, M., Kreutz, C., & Wöhnert, J.",
+      "title": "NMR resonance assignments for the tetramethylrhodamine binding RNA aptamer 3 in complex with the ligand 5-carboxy-tetramethylrhodamine",
+      "journal": "Biomolecular NMR assignments"
+    },
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31754719",
+    "publication": {
+      "pmid": "31754719",
+      "year": "2020",
+      "authors": "Duchardt-Ferner, E., Juen, M., Bourgeois, B., Madl, T.",
+      "title": "Structure of an RNA aptamer in complex with the  fluorophore tetramethylrhodamine",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35294188",
+    "publication": {
+      "pmid": "35294188",
+      "year": "2022",
+      "authors": "Wu, J., Svensen, N., Song, W., Kim, H., Zhang, S., Li, X., & Jaffrey, S. R.",
+      "title": "Self-assembly of intracellular multivalent RNA complexes using dimeric Corn and Beetroot Aptamers",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/Corn-aptamer.md",
+      "_posts/Beetroot-aptamer.md",
+      "_posts/Beetroot-aptamer(DFAME).md"
+    ]
+  },
+  {
+    "pmid": "29295996",
+    "publication": {
+      "pmid": "29295996",
+      "year": "2018",
+      "authors": "Jepsen, M. D. E., Sparvath, S. M., Nielsen, T. B., Langvad, A. H.",
+      "title": "Development of a genetically encodable FRET system using fluorescent RNA aptamers",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/Mango-III-aptamer(YO3).md",
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33376189",
+    "publication": {
+      "pmid": "33376189",
+      "year": "2021",
+      "authors": "Jeng, S. C. Y., Trachman, R. J., 3rd, Weissenboeck, F., Truong, L.",
+      "title": "Fluorogenic aptamers resolve the flexibility of RNA junctions using orientation-dependent FRET",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Mango-III-aptamer(YO3).md"
+    ]
+  },
+  {
+    "pmid": "36227560",
+    "publication": {
+      "pmid": "36227560",
+      "year": "2023",
+      "authors": "Trachman, R. J., 3rd, Link, K. A., Knutson, J. R., & Ferré-D'Amaré, A. R.",
+      "title": "Characterizing fluorescence properties of turn-on RNA aptamers",
+      "journal": "Methods in molecular biology"
+    },
+    "posts": [
+      "_posts/Mango-III-aptamer(YO3).md"
+    ]
+  },
+  {
+    "pmid": "23746618",
+    "publication": {
+      "pmid": "23746618",
+      "year": "2013",
+      "authors": "Strack, R. L., & Jaffrey, S. R.",
+      "title": "New approaches for sensing metabolites and proteins in live cells using RNA",
+      "journal": "Current opinion in chemical biology"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23991672",
+    "publication": {
+      "pmid": "23991672",
+      "year": "2013",
+      "authors": "Höfer, K., Langejürgen, L. V., & Jäschke, A.",
+      "title": "Universal aptamer-based real-time monitoring of enzymatic RNA synthesis",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24286188",
+    "publication": {
+      "pmid": "24286188",
+      "year": "2013",
+      "authors": "Han, K. Y., Leslie, B. J., Fei, J., Zhang, J., & Ha, T.",
+      "title": "Understanding the photophysics of the spinach-DFHBI RNA aptamer-fluorogen complex to improve live-cell RNA imaging",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24393009",
+    "publication": {
+      "pmid": "24393009",
+      "year": "2014",
+      "authors": "Song, W., Strack, R. L., Svensen, N., & Jaffrey, S. R.",
+      "title": "Plug-and-play fluorophores extend the spectral properties of Spinach",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23991760",
+    "publication": {
+      "pmid": "23991760",
+      "year": "2014",
+      "authors": "Pothoulakis, G., Ceroni, F., Reeve, B., & Ellis, T.",
+      "title": "The spinach RNA aptamer as a characterization tool for synthetic biology",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25026079",
+    "publication": {
+      "pmid": "25026079",
+      "year": "2014",
+      "authors": "Warner, K. D., Chen, M. C., Song, W., Strack, R. L.",
+      "title": "Structural basis for activity of highly efficient RNA mimics of green fluorescent protein",
+      "journal": "Nature structural & molecular biology"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24942625",
+    "publication": {
+      "pmid": "24942625",
+      "year": "2014",
+      "authors": "Bhadra, S., & Ellington, A. D.",
+      "title": "A Spinach molecular beacon triggered by strand displacement",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24932527",
+    "publication": {
+      "pmid": "24932527",
+      "year": "2015",
+      "authors": "Rogers, T. A., Andrews, G. E., Jaeger, L., & Grabow, W. W.",
+      "title": "Fluorescent monitoring of RNA assembly and processing using the split-Spinach aptamer",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25964329",
+    "publication": {
+      "pmid": "25964329",
+      "year": "2015",
+      "authors": "You, M., Litke, J. L., & Jaffrey, S. R.",
+      "title": "Imaging metabolite dynamics in living cells using a Spinach-based riboswitch",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Spinach-RNA-aptamer.md",
+      "_posts/Spinach-RNA-aptamer.md",
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26612428",
+    "publication": {
+      "pmid": "26612428",
+      "year": "2015",
+      "authors": "Zhang, J., Fei, J., Leslie, B. J., Han, K. Y., Kuhlman, T. E., & Ha, T.",
+      "title": "Tandem spinach array for mRNA imaging in living bacterial cells",
+      "journal": "Scientific reports"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26932363",
+    "publication": {
+      "pmid": "26932363",
+      "year": "2016",
+      "authors": "Autour, A., Westhof, E., & Ryckelynck, M.",
+      "title": "iSpinach: a fluorogenic RNA aptamer optimized for in vitro applications",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30016869",
+    "publication": {
+      "pmid": "30016869",
+      "year": "2018",
+      "authors": "Tang, X., Deng, R., Sun, Y., Ren, X., Zhou, M., & Li, J.",
+      "title": "Amplified tandem Spinach-based aptamer transcription enables low background miRNA detection",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30807171",
+    "publication": {
+      "pmid": "30807171",
+      "year": "2019",
+      "authors": "Santra, K., Geraskin, I., Nilsen-Hamilton, M., Kraus, G. A., & Petrich, J. W.",
+      "title": "Characterization of the photophysical behavior of DFHBI derivatives: Fluorogenic molecules that illuminate the Spinach RNA aptamer",
+      "journal": "The journal of physical chemistry"
+    },
+    "posts": [
+      "_posts/Spinach-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10339553",
+    "publication": {
+      "pmid": "10339553",
+      "year": "19990525",
+      "authors": "Grate, D., & Wilson, C.",
+      "title": "Laser-mediated, site-specific inactivation of RNA transcripts",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10926496",
+    "publication": {
+      "pmid": "10926496",
+      "year": "20000804",
+      "authors": "Baugh, C., Grate, D., & Wilson, C.",
+      "title": "2.8 A crystal structure of the malachite green aptamer",
+      "journal": "Journal of molecular biology"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12475353",
+    "publication": {
+      "pmid": "12475353",
+      "year": "20021218",
+      "authors": "Nguyen, D. H., DeFina, S. C., Fink, W. H., & Dieckmann, T.",
+      "title": "Binding to an RNA aptamer changes the charge distribution and conformation of malachite green",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14695514",
+    "publication": {
+      "pmid": "14695514",
+      "year": "20040103",
+      "authors": "Flinders, J., DeFina, S. C., Brackett, D. M., Baugh, C., Wilson, C.",
+      "title": "Recognition of planar and nonplanar Ligands in the malachite green±RNA aptamer complex",
+      "journal": "Chembiochem : a European journal of chemical biology"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16144363",
+    "publication": {
+      "pmid": "16144363",
+      "year": "20050914",
+      "authors": "Kolpashchikov D. M.",
+      "title": "Binary malachite green aptamer for fluorescent detection of nucleic acids",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18667307",
+    "publication": {
+      "pmid": "18667307",
+      "year": "20080815",
+      "authors": "Furukawa, K., Abe, H., Abe, N., Harada, M., Tsuneda, S., & Ito, Y.",
+      "title": "Fluorescence generation from tandem repeats of a malachite green RNA aptamer using rolling circle transcription",
+      "journal": "Bioorganic & medicinal chemistry letters"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19195013",
+    "publication": {
+      "pmid": "19195013",
+      "year": "20090301",
+      "authors": "Zhang, X., Potty, A. S., Jackson, G. W., Stepanov, V., Tang, A.",
+      "title": "Engineered 5S ribosomal RNAs displaying aptamers recognizing vascular endothelial growth factor and malachite green",
+      "journal": "Journal of molecular recognition: JMR"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21523267",
+    "publication": {
+      "pmid": "21523267",
+      "year": "20110701",
+      "authors": "Bernard Da Costa, J., & Dieckmann, T.",
+      "title": "Entropy and Mg2+ control ligand affinity and specificity in the malachite green binding RNA aptamer",
+      "journal": "Molecular bioSystems"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22192051",
+    "publication": {
+      "pmid": "22192051",
+      "year": "20120110",
+      "authors": "Sokoloski, J. E., Dombrowski, S. E., & Bevilacqua, P. C.",
+      "title": "Thermodynamics of ligand binding to a heterogeneous RNA population in the malachite green aptamer",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23984874",
+    "publication": {
+      "pmid": "23984874",
+      "year": "20130924",
+      "authors": "Da Costa, J. B., Andreiev, A. I., & Dieckmann, T.",
+      "title": "Thermodynamics and kinetics of adaptive binding in the malachite green RNA aptamer",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27591602",
+    "publication": {
+      "pmid": "27591602",
+      "year": "20161101",
+      "authors": "Zhou, Y., Chi, H., Wu, Y., Marks, R. S., & Steele, T. W. J.",
+      "title": "Organic additives stabilize RNA aptamer binding of malachite green",
+      "journal": "Talanta"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29513000",
+    "publication": {
+      "pmid": "29513000",
+      "year": "20180316",
+      "authors": "Yerramilli, V. S., & Kim, K. H.",
+      "title": "Labeling RNAs in live cells using malachite green aptamer scaffolds as fluorescent probes",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31187804",
+    "publication": {
+      "pmid": "31187804",
+      "year": "20190721",
+      "authors": "Luo, X., Chen, Z., Li, H., Li, W., Cui, L., & Huang, J.",
+      "title": "Exploiting the application of l-aptamer with excellent stability: an efficient sensing platform for malachite green in fish samples",
+      "journal": "The Analyst"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35529731",
+    "publication": {
+      "pmid": "35529731",
+      "year": "20191015",
+      "authors": "Wang, H., Wang, H., Zhang, M., Jia, Y., & Li, Z.",
+      "title": "A label-free aptamer-based biosensor for microRNA detection by the RNA-regulated fluorescence of malachite green",
+      "journal": "RSC advances"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36373144",
+    "publication": {
+      "pmid": "36373144",
+      "year": "20221101",
+      "authors": "R O'Steen, M., & M Kolpashchikov, D.",
+      "title": "A self-assembling split aptamer multiplex assay for SARS-COVID19 and miniaturization of a malachite green DNA-based aptamer",
+      "journal": "Sensors and actuators reports"
+    },
+    "posts": [
+      "_posts/MG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19901993",
+    "publication": {
+      "pmid": "19901993",
+      "year": "2009",
+      "authors": "Rahimi F, Murakami K, Summers JL, Chen CH, Bitan G",
+      "title": "RNA aptamers generated against oligomeric Abeta40 recognize common amyloid aptatopes with low specificity but high sensitivity",
+      "journal": "PLoS One"
+    },
+    "posts": [
+      "_posts/β55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25618678",
+    "publication": {
+      "pmid": "25618678",
+      "year": "2015",
+      "authors": "Babu E, Muthu Mareeswaran P, Sathish V, Singaravadivel S, Rajagopal S",
+      "title": "Sensing and inhibition of amyloid-β based on the simple luminescent aptamer-ruthenium complex system",
+      "journal": "Talanta"
+    },
+    "posts": [
+      "_posts/β55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30642129",
+    "publication": {
+      "pmid": "30642129",
+      "year": "2019",
+      "authors": "Janas T, Sapoń K, Stowell MHB, Janas T",
+      "title": "Selection of Membrane RNA Aptamers to Amyloid Beta Peptide: Implications for Exosome-Based Antioxidant Strategies",
+      "journal": "International journal of molecular sciences"
+    },
+    "posts": [
+      "_posts/β55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32127399",
+    "publication": {
+      "pmid": "32127399",
+      "year": "2020",
+      "authors": "Murakami K, Obata Y, Sekikawa A, Ueda H, Izuo N",
+      "title": "An RNA aptamer with potent affinity for a toxic dimer of amyloid β42 has potential utility for histochemical studies of Alzheimer's disease",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md",
+      "_posts/β55-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11884639",
+    "publication": {
+      "pmid": "11884639",
+      "year": "2002",
+      "authors": "Lato SM, Ozerova ND, He K, Sergueeva Z, Shaw BR, Burke DH",
+      "title": "Boron-containing aptamers to ATP",
+      "journal": "Nucleic acids research"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "9245404",
+    "publication": {
+      "pmid": "9245404",
+      "year": "1997",
+      "authors": "Mannironi C, Di Nardo A, Fruscoloni P, Tocchini-Valentini GP",
+      "title": "In vitro selection of dopamine RNA ligands",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21168553",
+    "publication": {
+      "pmid": "21168553",
+      "year": "2011",
+      "authors": "Park H, Paeng IR",
+      "title": "Development of direct competitive enzyme-linked aptamer assay for determination of dopamine in serum",
+      "journal": "Analytica chimica acta"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23069733",
+    "publication": {
+      "pmid": "23069733",
+      "year": "2012",
+      "authors": "Annoni C, Nakata E, Tamura T, Liew FF, Nakano S, Gelmi ML, Morii T",
+      "title": "Construction of ratiometric fluorescent sensors by ribonucleopeptides",
+      "journal": "Organic & biomolecular chemistry"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23210972",
+    "publication": {
+      "pmid": "23210972",
+      "year": "2013",
+      "authors": "Farjami E, Campos R, Nielsen JS, Gothelf KV, Kjems J, Ferapontova EE",
+      "title": "RNA aptamer-based electrochemical biosensor for selective and label-free analysis of dopamine",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25882962",
+    "publication": {
+      "pmid": "25882962",
+      "year": "2015",
+      "authors": "Álvarez-Martos I, Campos R, Ferapontova EE",
+      "title": "Surface state of the dopamine RNA aptamer affects specific recognition and binding of dopamine by the aptamer-modified electrodes",
+      "journal": "The Analyst"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26916821",
+    "publication": {
+      "pmid": "26916821",
+      "year": "2016",
+      "authors": "Álvarez-Martos I, Ferapontova EE",
+      "title": "Electrochemical Label-Free Aptasensor for Specific Analysis of Dopamine in Serum in the Presence of Structurally Related Neurotransmitters",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30605601",
+    "publication": {
+      "pmid": "30605601",
+      "year": "2019",
+      "authors": "Álvarez-Martos I, Møller A, Ferapontova EE",
+      "title": "Dopamine Binding and Analysis in Undiluted Human Serum and Blood by the RNA-Aptamer Electrode",
+      "journal": "ACS chemical neuroscience"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35775197",
+    "publication": {
+      "pmid": "35775197",
+      "year": "2022",
+      "authors": "Harbaugh SV, Silverman AD, Chushak YG, Zimlich K, Wolfe M",
+      "title": "Engineering a Synthetic Dopamine-Responsive Riboswitch for In Vitro Biosensing",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Dopamine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9631062",
+    "publication": {
+      "pmid": "9631062",
+      "year": "1996",
+      "authors": "Nolte A, Klussmann S, Bald R, Erdmann VA, Fürste JP",
+      "title": "Mirror-design of L-oligonucleotide ligands binding to L-arginine",
+      "journal": "Nature biotechnology"
+    },
+    "posts": [
+      "_posts/Citrulline-aptamer.md",
+      "_posts/Arginine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8604334",
+    "publication": {
+      "pmid": "8604334",
+      "year": "1996",
+      "authors": "Geiger A, Burgstaller P, von der Eltz H, Roeder A, Famulok M",
+      "title": "RNA aptamers that bind L-arginine with sub-micromolar dissociation constants and high enantioselectivity",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Citrulline-aptamer.md",
+      "_posts/Arginine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10786843",
+    "publication": {
+      "pmid": "10786843",
+      "year": "2000",
+      "authors": "Mannironi C, Scerch C, Fruscoloni P, Tocchini-Valentini GP",
+      "title": "Molecular recognition of amino acids by RNA aptamers: the evolution into an L-tyrosine binder of a dopamine-binding RNA motif",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Tyr-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28835641",
+    "publication": {
+      "pmid": "28835641",
+      "year": "2017",
+      "authors": "Abatemarco J, Sarhan MF, Wagner JM, Lin JL, Liu L",
+      "title": "NA-aptamers-in-droplets (RAPID) high-throughput screening for secretory phenotypes",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/Tyr-1-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11756401",
+    "publication": {
+      "pmid": "11756401",
+      "year": "2002",
+      "authors": "Proske D, Höfliger M, Söll RM, Beck-Sickinger AG, Famulok M",
+      "title": "A Y2 receptor mimetic aptamer directed against neuropeptide Y",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/DP3-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15984861",
+    "publication": {
+      "pmid": "15984861",
+      "year": "2005",
+      "authors": "Mendonsa SD, Bowser MT",
+      "title": "In vitro selection of aptamers with affinity for neuropeptide Y using capillary electrophoresis",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/DP3-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33297678",
+    "publication": {
+      "pmid": "33297678",
+      "year": "2021",
+      "authors": "López L, Hernández N, Reyes Morales J, Cruz J, Flores K",
+      "title": "Measurement of Neuropeptide Y Using Aptamer-Modified Microelectrodes by Electrochemical Impedance Spectroscopy",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/DP3-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38033269",
+    "publication": {
+      "pmid": "38033269",
+      "year": "2023",
+      "authors": "Seibold JM, Abeykoon SW, Ross AE, White RJ",
+      "title": "Development of an Electrochemical, Aptamer-Based Sensor for Dynamic Detection of Neuropeptide Y",
+      "journal": "ACS sensors"
+    },
+    "posts": [
+      "_posts/DP3-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38709872",
+    "publication": {
+      "pmid": "38709872",
+      "year": "2024",
+      "authors": "Fernández-Vega L, Meléndez-Rodríguez DE, Ospina-Alejandro M",
+      "title": "Development of a Neuropeptide Y-Sensitive Implantable Microelectrode for Continuous Measurements",
+      "journal": "ACS sensors"
+    },
+    "posts": [
+      "_posts/DP3-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11139634",
+    "publication": {
+      "pmid": "11139634",
+      "year": "2001",
+      "authors": "Srisawat C, Goldstein IJ, Engelke DR",
+      "title": "Sephadex-binding RNA ligands: rapid affinity purification of RNA from complex RNA mixtures",
+      "journal": "Nucleic acids research"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "26135474",
+    "publication": {
+      "pmid": "26135474",
+      "year": "2015",
+      "authors": "Lee T, Yagati AK, Pi F, Sharma A, Choi JW, Guo P",
+      "title": "Construction of RNA-Quantum Dot Chimera for Nanoscale Resistive Biomemory Application",
+      "journal": "ACS nano"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "32042566",
+    "publication": {
+      "pmid": "32042566",
+      "year": "2019",
+      "authors": "Lee T, Mohammadniaei M, Zhang H, Yoon J, Choi HK, Guo S",
+      "title": "Single Functionalized pRNA/Gold Nanoparticle for Ultrasensitive MicroRNA Detection Using Electrochemical Surface-Enhanced Raman Spectroscopy",
+      "journal": "Advanced science"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "11178986",
+    "publication": {
+      "pmid": "11178986",
+      "year": "2001",
+      "authors": "Jeong S, Eom T, Kim S, Lee S, Yu J",
+      "title": "In vitro selection of the RNA aptamer against the Sialyl Lewis X and its inhibition of the cell adhesion",
+      "journal": "Biochemical and biophysical research communications"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "15745995",
+    "publication": {
+      "pmid": "15745995",
+      "year": "2005",
+      "authors": "Eulberg D, Buchner K, Maasch C, Klussmann S",
+      "title": "Development of an automated in vitro selection protocol to obtain RNA-based aptamers: identification of a biostable substance P antagonist",
+      "journal": "Nucleic acids research"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "1370372",
+    "publication": {
+      "pmid": "1370372",
+      "year": "1992",
+      "authors": "Burnashev, N., Monyer, H., Seeburg, P. H., & Sakmann, B.",
+      "title": "Divalent ion permeability of AMPA receptor channels is dominated by the edited form of a single subunit",
+      "journal": "Neuron 8"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8604042",
+    "publication": {
+      "pmid": "8604042",
+      "year": "1996",
+      "authors": "Wenthold, R. J., Petralia, R. S., Blahos, J., II, & Niedzielski, A. S.",
+      "title": "Evidence for multiple AMPA receptor complexes in hippocampal CA1/CA2 neurons",
+      "journal": "J. Neurosci"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8522940",
+    "publication": {
+      "pmid": "8522940",
+      "year": "1996",
+      "authors": "Seeburg, P. H.",
+      "title": "The role of RNA editing in controlling glutamate receptor channel properties",
+      "journal": "J. Neurochem"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8987736",
+    "publication": {
+      "pmid": "8987736",
+      "year": "1997",
+      "authors": "Swanson, G. T., Kamboj, S. K., & Cull-Candy, S. G.",
+      "title": "Single-channel properties of recombinant AMPA receptors depend on RNA editing, splice variation, and subunit composition",
+      "journal": "J. Neurosci"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11124978",
+    "publication": {
+      "pmid": "11124978",
+      "year": "2000",
+      "authors": "Schiffer, H. H., Swanson, G. T., Masliah, E., & Heinemann, S. F.",
+      "title": "Unequal expression of allelic kainate receptor GluR7 mRNAs in human brains",
+      "journal": "J. Neurosci"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14622580",
+    "publication": {
+      "pmid": "14622580",
+      "year": "2003",
+      "authors": "Greger, I. H., Khatri, L., Kong, X., & Ziff, E. B.",
+      "title": "AMPA receptor tetramerization is mediated by Q/R editing",
+      "journal": "Neuron"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20518485",
+    "publication": {
+      "pmid": "20518485",
+      "year": "2010",
+      "authors": "Huang, Z., Han, Y., Wang, C., & Niu, L.",
+      "title": "Potent and selective inhibition of the open-channel conformation of AMPA receptors by an RNA aptamer",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21402710",
+    "publication": {
+      "pmid": "21402710",
+      "year": "2011",
+      "authors": "Park, J. S., Wang, C., Han, Y., Huang, Z., & Niu, L.",
+      "title": "Potent and selective inhibition of a single alpha-amino-3-hydroxy-5-methyl-4-isoxazolepropionic acid (AMPA) receptor subunit by an RNA aptamer",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28325839",
+    "publication": {
+      "pmid": "28325839",
+      "year": "2017",
+      "authors": "Jaremko, W. J., Huang, Z., Wen, W., Wu, A., Karl, N., & Niu, L.",
+      "title": "Identification and characterization of RNA aptamers: A long aptamer blocks the AMPA receptor and a short aptamer blocks both AMPA and kainate receptors",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34509496",
+    "publication": {
+      "pmid": "34509496",
+      "year": "2021",
+      "authors": "Huang, Z., & Niu, L.",
+      "title": "RNA aptamers for AMPA receptors",
+      "journal": "Neuropharmacology"
+    },
+    "posts": [
+      "_posts/AB9-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "6375662",
+    "publication": {
+      "pmid": "6375662",
+      "year": "1984",
+      "authors": "Glennera, G. G., & Wong, C. W.",
+      "title": "Alzheimer’s disease: initial report of the purification and characterization of a novel cerebrovascular amyloid protein",
+      "journal": "Biochemical and biophysical research communications"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "3159021",
+    "publication": {
+      "pmid": "3159021",
+      "year": "1985",
+      "authors": "Masters, C. L., Simms, G., Weinman, N. A., Multhaup, G.",
+      "title": "Amyloid plaque core protein in Alzheimer disease and Down syndrome",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9190286",
+    "publication": {
+      "pmid": "9190286",
+      "year": "1997",
+      "authors": "Harper, J. D., Wong, S. S., Lieber, C. M., & Lansbury, P. T.",
+      "title": "Observation of metastable Aβ amyloid protofibrils by atomic force microscopy",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9268388",
+    "publication": {
+      "pmid": "9268388",
+      "year": "1997",
+      "authors": "Walsh, D. M., Lomakin, A., Benedek, G. B., Condron, M. M.",
+      "title": "Amyloid beta-protein fibrillogenesis. Detection of a protofibrillar intermediate",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9600986",
+    "publication": {
+      "pmid": "9600986",
+      "year": "1998",
+      "authors": "Lambert, M. P., Barlow, A. K., Chromy, B. A., Edwards, C., Freed, R.",
+      "title": "Diffusible, nonfibrillar ligands derived from Abeta1-42 are potent central nervous system neurotoxins",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12750461",
+    "publication": {
+      "pmid": "12750461",
+      "year": "2003",
+      "authors": "Hoshi, M., Sato, M., Matsumoto, S., Noguchi, A., Yasutake, K.",
+      "title": "Spherical aggregates of beta-amyloid (amylospheroid) show high neurotoxicity and activate tau protein kinase I/glycogen synthase kinase-3beta",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17245412",
+    "publication": {
+      "pmid": "17245412",
+      "year": "2007",
+      "authors": "Haass, C., & Selkoe, D. J.",
+      "title": "Soluble protein oligomers in neurodegeneration: lessons from the Alzheimer's amyloid beta-peptide",
+      "journal": "Nature reviews. Molecular cell biology"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18845536",
+    "publication": {
+      "pmid": "18845536",
+      "year": "2009",
+      "authors": "Roychaudhuri, R., Yang, M., Hoshi, M. M., & Teplow, D. B.",
+      "title": "Amyloid β-protein assembly and Alzheimer disease",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27162352",
+    "publication": {
+      "pmid": "27162352",
+      "year": "2016",
+      "authors": "Watanabe-Nakayama, T., Ono, K., Itami, M., Takahashi, R.",
+      "title": "High-speed atomic force microscopy reveals structural dynamics of amyloid β1-42 aggregates",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Aβ42-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16868550",
+    "publication": {
+      "pmid": "16868550",
+      "year": "2006",
+      "authors": "Waldmann T. A.",
+      "title": "The biology of interleukin-2 and interleukin-15: implications for cancer therapy and vaccine design",
+      "journal": "Nature reviews. Immunology"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "20732639",
+    "publication": {
+      "pmid": "20732639",
+      "year": "2010",
+      "authors": "Malek, T. R., & Castro, I.",
+      "title": "Interleukin-2 receptor signaling: at the interface between tolerance and immunity",
+      "journal": "Immunity"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "23675235",
+    "publication": {
+      "pmid": "23675235",
+      "year": "2011",
+      "authors": "Ito, M., Zhao, N., Zeng, Z., Zhou, X., Chang, C. C., & Zu, Y.",
+      "title": "Interleukin-2 functions in anaplastic large cell lymphoma cells through augmentation of extracellular signal-regulated kinases 1/2 activation",
+      "journal": "International journal of biomedical science : IJBS"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "21719603",
+    "publication": {
+      "pmid": "21719603",
+      "year": "2011",
+      "authors": "Yang, Z. Z., Grote, D. M., Ziesmer, S. C., Manske, M. K.",
+      "title": "Soluble IL-2Ralpha facilitates IL-2-mediated immune responses and predicts reduced survival in follicular B-cell non-Hodgkin lymphoma",
+      "journal": "Blood"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "22849383",
+    "publication": {
+      "pmid": "22849383",
+      "year": "2012",
+      "authors": "Whiteside TL, Schuler P, Schilling B.",
+      "title": "Induced and natural regulatory T cells in human cancer",
+      "journal": "Expert opinion on biological therapy"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "25422100",
+    "publication": {
+      "pmid": "25422100",
+      "year": "2015",
+      "authors": "Mir, M. A., Maurer, M. J., Ziesmer, S. C., Slager, S. L.",
+      "title": "Elevated serum levels of IL-2R, IL-1RA, and CXCL9 are associated with a poor prognosis in follicular lymphoma",
+      "journal": "Blood"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "26205340",
+    "publication": {
+      "pmid": "26205340",
+      "year": "2015",
+      "authors": "Melero, I., Berman, D. M., Aznar, M. A., Korman, A. J.",
+      "title": "Evolving synergistic combinations of targeted immunotherapies to combat cancer.",
+      "journal": "Nature reviews. Cancer"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "25561050",
+    "publication": {
+      "pmid": "25561050",
+      "year": "2015",
+      "authors": "Ma, H., Liu, J., Ali, M. M., Mahmood, M. A., Labanieh, L.",
+      "title": "Nucleic acid aptamers in cancer research, diagnosis and therapy",
+      "journal": "Nucleic acid aptamers in cancer research"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "28383112",
+    "publication": {
+      "pmid": "28383112",
+      "year": "2017",
+      "authors": "Binder, M., O'Byrne, M. M., Maurer, M. J., Ansell, S.",
+      "title": "Associations between elevated pre-treatment serum cytokines and peripheral blood cellular markers of immunosuppression in patients with lymphoma",
+      "journal": "American journal of hematology"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "31383650",
+    "publication": {
+      "pmid": "31383650",
+      "year": "2019",
+      "authors": "Veeramani, S., Blackwell, S. E., Thiel, W. H., Yang, Z. Z.",
+      "title": "An RNA Aptamer-Based Biomarker Platform Demonstrates High Soluble CD25 Occupancy by IL2 in the Serum of Follicular Lymphoma Patients",
+      "journal": "Cancer immunology research"
+    },
+    "posts": [
+      "_posts/IL2-CD25-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "12453418",
+    "publication": {
+      "pmid": "12453418",
+      "year": "2002",
+      "authors": "Milne, T. A., Briggs, S. D., Brock, H. W., Martin, M. E.",
+      "title": "MLL targets SET domain methyltransferase activity to Hox gene promoters",
+      "journal": "Mol. Cell"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "12482972",
+    "publication": {
+      "pmid": "12482972",
+      "year": "2003",
+      "authors": "Hsieh, J. J., Ernst, P., Erdjument-Bromage, H., Tempst, P.",
+      "title": "Proteolytic cleavage of MLL generates a complex of N- and C-terminal fragments that confers protein stability and subnuclear localization",
+      "journal": "Mol. Cell. Biol."
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "16199523",
+    "publication": {
+      "pmid": "16199523",
+      "year": "2005",
+      "authors": "Milne, T. A., Dou, Y., Martin, M. E., Brock, H. W.",
+      "title": "MLL associates specifically with a subset of transcriptionally active target genes",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "15949446",
+    "publication": {
+      "pmid": "15949446",
+      "year": "2005",
+      "authors": "Morillon, A., Karabetsou, N., Nair, A., & Mellor, J.",
+      "title": "Dynamic lysine methylation on histone H3 defines the regulatory phase of gene transcription",
+      "journal": "Mol. Cell"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "18224408",
+    "publication": {
+      "pmid": "18224408",
+      "year": "2008",
+      "authors": "Dou, Y., & Hess, J. L.",
+      "title": "Mechanisms of transcriptional regulation by MLL and its disruption in acute leukemia",
+      "journal": "International journal of hematology"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "16878130",
+    "publication": {
+      "pmid": "16878130",
+      "year": "2008",
+      "authors": "Dou, Y., Milne, T. A., Ruthenburg, A. J., Lee, S., Lee, J. W.",
+      "title": "Regulation of MLL1 H3K4 methyltransferase activity by its core components",
+      "journal": "Nat. Struct. Mol. Biol."
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "19187761",
+    "publication": {
+      "pmid": "19187761",
+      "year": "2009",
+      "authors": "Southall, S. M., Wong, P. S., Odho, Z., Roe, S. M., & Wilson, J. R.",
+      "title": "Structural basis for the requirement of additional factors for MLL1 SET domain activity and recognition of epigenetic marks",
+      "journal": "Mol. Cell"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "24288367",
+    "publication": {
+      "pmid": "24288367",
+      "year": "2013",
+      "authors": "Jeong, K. W., Andreu-Vieyra, C., You, J. S., Jones, P. A.",
+      "title": "Establishment of active chromatin structure at enhancer elements by mixed-lineage leukemia 1 to initiate estrogendependent gene expression",
+      "journal": "Nucleic Acids Res."
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "23210835",
+    "publication": {
+      "pmid": "23210835",
+      "year": "2013",
+      "authors": "Karatas, H., Townsend, E. C., Cao, F., Chen, Y., Bernard, D.",
+      "title": "High-affinity, small-molecule peptidomimetic inhibitors of MLL1/WDR5 protein-protein interaction",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "24389101",
+    "publication": {
+      "pmid": "24389101",
+      "year": "2014",
+      "authors": "Cao, F., Townsend, E. C., Karatas, H., Xu, J., Li, L., Lee, S.",
+      "title": "Targeting MLL1 H3K4 methyltransferase activity in mixed-lineage leukemia",
+      "journal": "Molecular cell"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "30419633",
+    "publication": {
+      "pmid": "30419633",
+      "year": "2019",
+      "authors": "Ul-Haq, A., Jin, M. L., Jeong, K. W., Kim, H. M., & Chun, K. H.",
+      "title": "Isolation of MLL1 Inhibitory RNA Aptamers",
+      "journal": "Biomolecules & therapeutics"
+    },
+    "posts": [
+      "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+    ]
+  },
+  {
+    "pmid": "18776253",
+    "publication": {
+      "pmid": "18776253",
+      "year": "2008",
+      "authors": "Maasch, C., Buchner, K., Eulberg, D., Vonhoff, S., & Klussmann, S.",
+      "title": "Physicochemical stability of NOX-E36, a 40mer L-RNA (Spiegelmer) for therapeutic applications",
+      "journal": "Nucleic acids symposium series"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18258851",
+    "publication": {
+      "pmid": "18258851",
+      "year": "2008",
+      "authors": "Ninichuk, V., Clauss, S., Kulkarni, O., Schmid, H., Segerer, S.",
+      "title": "Late onset of Ccl2 blockade with the Spiegelmer mNOX-E36-3'PEG prevents glomerulosclerosis and improves glomerular filtration rate in db/db mice",
+      "journal": "The American journal of pathology"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19156777",
+    "publication": {
+      "pmid": "19156777",
+      "year": "2009",
+      "authors": "Clauss, S., Gross, O., Kulkarni, O., Avila-Ferrufino, A.",
+      "title": "Ccl2/Mcp-1 blockade reduces glomerular and interstitial macrophages but does not ameliorate renal pathology in collagen4A3-deficient mice with autosomal recessive Alport nephropathy",
+      "journal": "The Journal of pathology"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21813474",
+    "publication": {
+      "pmid": "21813474",
+      "year": "2012",
+      "authors": "Baeck, C., Wehr, A., Karlmark, K. R., Heymann, F., Vucur, M.",
+      "title": "Pharmacological inhibition of the chemokine CCL2 (MCP-1) diminishes liver macrophage infiltration and steatohepatitis in chronic hepatic injury",
+      "journal": "Gut"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24561613",
+    "publication": {
+      "pmid": "24561613",
+      "year": "2014",
+      "authors": "Ehling, J., Bartneck, M., Wei, X., Gremse, F., Fech, V.",
+      "title": "CCL2-dependent infiltrating macrophages promote angiogenesis in progressive liver fibrosis",
+      "journal": "Gut"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24481979",
+    "publication": {
+      "pmid": "24481979",
+      "year": "2014",
+      "authors": "Baeck, C., Wei, X., Bartneck, M., Fech, V., Heymann, F.",
+      "title": "Pharmacological inhibition of the chemokine C-C motif chemokine ligand 2 (monocyte chemoattractant protein 1) accelerates liver fibrosis regression by suppressing Ly-6C(+) macrophage infiltration in mice",
+      "journal": "Hepatology"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25901662",
+    "publication": {
+      "pmid": "25901662",
+      "year": "2015",
+      "authors": "Oberthür D, Achenbach J, Gabdulkhakov A, Buchner K, Maasch C",
+      "title": "Crystal structure of a mirror-image L-RNA aptamer (Spiegelmer) in complex with the natural L-protein target CCL2",
+      "journal": "Nat Commun"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25970072",
+    "publication": {
+      "pmid": "25970072",
+      "year": "2015",
+      "authors": "Kalnins, A., Thomas, M. N., Andrassy, M., Müller, S., Wagner, A.",
+      "title": "Spiegelmer Inhibition of MCP-1/CCR2--Potential as an Adjunct Immunosuppressive Therapy in Transplantation",
+      "journal": "Scandinavian journal of immunology"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28186566",
+    "publication": {
+      "pmid": "28186566",
+      "year": "2017",
+      "authors": "Menne, J., Eulberg, D., Beyer, D., Baumann, M., Saudek, F.",
+      "title": "C-C motif-ligand 2 inhibition with emapticap pegol (NOX-E36) in type 2 diabetic patients with albuminuria",
+      "journal": "Nephrology"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28837800",
+    "publication": {
+      "pmid": "28837800",
+      "year": "2017",
+      "authors": "Boels, M. G. S., Koudijs, A., Avramut, M. C., Sol, W. M. P. J.",
+      "title": "Systemic Monocyte Chemotactic Protein-1 Inhibition Modifies Renal Macrophages and Restores Glomerular Endothelial Glycocalyx and Barrier Function in Diabetic Nephropathy",
+      "journal": "The American journal of pathology"
+    },
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9346949",
+    "publication": {
+      "pmid": "9346949",
+      "year": "1997",
+      "authors": "Thomas, M., Chédin, S., Carles, C., Riva, M., Famulok, M.",
+      "title": "Selective targeting and inhibition of yeast RNA polymerase II by RNA aptamers",
+      "journal": "The Journal of biological chemistry"
+    },
+    "posts": [
+      "_posts/FC-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16341226",
+    "publication": {
+      "pmid": "16341226",
+      "year": "2006",
+      "authors": "Kettenberger, H., Eisenführ, A., Brueckner, F., Theis, M.",
+      "title": "Structure of an RNA polymerase II-RNA inhibitor complex elucidates transcription regulation by noncoding RNAs",
+      "journal": "Nature structural & molecular biology"
+    },
+    "posts": [
+      "_posts/FC-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29570714",
+    "publication": {
+      "pmid": "29570714",
+      "year": "2018",
+      "authors": "Klopf, E., Moes, M., Amman, F., Zimmermann, B., von Pelchrzim, F.",
+      "title": "Nascent RNA signaling to yeast RNA Pol II during transcription elongation",
+      "journal": "PloS one"
+    },
+    "posts": [
+      "_posts/FC-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32663063",
+    "publication": {
+      "pmid": "32663063",
+      "year": "2020",
+      "authors": "Boots, J. L., von Pelchrzim, F., Weiss, A., Zimmermann, B.",
+      "title": "RNA polymerase II-binding aptamers in human ACRO1 satellites disrupt transcription in cis",
+      "journal": "Transcription"
+    },
+    "posts": [
+      "_posts/FC-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9772167",
+    "publication": {
+      "pmid": "9772167",
+      "year": "1998",
+      "authors": "Wilson, C., Nix, J., & Szostak, J.",
+      "title": "Functional requirements for specific ligand recognition by a biotin-binding RNA pseudoknot",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/Biotin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10089439",
+    "publication": {
+      "pmid": "10089439",
+      "year": "1999",
+      "authors": "Nix, J. C., Newhoff, A. R., & Wilson, C.",
+      "title": "Preliminary crystallographic characterization of an in vitro evolved biotin-binding RNA pseudoknot",
+      "journal": "Acta crystallographica. Section D"
+    },
+    "posts": [
+      "_posts/Biotin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10698630",
+    "publication": {
+      "pmid": "10698630",
+      "year": "2000",
+      "authors": "Nix, J., Sussman, D., & Wilson, C.",
+      "title": "The 1.3 A crystal structure of a biotin-binding pseudoknot and the basis for RNA molecular recognition",
+      "journal": "Journal of molecular biology"
+    },
+    "posts": [
+      "_posts/Biotin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26903199",
+    "publication": {
+      "pmid": "26903199",
+      "year": "2016",
+      "authors": "Sung, T. C., Chen, W. Y., Shah, P., & Chen, C. S.",
+      "title": "A replaceable liposomal aptamer for the ultrasensitive and rapid detection of biotin",
+      "journal": "Scientific reports"
+    },
+    "posts": [
+      "_posts/Biotin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35340298",
+    "publication": {
+      "pmid": "35340298",
+      "year": "2022",
+      "authors": "Uppala, J. K., Ghosh, C., Sabat, G., & Dey, M.",
+      "title": "Pull-down of Biotinylated RNA and Associated Proteins",
+      "journal": "Bio-protocol"
+    },
+    "posts": [
+      "_posts/Biotin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8289245",
+    "publication": {
+      "pmid": "8289245",
+      "year": "1994",
+      "authors": "Jensen KB, Green L, MacDougal-Waugh S, Tuerk C.",
+      "title": "Characterization of an in vitro-selected RNA ligand to the HIV-1 Rev protein",
+      "journal": "J Mol Biol"
+    },
+    "posts": [
+      "_posts/HIV-1-REV-peptide-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10467126",
+    "publication": {
+      "pmid": "10467126",
+      "year": "1999",
+      "authors": "Ye X, Gorin A, Frederick R, et al",
+      "title": "RNA architecture dictates the conformations of a bound peptide",
+      "journal": "Chem Biol"
+    },
+    "posts": [
+      "_posts/HIV-1-REV-peptide-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10647177",
+    "publication": {
+      "pmid": "10647177",
+      "year": "1999",
+      "authors": "Jiang F, Gorin A, Hu W, et al.",
+      "title": "Anchoring an extended HTLV-1 Rex peptide within an RNA major groove containing junctional base triples",
+      "journal": "Structure"
+    },
+    "posts": [
+      "_posts/Rex-protein-aptamer.md",
+      "_posts/HIV-1-REV-peptide-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18922466",
+    "publication": {
+      "pmid": "18922466",
+      "year": "2008",
+      "authors": "Daugherty MD, D'Orso I, Frankel AD.",
+      "title": "A solution to limited genomic capacity: using adaptable binding surfaces to assemble the functional HIV Rev oligomer on RNA",
+      "journal": "Mol Cell"
+    },
+    "posts": [
+      "_posts/HIV-1-REV-peptide-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23972852",
+    "publication": {
+      "pmid": "23972852",
+      "year": "2013",
+      "authors": "Casu F, Duggan BM, Hennig M",
+      "title": "The arginine-rich RNA-binding motif of HIV-1 Rev is intrinsically disordered and folds upon RRE binding",
+      "journal": "Biophys J"
+    },
+    "posts": [
+      "_posts/HIV-1-REV-peptide-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25486594",
+    "publication": {
+      "pmid": "25486594",
+      "year": "2014",
+      "authors": "Jayaraman B, Crosby DC, Homer C, Ribeiro I, Mavor D, Frankel AD",
+      "title": "RNA-directed remodeling of the HIV-1 protein Rev orchestrates assembly of the Rev-Rev response element complex",
+      "journal": "Elife"
+    },
+    "posts": [
+      "_posts/HIV-1-REV-peptide-aptamer.md",
+      "_posts/HIV-1-Rev-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10233958",
+    "publication": {
+      "pmid": "10233958",
+      "year": "1999",
+      "authors": "Baskerville, S., Zapp, M., & Ellington, A. D.",
+      "title": "Anti-Rex aptamers as mimics of the Rex-binding element",
+      "journal": "Journal of virology"
+    },
+    "posts": [
+      "_posts/Rex-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12925996",
+    "publication": {
+      "pmid": "12925996",
+      "year": "2003",
+      "authors": "Luedtke, N. W., & Tor, Y.",
+      "title": "Fluorescence-based methods for evaluating the RNA affinity and specificity of HIV-1 Rev-RRE inhibitors",
+      "journal": "Biopolymers"
+    },
+    "posts": [
+      "_posts/Rex-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18351707",
+    "publication": {
+      "pmid": "18351707",
+      "year": "2008",
+      "authors": "Sugaya, M., Nishino, N., Katoh, A., & Harada, K.",
+      "title": "Amino acid requirement for the high affinity binding of a selected arginine-rich peptide with the HIV Rev-response element RNA",
+      "journal": "Journal of peptide science : an official publication of the European Peptide Society"
+    },
+    "posts": [
+      "_posts/Rex-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26896646",
+    "publication": {
+      "pmid": "26896646",
+      "year": "2016",
+      "authors": "Prado, S., Beltrán, M., Coiras, M., Bedoya, L. M., Alcamí, J.",
+      "title": "Bioavailable inhibitors of HIV-1 RNA biogenesis identified through a Rev-based screen",
+      "journal": "Biochemical pharmacology"
+    },
+    "posts": [
+      "_posts/Rex-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12604126",
+    "publication": {
+      "pmid": "12604126",
+      "year": "2003",
+      "authors": "Asou N.",
+      "title": "The role of a Runt domain transcription factor AML1/RUNX1 in leukemogenesis and its clinical implications.",
+      "journal": "Critical reviews in oncology/hematology"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20140822",
+    "publication": {
+      "pmid": "20140822",
+      "year": "2010",
+      "authors": "Mongelard, F., & Bouvet, P",
+      "title": "AS-1411, a guanosine-rich oligonucleotide aptamer targeting nucleolin for the potential treatment of cancer, including acute myeloid leukemia.",
+      "journal": "Current opinion in molecular therapeutics"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23997091",
+    "publication": {
+      "pmid": "23997091",
+      "year": "2013",
+      "authors": "Nomura, Y., Tanaka, Y., Fukunaga, J., Fujiwara, K., Chiba, M.",
+      "title": "Solution structure of a DNA mimicking motif of an RNA aptamer against transcription factor AML1 Runt domain",
+      "journal": "Journal of biochemistry"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26204224",
+    "publication": {
+      "pmid": "26204224",
+      "year": "2015",
+      "authors": "Zhao, N., Pei, S. N., Qi, J., Zeng, Z., Iyer, S. P., Lin, P.",
+      "title": "Oligonucleotide aptamer-drug conjugates for targeted therapy of acute myeloid leukemia",
+      "journal": "Biomaterials"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27514505",
+    "publication": {
+      "pmid": "27514505",
+      "year": "2016",
+      "authors": "Zaimy, M. A., Jebali, A., Bazrafshan, B., Mehrtashfar, S., Shabani, S.",
+      "title": "Coinhibition of overexpressed genes in acute myeloid leukemia subtype M2 by gold nanoparticles functionalized with five antisense oligonucleotides and one anti-CD33(+)/CD34(+) aptamer",
+      "journal": "Cancer gene therapy"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27766833",
+    "publication": {
+      "pmid": "27766833",
+      "year": "2016",
+      "authors": "Amano, R., Takada, K., Tanaka, Y., Nakamura, Y., Kawai, G., Kozu, T., & Sakamoto, T",
+      "title": "Kinetic and Thermodynamic Analyses of Interaction between a High-Affinity RNA Aptamer and Its Target Protein",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md",
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26972431",
+    "publication": {
+      "pmid": "26972431",
+      "year": "2016",
+      "authors": "Kadioglu, O., & Efferth, T",
+      "title": "Peptide aptamer identified by molecular docking targeting translationally controlled tumor protein in leukemia cells",
+      "journal": "Investigational new drugs"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30519686",
+    "publication": {
+      "pmid": "30519686",
+      "year": "2019",
+      "authors": "Yang, C., , Wang, Y., , Ge, M. H., , Fu, Y. J., , Hao, R., , Islam, K.",
+      "title": "Rapid identification of specific DNA aptamers precisely targeting CD33 positive leukemia cells through a paired cell-based approach",
+      "journal": "Biomaterials science"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31824168",
+    "publication": {
+      "pmid": "31824168",
+      "year": "2019",
+      "authors": "Tan, Y., Li, Y., & Tang, F",
+      "title": "Nucleic Acid Aptamer: A Novel Potential Diagnostic and Therapeutic Tool for Leukemia",
+      "journal": "OncoTargets and therapy"
+    },
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9383458",
+    "publication": {
+      "pmid": "9383458",
+      "year": "1995",
+      "authors": "Wallis, M. G., von Ahsen, U., Schroeder, R., & Famulok, M.",
+      "title": "A novel RNA motif for neomycin recognition",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10425683",
+    "publication": {
+      "pmid": "10425683",
+      "year": "1999",
+      "authors": "Jiang, L., Majumdar, A., Hu, W., Jaishree, T. J., Xu, W.",
+      "title": "Saccharide-RNA recognition in a complex formed between neomycin B and an RNA aptamer",
+      "journal": "Structure"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10908357",
+    "publication": {
+      "pmid": "10908357",
+      "year": "2000",
+      "authors": "Cowan, J. A., Ohyama, T., Wang, D., & Natarajan, K",
+      "title": "Recognition of a cognate RNA aptamer by neomycin B: quantitative evaluation of hydrogen bonding and electrostatic interactions",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18000033",
+    "publication": {
+      "pmid": "18000033",
+      "year": "2008",
+      "authors": "Weigand, J. E., Sanchez, M., Gunnesch, E. B., Zeiher, S., Schroeder, R.",
+      "title": "Screening for engineered neomycin riboswitches that control translation initiation",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md",
+      "_posts/Ribostamycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19217276",
+    "publication": {
+      "pmid": "19217276",
+      "year": "2009",
+      "authors": "de-los-Santos-Alvarez, N., Lobo-Castañón, M. J., Miranda-Ordieres, A. J., & Tuñón-Blanco, P.",
+      "title": "SPR sensing of small molecules with modified RNA aptamers: detection of neomycin B",
+      "journal": "Biosensors & bioelectronics"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20478079",
+    "publication": {
+      "pmid": "20478079",
+      "year": "2010",
+      "authors": "Wilhelmsson L. M.",
+      "title": "Fluorescent nucleic acid base analogues",
+      "journal": "Quarterly reviews of biophysics"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22951899",
+    "publication": {
+      "pmid": "22951899",
+      "year": "2012",
+      "authors": "Jeon, J., Lee, K. H., & Rao, J.",
+      "title": "A strategy to enhance the binding affinity of fluorophore-aptamer pairs for RNA tagging with neomycin conjugation",
+      "journal": "Chemical communications"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24757168",
+    "publication": {
+      "pmid": "24757168",
+      "year": "2014",
+      "authors": "Ilgu, M., Fulton, D. B., Yennamalli, R. M., Lamm, M. H.",
+      "title": "An adaptable pentaloop defines a robust neomycin-B RNA aptamer with conditional ligand-bound structures",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26661511",
+    "publication": {
+      "pmid": "26661511",
+      "year": "2016",
+      "authors": "Duchardt-Ferner, E., Gottstein-Schmidtke, S. R., Weigand, J. E.",
+      "title": "What a Difference an OH Makes: Conformational Dynamics as the Basis for the Ligand Specificity of the Neomycin-Sensing Riboswitch",
+      "journal": "Angewandte Chemie"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md",
+      "_posts/Ribostamycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26942739",
+    "publication": {
+      "pmid": "26942739",
+      "year": "2016",
+      "authors": "Ling, K., Jiang, H., Zhang, L., Li, Y., Yang, L., Qiu, C., & Li, F. R.",
+      "title": "A self-assembling RNA aptamer-based nanoparticle sensor for fluorometric detection of Neomycin B in milk",
+      "journal": "Analytical and bioanalytical chemistry"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30462266",
+    "publication": {
+      "pmid": "30462266",
+      "year": "2019",
+      "authors": "Gustmann, H., Segler, A. J., Gophane, D. B., Reuss, A. J.",
+      "title": "Structure guided fluorescence labeling reveals a two-step binding mechanism of neomycin to its RNA aptamer",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33237073",
+    "publication": {
+      "pmid": "33237073",
+      "year": "2020",
+      "authors": "Bastian, A. A., Gruszka, A., Jung, P., & Herrmann, A",
+      "title": "Aptamer protective groups tolerate different reagents and reactions for regioselective modification of neomycin B",
+      "journal": "Organic & biomolecular chemistry"
+    },
+    "posts": [
+      "_posts/NeomycinB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9436913",
+    "publication": {
+      "pmid": "9436913",
+      "year": "1998",
+      "authors": "Wallace, S. T., & Schroeder, R.",
+      "title": "In vitro selection and characterization of streptomycin-binding RNAs: recognition discrimination between antibiotics",
+      "journal": "RNA (New York"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12618190",
+    "publication": {
+      "pmid": "12618190",
+      "year": "2003",
+      "authors": "Tereshko, V., Skripkin, E., & Patel, D. J.",
+      "title": "Encapsulating streptomycin within a small 40-mer RNA",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16621675",
+    "publication": {
+      "pmid": "16621675",
+      "year": "2006",
+      "authors": "Lee, J. F., Stovall, G. M., & Ellington, A. D.",
+      "title": "Aptamer therapeutics advance",
+      "journal": "Current opinion in chemical biology"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17355135",
+    "publication": {
+      "pmid": "17355135",
+      "year": "2007",
+      "authors": "de-los-Santos-Alvarez, N., Lobo-Castañón, M. J., Miranda-Ordieres, A. J.",
+      "title": "Modified-RNA aptamer-based sensor for competitive impedimetric assay of neomycin B",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18388495",
+    "publication": {
+      "pmid": "18388495",
+      "year": "2008",
+      "authors": "Windbichler, N., von Pelchrzim, F., Mayer, O., Csaszar, E., & Schroeder, R.",
+      "title": "Isolation of small RNA-binding proteins from E. coli: evidence for frequent interaction of RNAs with RNA polymerase",
+      "journal": "RNA biology"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20426747",
+    "publication": {
+      "pmid": "20426747",
+      "year": "2010",
+      "authors": "Tombelli, S., & Mascini, M.",
+      "title": "Aptamers biosensors for pharmaceutical compounds",
+      "journal": "Combinatorial chemistry & high throughput screening"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22173871",
+    "publication": {
+      "pmid": "22173871",
+      "year": "2012",
+      "authors": "Bose, D., Jayaraj, G., Suryawanshi, H., Agarwala, P., Pore, S. K.",
+      "title": "The tuberculosis drug streptomycin as a potential cancer therapeutic: inhibition of miR-21 function by directly targeting its precursor",
+      "journal": "Angewandte Chemie"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22793869",
+    "publication": {
+      "pmid": "22793869",
+      "year": "2012",
+      "authors": "Derbyshire, N., White, S. J., Bunka, D. H., Song, L., Stead, S., Tarbin, J.",
+      "title": "Toggled RNA aptamers against aminoglycosides allowing facile detection of antibiotics using gold nanoparticle assays",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23601877",
+    "publication": {
+      "pmid": "23601877",
+      "year": "2013",
+      "authors": "Zhou, N., Wang, J., Zhang, J., Li, C., Tian, Y., & Wang, J.",
+      "title": "Selection and identification of streptomycin-specific single-stranded DNA aptamers and the application in the detection of streptomycin in honey",
+      "journal": "Talanta"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23192876",
+    "publication": {
+      "pmid": "23192876",
+      "year": "2013",
+      "authors": "Nicholson, B. L., Zaslaver, O., Mayberry, L. K., Browning, K. S.",
+      "title": "Tombusvirus Y-shaped translational enhancer forms a complex with eIF4F and can be functionally replaced by heterologous translational enhancers",
+      "journal": "Journal of virology"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27281393",
+    "publication": {
+      "pmid": "27281393",
+      "year": "2016",
+      "authors": "Nick, T. A., de Oliveira, T. E., Pilat, D. W., Spenkuch, F., Butt, H. J.",
+      "title": "Stability of a Split Streptomycin Binding Aptamer",
+      "journal": "The journal of physical chemistry. B"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28965053",
+    "publication": {
+      "pmid": "28965053",
+      "year": "2018",
+      "authors": "Lin, B., Yu, Y., Cao, Y., Guo, M., Zhu, D., Dai, J., & Zheng, M.",
+      "title": "Point-of-care testing for streptomycin based on aptamer recognizing and digital image colorimetry by smartphone",
+      "journal": "Biosensors & bioelectronics"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31757139",
+    "publication": {
+      "pmid": "31757139",
+      "year": "2019",
+      "authors": "Baptista, L. A., & Netz, P. A.",
+      "title": "Single molecule force spectroscopy of a streptomycin-binding RNA aptamer: An out-of-equilibrium molecular dynamics study.",
+      "journal": "The Journal of chemical physics"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35297324",
+    "publication": {
+      "pmid": "35297324",
+      "year": "2023",
+      "authors": "Nosrati, M., & Roushani, M.",
+      "title": "Three-dimensional modeling of streptomycin binding single-stranded DNA for aptamer-based biosensors, a molecular dynamics simulation approach",
+      "journal": "Journal of biomolecular structure & dynamics"
+    },
+    "posts": [
+      "_posts/Streptomycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11557342",
+    "publication": {
+      "pmid": "11557342",
+      "year": "2001",
+      "authors": "Berens, C., Thain, A. & Schroeder, R.",
+      "title": "A tetracycline-binding RNA aptamer.",
+      "journal": "Bioorganic & medicinal chemistry"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12950926",
+    "publication": {
+      "pmid": "12950926",
+      "year": "2003",
+      "authors": "Hanson, S., Berthelot, K., Fink, B., McCarthy, J. E. G. & Suess, B.",
+      "title": "Tetracycline-aptamer-mediated translational regulation in yeast",
+      "journal": "Molecular microbiology"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15769877",
+    "publication": {
+      "pmid": "15769877",
+      "year": "2005",
+      "authors": "Hanson, S., Bauer, G., Fink, B. & Suess, B",
+      "title": "Molecular analysis of a synthetic tetracycline-binding riboswitch",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15723047",
+    "publication": {
+      "pmid": "15723047",
+      "year": "2005",
+      "authors": "Bayer, T. S. & Smolke, C. D.",
+      "title": "Programmable ligand-controlled riboregulators of eukaryotic gene expression",
+      "journal": "Nature biotechnology"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md",
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "16707663",
+    "publication": {
+      "pmid": "16707663",
+      "year": "2006",
+      "authors": "Müller, M., Weigand, J., Weichenrieder, O. & Suess, B",
+      "title": "Thermodynamic characterization of an engineered tetracyline-binding riboswitch",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17567606",
+    "publication": {
+      "pmid": "17567606",
+      "year": "2007",
+      "authors": "Weigand, J. E. & Suess, B",
+      "title": "Tetracycline aptamer-controlled regulation of pre-mRNA splicing in yeast",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18940672",
+    "publication": {
+      "pmid": "18940672",
+      "year": "2008",
+      "authors": "Xiao, H., Edwards, T. E. & Ferré-D'Amaré, A. R.",
+      "title": "Structural basis for specific, high-affinity tetracycline binding by an in vitro evolved aptamer and artificial riboswitch",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19592423",
+    "publication": {
+      "pmid": "19592423",
+      "year": "2009",
+      "authors": "Xiao, H., Edwards, T. E. & Ferré-D'Amaré, A. R.",
+      "title": "A fast and efficient translational control system for conditional expression of yeast genes",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "21603688",
+    "publication": {
+      "pmid": "21603688",
+      "year": "2011",
+      "authors": "Wittmann, A. & Suess, B",
+      "title": "Selection of tetracycline inducible self-cleaving ribozymes as synthetic devices for gene regulation in yeast",
+      "journal": "Molecular bioSystems"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24678266",
+    "publication": {
+      "pmid": "24678266",
+      "year": "2014",
+      "authors": "Demolli, S., Geist, M. M., Weigand, J. E., Matschiavelli, N., Suess, B.",
+      "title": "Development of β -lactamase as a tool for monitoring conditional gene expression by a tetracycline-riboswitch in Methanosarcina acetivorans",
+      "journal": "Archaea (Vancouver"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25517161",
+    "publication": {
+      "pmid": "25517161",
+      "year": "2014",
+      "authors": "Reuss, A. J., Vogel, M., Weigand, J. E., Suess, B. & Wachtveitl, J",
+      "title": "Tetracycline determines the conformation of its aptamer at physiological magnesium concentrations",
+      "journal": "Biophysical journal"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25265236",
+    "publication": {
+      "pmid": "25265236",
+      "year": "2015",
+      "authors": "Beilstein, K., Wittmann, A., Grez, M., & Suess, B",
+      "title": "Conditional control of mammalian gene expression by tetracycline-dependent hammerhead ribozymes",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27595406",
+    "publication": {
+      "pmid": "27595406",
+      "year": "2016",
+      "authors": "Liu, Y., Zhan, Y., Chen, Z., He, A., Li, J., Wu, H., Liu, L., Zhuang, C.",
+      "title": "Directing cellular information flow via CRISPR signal conductors",
+      "journal": "Nature methods"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27994029",
+    "publication": {
+      "pmid": "27994029",
+      "year": "2017",
+      "authors": "Domin, G., Findeiß, S., Wachsmuth, M., Will, S., Stadler, P. F., & Mörl, M",
+      "title": "Applicability of a computational design approach for synthetic riboswitches",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29420816",
+    "publication": {
+      "pmid": "29420816",
+      "year": "2018",
+      "authors": "Vogel, M., Weigand, J. E., Kluge, B., Grez, M., & Suess, B",
+      "title": "A small, portable RNA device for the control of exon skipping in mammalian cells",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30337459",
+    "publication": {
+      "pmid": "30337459",
+      "year": "2019",
+      "authors": "Hetzke, T., Vogel, M., Gophane, D. B., Weigand, J. E., Suess, B.",
+      "title": "Influence of Mg2+ on the conformational flexibility of a tetracycline aptamer",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30513199",
+    "publication": {
+      "pmid": "30513199",
+      "year": "2019",
+      "authors": "Groher, A. C., Jager, S., Schneider, C., Groher, F., Hamacher, K., & Suess, B",
+      "title": "Tuning the Performance of Synthetic Riboswitches using Machine Learning",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32024835",
+    "publication": {
+      "pmid": "32024835",
+      "year": "2020",
+      "authors": "Strobel, B., Spöring, M., Klein, H., Blazevic, D., Rust, W., Sayols, S.",
+      "title": "High-throughput identification of synthetic riboswitches by barcode-free amplicon-sequencing in human cells",
+      "journal": "Nature communications"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37459466",
+    "publication": {
+      "pmid": "37459466",
+      "year": "2023",
+      "authors": "Kelvin, D. & Suess, B",
+      "title": "Tapping the potential of synthetic riboswitches: reviewing the versatility of the tetracycline aptamer",
+      "journal": "RNA biology"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38168982",
+    "publication": {
+      "pmid": "38168982",
+      "year": "2024",
+      "authors": "Luo, L., Jea, J. D., Wang, Y., Chao, P. W., & Yen, L",
+      "title": "Control of mammalian gene expression by modulation of polyA signal cleavage at 5' UTR",
+      "journal": "Nature biotechnology"
+    },
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7510417",
+    "publication": {
+      "pmid": "7510417",
+      "year": "1994",
+      "authors": "Jenison, R. D., Gill, S. C., Pardi, A., & Polisky, B.",
+      "title": "High-resolution molecular discrimination by RNA",
+      "journal": "Science"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer.md",
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "9224568",
+    "publication": {
+      "pmid": "9224568",
+      "year": "1997",
+      "authors": "Tang, J., & Breaker, R. R.",
+      "title": "Rational design of allosteric ribozymes",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer.md",
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "9253414",
+    "publication": {
+      "pmid": "9253414",
+      "year": "1997",
+      "authors": "Zimmermann, G. R., Jenison, R. D., Wick, C. L., Simorre, J. P., & Pardi, A.",
+      "title": "Interlocking structural motifs mediate molecular discrimination by a theophylline-binding RNA",
+      "journal": "Nature structural biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "9636066",
+    "publication": {
+      "pmid": "9636066",
+      "year": "1998",
+      "authors": "Zimmermann, G. R., Shields, T. P., Jenison, R. D., Wick, C. L., & Pardi, A.",
+      "title": "A semiconserved residue inhibits complex formation by stabilizing interactions in the free state of a theophylline-binding RNA",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "10097080",
+    "publication": {
+      "pmid": "10097080",
+      "year": "1999",
+      "authors": "Soukup, G. A., & Breaker, R. R.",
+      "title": "Engineering precision RNA molecular switches",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "10425680",
+    "publication": {
+      "pmid": "10425680",
+      "year": "1999",
+      "authors": "Soukup, G. A., & Breaker, R. R.",
+      "title": "Design of allosteric hammerhead ribozymes activated by ligand-induced structure stabilization",
+      "journal": "Structure"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "10836787",
+    "publication": {
+      "pmid": "10836787",
+      "year": "2000",
+      "authors": "Zimmermann, G. R., Wick, C. L., Shields, T. P., Jenison, R. D., & Pardi, A.",
+      "title": "Molecular interactions and metal binding in the theophylline-binding core of an RNA aptamer",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "11266567",
+    "publication": {
+      "pmid": "11266567",
+      "year": "2001",
+      "authors": "Jose, A. M., Soukup, G. A., & Breaker, R. R.",
+      "title": "Cooperative binding of effectors by an allosteric ribozyme",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "15109659",
+    "publication": {
+      "pmid": "15109659",
+      "year": "2004",
+      "authors": "Endo, M., Mitsui, T., Okuni, T., Kimoto, M., Hirao, I., & Yokoyama, S.",
+      "title": "Unnatural base pairs mediate the site-specific incorporation of an unnatural hydrophobic component into RNA transcripts.",
+      "journal": "Bioorganic & medicinal chemistry letters"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "15004248",
+    "publication": {
+      "pmid": "15004248",
+      "year": "2004",
+      "authors": "Suess, B., Fink, B., Berens, C., Stentz, R., & Hillen, W.",
+      "title": "A theophylline responsive riboswitch based on helix slipping controls gene expression in vivo.",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "15826145",
+    "publication": {
+      "pmid": "15826145",
+      "year": "2005",
+      "authors": "Anderson, P. C., & Mecozzi, S.",
+      "title": "Unusually short RNA sequences: design of a 13-mer RNA that selectively binds and recognizes theophylline",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "16996258",
+    "publication": {
+      "pmid": "16996258",
+      "year": "2007",
+      "authors": "Hall, B., Hesselberth, J. R., & Ellington, A. D.",
+      "title": "Computational selection of nucleic acid biosensors via a slip structure model",
+      "journal": "Biosensors & bioelectronics"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md",
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17317571",
+    "publication": {
+      "pmid": "17317571",
+      "year": "2007",
+      "authors": "Lynch, S. A., Desai, S. K., Sajja, H. K., & Gallivan, J. P.",
+      "title": "A high-throughput screen for synthetic riboswitches reveals mechanistic insights into their function",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "19033367",
+    "publication": {
+      "pmid": "19033367",
+      "year": "2009",
+      "authors": "Lynch, S. A., & Gallivan, J. P.",
+      "title": "A flow cytometry-based screen for synthetic riboswitches",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "20041206",
+    "publication": {
+      "pmid": "20041206",
+      "year": "2009",
+      "authors": "Chen, X., & Ellington, A. D.",
+      "title": "Design principles for ligand-sensing, conformation-switching ribozymes",
+      "journal": "PLoS computational biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "22733807",
+    "publication": {
+      "pmid": "22733807",
+      "year": "2012",
+      "authors": "Kobori, S., Ichihashi, N., Kazuta, Y., Matsuura, T., & Yomo, T.",
+      "title": "Kinetic analysis of aptazyme-regulated gene expression in a cell-free translation system: modeling of ligand-dependent and -independent expression",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "23452219",
+    "publication": {
+      "pmid": "23452219",
+      "year": "2013",
+      "authors": "Penchovsky R.",
+      "title": "Computational design and biosensor applications of small molecule-sensing allosteric ribozymes",
+      "journal": "Biomacromolecules"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "23969558",
+    "publication": {
+      "pmid": "23969558",
+      "year": "2013",
+      "authors": "Nakahira, Y., Ogawa, A., Asano, H., Oyama, T., & Tozawa, Y.",
+      "title": "Theophylline-dependent riboswitch as a novel genetic tool for strict regulation of protein expression in Cyanobacterium Synechococcus elongatus PCC 7942",
+      "journal": "Plant & cell physiology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "23654267",
+    "publication": {
+      "pmid": "23654267",
+      "year": "2013",
+      "authors": "Ceres, P., Garst, A. D., Marcano-Velázquez, J. G., & Batey, R. T.",
+      "title": "Modularity of select riboswitch expression platforms enables facile engineering of novel genetic regulatory devices",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "25726466",
+    "publication": {
+      "pmid": "25726466",
+      "year": "2015",
+      "authors": "Badelt, S., Hammer, S., Flamm, C., & Hofacker, I. L.",
+      "title": "Thermodynamic and kinetic folding of riboswitches",
+      "journal": "Methods in enzymology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "26594238",
+    "publication": {
+      "pmid": "26594238",
+      "year": "2015",
+      "authors": "Wei, K. Y., & Smolke, C. D",
+      "title": "Engineering dynamic cell cycle control with synthetic small molecule-responsive RNA devices",
+      "journal": "Journal of biological engineering"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "26642994",
+    "publication": {
+      "pmid": "26642994",
+      "year": "2015",
+      "authors": "Zhou, Q., Xia, X., Luo, Z., Liang, H., & Shakhnovich, E.",
+      "title": "Searching the Sequence Space for Potent Aptamers Using SELEX in Silico",
+      "journal": "Journal of chemical theory and computation"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "29319503",
+    "publication": {
+      "pmid": "29319503",
+      "year": "2018",
+      "authors": "Liu, Y., Li, J., Chen, Z., Huang, W., & Cai, Z.",
+      "title": "ynthesizing artificial devices that redirect cellular information at will",
+      "journal": "eLife"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "30119599",
+    "publication": {
+      "pmid": "30119599",
+      "year": "2018",
+      "authors": "Page, K., Shaffer, J., Lin, S., Zhang, M., & Liu, J. M.",
+      "title": "Engineering Riboswitches in Vivo Using Dual Genetic Selection and Fluorescence-Activated Cell Sorting",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "30773480",
+    "publication": {
+      "pmid": "30773480",
+      "year": "2019",
+      "authors": "You, M., Litke, J. L., Wu, R., & Jaffrey, S. R.",
+      "title": "Detection of Low-Abundance Metabolites in Live Cells Using an RNA Integrator",
+      "journal": "Cell chemical biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "31490060",
+    "publication": {
+      "pmid": "31490060",
+      "year": "2019",
+      "authors": "Tamiev, D., Lantz, A., Vezeau, G., Salis, H., & Reuel, N. F.",
+      "title": "Controlling Heterogeneity and Increasing Titer from Riboswitch-Regulated Bacillus subtilis Spores for Time-Delayed Protein Expression Applications",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "32142605",
+    "publication": {
+      "pmid": "32142605",
+      "year": "2020",
+      "authors": "Wrist, A., Sun, W., & Summers, R. M.",
+      "title": "The Theophylline Aptamer: 25 Years as an Important Tool in Cellular Engineering Research.",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "9383430",
+    "publication": {
+      "pmid": "9383430",
+      "year": "1995",
+      "authors": "Wang, Y., & Rando, R. R.",
+      "title": "Specific binding of aminoglycoside antibiotics to RNA",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9070426",
+    "publication": {
+      "pmid": "9070426",
+      "year": "1997",
+      "authors": "Jiang, L., Suri, A. K., Fiala, R., & Patel, D. J.",
+      "title": "Accharide-RNA recognition in an aminoglycoside antibiotic-RNA aptamer complex.",
+      "journal": "SChemistry & biology"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9731769",
+    "publication": {
+      "pmid": "9731769",
+      "year": "1998",
+      "authors": "Jiang, L., & Patel, D. J.",
+      "title": "Solution structure of the tobramycin-RNA aptamer complex",
+      "journal": "Nature structural biology"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14769995",
+    "publication": {
+      "pmid": "14769995",
+      "year": "2004",
+      "authors": "Hartmuth, K., Vornlocher, H. P., & Lührmann, R.",
+      "title": "Tobramycin affinity tag purification of spliceosomes",
+      "journal": "Methods in molecular biology"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16217837",
+    "publication": {
+      "pmid": "16217837",
+      "year": "2005",
+      "authors": "Keller, K. M., Breeden, M. M., Zhang, J., Ellington, A. D., & Brodbelt, J. S.",
+      "title": "Electrospray ionization of nucleic acid aptamer/small molecule complexes for screening aptamer selectivity.",
+      "journal": "Journal of mass spectrometry : JMS"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25337781",
+    "publication": {
+      "pmid": "25337781",
+      "year": "2014",
+      "authors": "Liu, J., Wagan, S., Dávila Morris, M., Taylor, J., & White, R. J.",
+      "title": "Achieving reproducible performance of electrochemical, folding aptamer-based sensors on microelectrodes: challenges and prospects",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25835184",
+    "publication": {
+      "pmid": "25835184",
+      "year": "2015",
+      "authors": "Schoukroun-Barnes, L. R., & White, R. J.",
+      "title": "Rationally designing aptamer sequences with reduced affinity for controlled sensor performance",
+      "journal": "Sensors"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29594665",
+    "publication": {
+      "pmid": "29594665",
+      "year": "2017",
+      "authors": "Han, X., Zhang, Y., Nie, J., Zhao, S., Tian, Y., & Zhou, N.",
+      "title": "Gold nanoparticle based photometric determination of tobramycin by using new specific DNA aptamers",
+      "journal": "Mikrochimica acta"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30356136",
+    "publication": {
+      "pmid": "30356136",
+      "year": "2018",
+      "authors": "Auwardt, S. L., Seo, Y. J., Ilgu, M., Ray, J., Feldges, R. R., Shubham, S.",
+      "title": "Aptamer-enabled uptake of small molecule ligands",
+      "journal": "Scientific reports"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30268963",
+    "publication": {
+      "pmid": "30268963",
+      "year": "2018",
+      "authors": "Nie, J., Yuan, L., Jin, K., Han, X., Tian, Y., & Zhou, N.",
+      "title": "Electrochemical detection of tobramycin based on enzymes-assisted dual signal amplification by using a novel truncated aptamer with high affinity",
+      "journal": "Biosensors & bioelectronics"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31625087",
+    "publication": {
+      "pmid": "31625087",
+      "year": "2020",
+      "authors": "Zhou, N., Cai, R., & Han, X.  S.",
+      "title": "Creening, Post-SELEX Optimization and Application of DNA Aptamers Specific for Tobramycin",
+      "journal": "Methods in molecular biology"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35217273",
+    "publication": {
+      "pmid": "35217273",
+      "year": "2022",
+      "authors": "Wang, J., Li, H., Du, C., Li, Y., Ma, X., Yang, C., Xu, W., & Sun, C.",
+      "title": "Structure-switching aptamer triggering signal amplification strategy for tobramycin detection based on hybridization chain reaction and fluorescence synergism.",
+      "journal": "Talanta"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37791877",
+    "publication": {
+      "pmid": "37791877",
+      "year": "2023",
+      "authors": "Kraus, L., Duchardt-Ferner, E., Bräuchle, E., Fürbacher, S., Kelvin, D., Marx, H.",
+      "title": "Development of a novel tobramycin dependent riboswitch",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Tobramycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8504070",
+    "publication": {
+      "pmid": "8504070",
+      "year": "1993",
+      "authors": "Connell, G. J., Illangesekare, M., & Yarus, M.",
+      "title": "Three small ribooligonucleotides with specific arginine sites",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/A9g-RNA-aptamer.md",
+      "_posts/PSMA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12124337",
+    "publication": {
+      "pmid": "12124337",
+      "year": "2002",
+      "authors": "Lupold, S. E., Hicke, B. J., Lin, Y., & Coffey, D. S.",
+      "title": "Identification and characterization of nuclease-stabilized RNA molecules that bind human prostate cancer cells via the prostate-specific membrane antigen",
+      "journal": "Cancer research"
+    },
+    "posts": [
+      "_posts/A9g-RNA-aptamer.md",
+      "_posts/PSMA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16740739",
+    "publication": {
+      "pmid": "16740739",
+      "year": "2006",
+      "authors": "Chu, T. C., Twu, K. Y., Ellington, A. D., & Levy, M.",
+      "title": "Aptamer mediated siRNA delivery",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/A9g-RNA-aptamer.md",
+      "_posts/PSMA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20550178",
+    "publication": {
+      "pmid": "20550178",
+      "year": "2010",
+      "authors": "Kim, D., Jeong, Y. Y., & Jon, S.",
+      "title": "A drug-loaded aptamer-gold nanoparticle bioconjugate for combined CT imaging and therapy of prostate cancer",
+      "journal": "ACS nano"
+    },
+    "posts": [
+      "_posts/A9g-RNA-aptamer.md",
+      "_posts/PSMA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22004414",
+    "publication": {
+      "pmid": "22004414",
+      "year": "2011",
+      "authors": "Rockey, W. M., Hernandez, F. J., Huang, S. Y., Cao, S., Howell, C. A., Thomas, G. S.",
+      "title": "Rational truncation of an RNA aptamer to prostate-specific membrane antigen using computational structural modeling",
+      "journal": "Nucleic acid therapeutics"
+    },
+    "posts": [
+      "_posts/A9g-RNA-aptamer.md",
+      "_posts/PSMA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25450401",
+    "publication": {
+      "pmid": "25450401",
+      "year": "2014",
+      "authors": "Baek, S. E., Lee, K. H., Park, Y. S., Oh, D. K., Oh, S., Kim, K. S., & Kim, D. E.",
+      "title": "RNA aptamer-conjugated liposome as an efficient anticancer drug delivery vehicle targeting cancer cells in vivo",
+      "journal": "Journal of controlled release : official journal of the Controlled Release Society"
+    },
+    "posts": [
+      "_posts/A9g-RNA-aptamer.md",
+      "_posts/PSMA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32525981",
+    "publication": {
+      "pmid": "32525981",
+      "year": "2020",
+      "authors": "Ptacek, J., Zhang, D., Qiu, L., Kruspe, S., Motlova, L., Kolenko, P., Novakova, Z.",
+      "title": "Structural basis of prostate-specific membrane antigen recognition by the A9g RNA aptamer",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/A9g-RNA-aptamer.md",
+      "_posts/PSMA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8532517",
+    "publication": {
+      "pmid": "8532517",
+      "year": "1995",
+      "authors": "P Burgstaller, M Kochoyan, M Famulok",
+      "title": "Structural probing and damage selection of citrulline- and arginine-specific RNA aptamers identify base positions required for binding",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Citrulline-aptamer.md",
+      "_posts/Arginine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8650546",
+    "publication": {
+      "pmid": "8650546",
+      "year": "1996",
+      "authors": "Y Yang, M Kochoyan, P Burgstaller, E Westhof, M Famulok",
+      "title": "Structural basis of ligand discrimination by two related RNA aptamers resolved by NMR spectroscopy",
+      "journal": "Science"
+    },
+    "posts": [
+      "_posts/Citrulline-aptamer.md",
+      "_posts/Arginine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15801729",
+    "publication": {
+      "pmid": "15801729",
+      "year": "2005",
+      "authors": "Agnès Brumbt, Corinne Ravelet, Catherine Grosset, Anne Ravel, Annick Villet, Eric Peyrin",
+      "title": "Chiral stationary phase based on a biostable L-RNA aptamer",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/Citrulline-aptamer.md",
+      "_posts/Arginine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7508262",
+    "publication": {
+      "pmid": "7508262",
+      "year": "1994",
+      "authors": "Lorsch JR, Szostak JW",
+      "title": "In vitro selection of RNA aptamers specific for cyanocobalamin",
+      "journal": "Biochemistry"
+    },
+    "posts": []
+  },
+  {
+    "pmid": "10089440",
+    "publication": {
+      "pmid": "10089440",
+      "year": "1999",
+      "authors": "Sussman D, Greensides D, Reilly K, Wilson C",
+      "title": "Preliminary characterization of crystals of an in vitro evolved cyanocobalamin (vitamin B12) binding RNA",
+      "journal": "Acta crystallographica"
+    },
+    "posts": [
+      "_posts/Vitamin-B12-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10625428",
+    "publication": {
+      "pmid": "10625428",
+      "year": "2000",
+      "authors": "Sussman D, Nix JC, Wilson C",
+      "title": "The structural basis for molecular recognition by the vitamin B 12 RNA aptamer",
+      "journal": "Nature structural biology"
+    },
+    "posts": [
+      "_posts/Vitamin-B12-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10903943",
+    "publication": {
+      "pmid": "10903943",
+      "year": "2000",
+      "authors": "Sussman D, Wilson C",
+      "title": "A water channel in the core of the vitamin B(12) RNA aptamer",
+      "journal": "Structure"
+    },
+    "posts": [
+      "_posts/Vitamin-B12-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18672888",
+    "publication": {
+      "pmid": "18672888",
+      "year": "2008",
+      "authors": "Gopinath SC, Awazu K, Fujimaki M, Sugimoto K, Ohki Y, Komatsubara T",
+      "title": "Influence of nanometric holes on the sensitivity of a waveguide-mode sensor: label-free nanosensor for the analysis of RNA aptamer-ligand interactions",
+      "journal": "Analytical chemistry"
+    },
+    "posts": [
+      "_posts/Vitamin-B12-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22658959",
+    "publication": {
+      "pmid": "22658959",
+      "year": "2012",
+      "authors": "Selvakumar LS, Thakur MS",
+      "title": "Nano RNA aptamer wire for analysis of vitamin B₁₂",
+      "journal": "Analytical biochemistry"
+    },
+    "posts": [
+      "_posts/Vitamin-B12-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29863725",
+    "publication": {
+      "pmid": "29863725",
+      "year": "2018",
+      "authors": "Gunaratne, R., Kumar, S., Frederiksen, J. W., Stayrook, S., Lohrmann, J. L., Perry, K.",
+      "title": "Combination of aptamer and drug for reversible anticoagulation in cardiopulmonary bypass",
+      "journal": "Nature biotechnology"
+    },
+    "posts": [
+      "_posts/Factor-Xa-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35021888",
+    "publication": {
+      "pmid": "35021888",
+      "year": "2022",
+      "authors": "Chabata, C. V., Frederiksen, J. W., Olson, L. B., Naqvi, I. A., Hall, S. E., Gunaratne, R.",
+      "title": "Combining Heparin and a FX/Xa Aptamer to Reduce Thrombin Generation in Cardiopulmonary Bypass and COVID-19",
+      "journal": "Nucleic acid therapeutics"
+    },
+    "posts": [
+      "_posts/Factor-Xa-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8642604",
+    "publication": {
+      "pmid": "8642604",
+      "year": "1996",
+      "authors": "Fan P, Suri AK, Fiala R, Live D, Patel DJ.",
+      "title": "Molecular recognition in the FMN-RNA aptamer complex",
+      "journal": "J Mol Biol"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10397790",
+    "publication": {
+      "pmid": "10397790",
+      "year": "1999",
+      "authors": "Schneider C, Sühnel J.",
+      "title": "A molecular dynamics simulation of the flavin mononucleotide-RNA aptamer complex",
+      "journal": "Biopolymers"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12903340",
+    "publication": {
+      "pmid": "12903340",
+      "year": "2000",
+      "authors": "Jiang, F., Patel, D. J., Zhang, X., Zhao, H., & Jones, R. A",
+      "title": "Specific labeling approaches to guanine and adenine imino and amino proton assignments in the AMP-RNA aptamer complex.",
+      "journal": "Journal of biomolecular NMR"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11377174",
+    "publication": {
+      "pmid": "11377174",
+      "year": "2001",
+      "authors": "Araki M, Okuno Y, Sugiura Y.",
+      "title": "Expression mechanism of the allosteric interactions in a ribozyme catalysis",
+      "journal": "Nucleic Acids Symp Ser"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14588007",
+    "publication": {
+      "pmid": "14588007",
+      "year": "2003",
+      "authors": "Clark SL, Remcho VT.",
+      "title": "Electrochromatographic retention studies on a flavin-binding RNA aptamer sorbent",
+      "journal": "Anal Chem"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16377778",
+    "publication": {
+      "pmid": "16377778",
+      "year": "2005",
+      "authors": "Anderson PC, Mecozzi S",
+      "title": "Identification of a 14mer RNA that recognizes and binds flavin mononucleotide with high affinity",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16199761",
+    "publication": {
+      "pmid": "16199761",
+      "year": "2005",
+      "authors": "Najafi-Shoushtari SH, Famulok M",
+      "title": "Competitive regulation of modular allosteric aptazymes by a small molecule and oligonucleotide effector",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25173759",
+    "publication": {
+      "pmid": "25173759",
+      "year": "2014",
+      "authors": "Sengupta A, Gavvala K, Koninti RK, Hazra P.",
+      "title": "Role of Mg²⁺ ions in flavin recognition by RNA aptamer",
+      "journal": "J Photochem Photobiol B"
+    },
+    "posts": [
+      "_posts/FMN-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15099096",
+    "publication": {
+      "pmid": "15099096",
+      "year": "2004",
+      "authors": "James M. Carothers, Stephanie C. Oestreich‡, Jonathan H. Davis, and Jack W. Szostak.",
+      "title": "Informational Complexity and Functional Activity of RNA Structures",
+      "journal": "JACS"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16510427",
+    "publication": {
+      "pmid": "16510427",
+      "year": "2006",
+      "authors": "Carothers, J. M., Davis, J. H., Chou, J. J., & Szostak, J. W.",
+      "title": "Solution structure of an informationally complex high-affinity RNA aptamer to GTP",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23601641",
+    "publication": {
+      "pmid": "23601641",
+      "year": "2013",
+      "authors": "Curtis, E. A., & Liu, D. R.",
+      "title": "Discovery of widespread GTP-binding motifs in genomic DNA and RNA",
+      "journal": "Chemistry & biology"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24824832",
+    "publication": {
+      "pmid": "24824832",
+      "year": "2014",
+      "authors": "Curtis, Edward A., and David R. Liu",
+      "title": "A naturally occurring, noncanonical GTP aptamer made of simple tandem repeats.",
+      "journal": "RNA biology"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27659052",
+    "publication": {
+      "pmid": "27659052",
+      "year": "2016",
+      "authors": "Nasiri, A. H., Wurm, J. P., Immer, C., Weickhmann, A. K., & Wöhnert, J.",
+      "title": "An intermolecular G-quadruplex as the basis for GTP recognition in the class V–GTP aptamer",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27885761",
+    "publication": {
+      "pmid": "27885761",
+      "year": "2017",
+      "authors": "Wolter, A. C., Weickhmann, A. K., Nasiri, A. H., Hantke, K., Ohlenschläger, O.",
+      "title": "A stably protonated adenine nucleotide with a highly shifted pKa value stabilizes the tertiary structure of a GTP‐binding RNA aptamer",
+      "journal": "Angewandte Chemie International Edition"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31030336",
+    "publication": {
+      "pmid": "31030336",
+      "year": "2019",
+      "authors": "Wolter, A. C., Pianu, A., Kremser, J., Strebitzer, E., Schnieders, R., Fürtig, B.& Wöhnert, J.",
+      "title": "NMR resonance assignments for the GTP-binding RNA aptamer 9-12 in complex with GTP",
+      "journal": "Biomolecular NMR Assignments"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38074198",
+    "publication": {
+      "pmid": "38074198",
+      "year": "2023",
+      "authors": "Wachowius, F., Porebski, B. T., Johnson, C. M., & Holliger, P.",
+      "title": "Emergence of ATP‐and GTP‐Binding Aptamers from Single RNA Sequences by Error‐Prone Replication and Selection",
+      "journal": "ChemSystemsChem"
+    },
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10212256",
+    "publication": {
+      "pmid": "10212256",
+      "year": "1999",
+      "authors": "Boiziau, C., Dausse, E., Yurchenko, L., & Toulmé, J. J.",
+      "title": "DNA aptamers selected against the HIV-1 trans-activation-responsive RNA element form RNA-DNA kissing complexes",
+      "journal": "J Biol Chem"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10606271",
+    "publication": {
+      "pmid": "10606271",
+      "year": "1999",
+      "authors": "Ducongé, F., & Toulmé, J. J.",
+      "title": "In vitro selection identifies key determinants for loop-loop interactions: RNA aptamers selective for the TAR RNA element of HIV-1",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10954609",
+    "publication": {
+      "pmid": "10954609",
+      "year": "2000",
+      "authors": "Collin, D., van, Heijenoort, C., Boiziau, C., Toulmé, J. J., & Guittet, E.",
+      "title": "NMR characterization of a kissing complex formed between the TAR RNA element of HIV-1 and a DNA aptamer",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12052182",
+    "publication": {
+      "pmid": "12052182",
+      "year": "2002",
+      "authors": "Darfeuille, F., Sekkai, D., Dausse, E., Kolb, G., Yurchenko, L., Boiziau, C., & Toulmé, J. J.",
+      "title": "Driving in vitro selection of anti-HIV-1 TAR aptamers by magnesium concentration and temperature",
+      "journal": "Comb Chem High Throughput Screen"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12853646",
+    "publication": {
+      "pmid": "12853646",
+      "year": "2003",
+      "authors": "Beaurain, F, .Di, Primo, C., Toulmé, J. J., & Laguerre, M.",
+      "title": "Molecular dynamics reveals the stabilizing role of loop closing residues in kissing interactions: comparison between TAR-TAR* and TAR-aptamer",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15181175",
+    "publication": {
+      "pmid": "15181175",
+      "year": "2004",
+      "authors": "Darfeuille, F., Hansen, JB., Orum, H., Di, Primo, C., & Toulmé, J. J.",
+      "title": "LNA/DNA chimeric oligomers mimic RNA aptamers targeted to the TAR RNA element of HIV-1",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15723535",
+    "publication": {
+      "pmid": "15723535",
+      "year": "2005",
+      "authors": "Kolb,G., Reigadas, S., Boiziau, C., van Aerschot, A., Arzumanov, A., Gait, MJ.",
+      "title": "Hexitol nucleic acid-containing aptamers are efficient ligands of HIV-1 TAR RNA",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16445294",
+    "publication": {
+      "pmid": "16445294",
+      "year": "2006",
+      "authors": "Boucard, D., Toulmé, J. J, Di., & Primo, C.",
+      "title": "Bimodal loop-loop interactions increase the affinity of RNA aptamers for HIV-1 RNA structures",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17312962",
+    "publication": {
+      "pmid": "17312962",
+      "year": "2006",
+      "authors": "Bugaut, A., Toulmé , J. J., & Rayner, B.",
+      "title": "SELEX and dynamic combinatorial chemistry interplay for the selection of conjugated RNA aptamers",
+      "journal": "Org Biomol Chem"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17768146",
+    "publication": {
+      "pmid": "17768146",
+      "year": "2007",
+      "authors": "Lebars, I., Richard, T., Di Primo, C., & Toulmé, J. J.",
+      "title": "NMR structure of a kissing complex formed between the TAR RNA element of HIV-1 and a LNA-modified aptamer",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18996893",
+    "publication": {
+      "pmid": "18996893",
+      "year": "2008",
+      "authors": "Lebars, I., Legrand, P., Aimé, A., Pinaud, N., Fribourg, S., & Di Primo, C.",
+      "title": "Exploring TAR–RNA aptamer loop–loop interaction by X-ray crystallography, UV spectroscopy and surface plasmon resonance",
+      "journal": "Nucleic Acids Res"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19496624",
+    "publication": {
+      "pmid": "19496624",
+      "year": "2009",
+      "authors": "Watrin, M., Von Pelchrzim, F., Dausse, E., Schroeder, R., & Toulmé, J. J.",
+      "title": "In vitro selection of RNA aptamers derived from a genomic human library against the TAR RNA element of HIV-1",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/HIV-1-TAR-RNA-aptamer.md",
+      "_posts/LR06-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31548726",
+    "publication": {
+      "pmid": "31548726",
+      "year": "2019",
+      "authors": "Chen, X., Zhang, D., Su, N., Bao, B., Xie, X.",
+      "title": "Visualizing RNA dynamics in live cells with bright and stable fluorescent RNAs",
+      "journal": "Nature Biotechnology"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34725509",
+    "publication": {
+      "pmid": "34725509",
+      "year": "2021",
+      "authors": "Huang, K., Chen, X., Li, C., Song, Q., Li, H., Zhu, L., Yang, Y., Ren, A.",
+      "title": "Structure-based investigation of fluorogenic Pepper aptamer",
+      "journal": "Nature Chemical Biology"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35759696",
+    "publication": {
+      "pmid": "35759696",
+      "year": "2022",
+      "authors": "Rees, H. C., Gogacz, W., Li, N.-S., Koirala, D., Piccirilli, J. A.",
+      "title": "Structural basis for fluorescence activation by Pepper RNA",
+      "journal": "ACS chemical biology"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35580055",
+    "publication": {
+      "pmid": "35580055",
+      "year": "2022",
+      "authors": "Wang, Q., Xiao, F., Su, H., Liu, H., Xu, J.",
+      "title": "Inert Pepper aptamer-mediated endogenous mRNA recognition and imaging in living cells",
+      "journal": "Nucleic Acids Research"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35921263",
+    "publication": {
+      "pmid": "35921263",
+      "year": "2022",
+      "authors": "Dionisi, S., Piera, K., Baumschlager, A., Khammash, M.",
+      "title": "Implementation of a novel optogenetic tool in mammalian cells based on a split t7 RNA polymerase",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37192858",
+    "publication": {
+      "pmid": "37192858",
+      "year": "2022",
+      "authors": "Yang, L.-Z., Gao, B.-Q., Huang, Y., Wang, Y., Yang, L., Chen, L.-L.",
+      "title": "Multi-color RNA imaging with CRISPR-Cas13b systems in living cells",
+      "journal": "Cell Insight"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36999628",
+    "publication": {
+      "pmid": "36999628",
+      "year": "2023",
+      "authors": "Sampedro Vallina, N., McRae, E. K. S., Hansen, B. K., Boussebayle, A., Andersen, E. S.",
+      "title": "RNA origami scaffolds facilitate cryo-EM characterization of a Broccoli-Pepper aptamer FRET pair",
+      "journal": "Nucleic Acids Research"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37236014",
+    "publication": {
+      "pmid": "37236014",
+      "year": "2023",
+      "authors": "Fang, M., Li, H., Xie, X., Wang, H., Jiang, Y.",
+      "title": "Imaging intracellular metabolite and protein changes in live mammalian cells with bright fluorescent RNA-based genetically encoded sensors",
+      "journal": "Biosensors & Bioelectronics"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37486780",
+    "publication": {
+      "pmid": "37486780",
+      "year": "2023",
+      "authors": "Chen, Z., Chen, W., Reheman, Z., Jiang, H., Wu, J., Li, X.",
+      "title": "Genetically encoded RNA-based sensors with Pepper fluorogenic aptamer",
+      "journal": "Nucleic Acids Research"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38098702",
+    "publication": {
+      "pmid": "38098702",
+      "year": "2023",
+      "authors": "Yin, P., Ge, M., Xie, S., Zhang, L., Kuang, S., Nie, Z.",
+      "title": "A universal orthogonal imaging platform for living-cell RNA detection using fluorogenic RNA aptamers",
+      "journal": "Chemical Science"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md",
+      "_posts/Squash-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38105499",
+    "publication": {
+      "pmid": "38105499",
+      "year": "2024",
+      "authors": "Ying, X., Huang, C., Li, T., Li, T., Gao, M., Wang, F., Cao, J., Liu, J.",
+      "title": "An RNA Methylation-Sensitive AIEgen-Aptamer reporting system for quantitatively evaluating m6A methylase and demethylase activities",
+      "journal": "ACS chemical biology"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38295291",
+    "publication": {
+      "pmid": "38295291",
+      "year": "2024",
+      "authors": "Tang, A. A., Afasizheva, A., Cano, C. T., Plath, K., Black, D., Franco, E.",
+      "title": "Optimization of RNA Pepper sensors for the detection of arbitrary RNA targets",
+      "journal": "ACS synthetic biology"
+    },
+    "posts": [
+      "_posts/Pepper-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20445260",
+    "publication": {
+      "pmid": "20445260",
+      "year": "2010",
+      "authors": "Baba, S., Someya, T., Kawai, G., Nakamura, K., & Kumasaka, T.",
+      "title": "Expression, crystallization and preliminary crystallographic analysis of RNA-binding protein Hfq (YmaH) from Bacillus subtilis in complex with an RNA aptamer",
+      "journal": "Acta crystallographica. Section F"
+    },
+    "posts": [
+      "_posts/Hfq-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22053080",
+    "publication": {
+      "pmid": "22053080",
+      "year": "2012",
+      "authors": "Someya, T., Baba, S., Fujimoto, M., Kawai, G., Kumasaka, T., & Nakamura, K.",
+      "title": "Crystal structure of Hfq from Bacillus subtilis in complex with SELEX-derived RNA aptamer: insight into RNA-binding properties of bacterial Hfq",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Hfq-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22965117",
+    "publication": {
+      "pmid": "22965117",
+      "year": "2012",
+      "authors": "Horstmann, N., Orans, J., Valentin-Hansen, P., Shelburne, S. A., 3rd, & Brennan, R. G.",
+      "title": "Structural mechanism of Staphylococcus aureus Hfq binding to an RNA A-tract",
+      "journal": "Structural mechanism of Staphylococcus aureus Hfq binding to an RNA A-tract. Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Hfq-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24828406",
+    "publication": {
+      "pmid": "24828406",
+      "year": "2014",
+      "authors": "Weichenrieder O.",
+      "title": "RNA binding by Hfq and ring-forming (L)Sm proteins: a trade-off between optimal sequence readout and RNA backbone conformation",
+      "journal": "RNA biology"
+    },
+    "posts": [
+      "_posts/Hfq-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37942477",
+    "publication": {
+      "pmid": "37942477",
+      "year": "2023",
+      "authors": "Watkins, D., & Arya, D.",
+      "title": "Models of Hfq interactions with small non-coding RNA in Gram-negative and Gram-positive bacteria",
+      "journal": "Frontiers in cellular and infection microbiology"
+    },
+    "posts": [
+      "_posts/Hfq-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30916478",
+    "publication": {
+      "pmid": "30916478",
+      "year": "2019",
+      "authors": "Iida, M., Mashima, T., Yamaoki, Y., So, M., Nagata, T., & Katahira, M.",
+      "title": "The anti-prion RNA aptamer R12 disrupts the Alzheimer's disease-related complex between prion and amyloid β",
+      "journal": "FEBS Journal"
+    },
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22021209",
+    "publication": {
+      "pmid": "22021209",
+      "year": "2011",
+      "authors": "Steber, M., Arora, A., Hofmann, J., Brutschy, B., & Suess, B.",
+      "title": "Mechanistic basis for RNA aptamer-based induction of TetR",
+      "journal": "Chembiochem : a European journal of chemical biology"
+    },
+    "posts": [
+      "_posts/TetR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29036355",
+    "publication": {
+      "pmid": "29036355",
+      "year": "2017",
+      "authors": "Atanasov, J., Groher, F., Weigand, J. E., & Suess, B.",
+      "title": "Design and implementation of a synthetic pre-miR switch for controlling miRNA biogenesis in mammals",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/TetR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32052019",
+    "publication": {
+      "pmid": "32052019",
+      "year": "2020",
+      "authors": "Grau, F. C., Jaeger, J., Groher, F., Suess, B., & Muller, Y. A.",
+      "title": "The complex formed between a synthetic RNA aptamer and the transcription repressor TetR is a structural and functional twin of the operator DNA-TetR regulator complex",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/TetR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22727813",
+    "publication": {
+      "pmid": "22727813",
+      "year": "2012",
+      "authors": "Tesmer, V. M., Lennarz, S., Mayer, G., & Tesmer, J. J.",
+      "title": "Molecular mechanism for inhibition of g protein-coupled receptor kinase 2 by a selective RNA aptamer",
+      "journal": "Structure"
+    },
+    "posts": [
+      "_posts/GRK2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26552823",
+    "publication": {
+      "pmid": "26552823",
+      "year": "2016",
+      "authors": "Tesmer J. J.",
+      "title": "Crystallographic Pursuit of a Protein-RNA Aptamer Complex",
+      "journal": "Methods in molecular biology"
+    },
+    "posts": [
+      "_posts/GRK2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16027048",
+    "publication": {
+      "pmid": "16027048",
+      "year": "2005",
+      "authors": "Tombelli, S., Minunni, M., Luzi, E., & Mascini, M.",
+      "title": "Aptamer-based biosensors for the detection of HIV-1 Tat protein",
+      "journal": "Bioelectrochemistry (Amsterdam"
+    },
+    "posts": [
+      "_posts/HIV-Tat-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22975093",
+    "publication": {
+      "pmid": "22975093",
+      "year": "2013",
+      "authors": "Rahim Ruslinda, A., Tanabe, K., Ibori, S., Wang, X., & Kawarada, H.",
+      "title": "Effects of diamond-FET-based RNA aptamer sensing for detection of real sample of HIV-1 Tat protein",
+      "journal": "Biosensors & bioelectronics"
+    },
+    "posts": [
+      "_posts/HIV-Tat-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18441054",
+    "publication": {
+      "pmid": "18441054",
+      "year": "2008",
+      "authors": "Miyakawa, S., Nomura, Y., Sakamoto, T., Yamaguchi, Y., Kato, K., Yamazaki, S., & Nakamura, Y.",
+      "title": "Structural and molecular basis for hyperspecificity of RNA aptamer to human immunoglobulin G",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/IgG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18931441",
+    "publication": {
+      "pmid": "18931441",
+      "year": "2008",
+      "authors": "Sugiyama, S., Nomura, Y., Sakamoto, T., Kitatani, T., Kobayashi, A., Miyakawa, S.",
+      "title": "Crystallization and preliminary X-ray diffraction studies of an RNA aptamer in complex with the human IgG Fc fragment",
+      "journal": "Acta crystallographica. Section F"
+    },
+    "posts": [
+      "_posts/IgG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20675355",
+    "publication": {
+      "pmid": "20675355",
+      "year": "2010",
+      "authors": "Nomura, Y., Sugiyama, S., Sakamoto, T., Miyakawa, S., Adachi, H., Takano, K., Murakami, S.",
+      "title": "Conformational plasticity of RNA for target recognition as revealed by the 2.15 A crystal structure of a human IgG-aptamer complex",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/IgG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "22924890",
+    "publication": {
+      "pmid": "22924890",
+      "year": "2012",
+      "authors": "Lee, S. H., Hoshino, Y., Randall, A., Zeng, Z., Baldi, P., Doong, R. A., & Shea, K. J.",
+      "title": "Engineered synthetic polymer nanoparticles as IgG affinity ligands",
+      "journal": "Journal of the American Chemical Society"
+    },
+    "posts": [
+      "_posts/IgG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23661463",
+    "publication": {
+      "pmid": "23661463",
+      "year": "2013",
+      "authors": "Ma, J., Wang, M. G., Mao, A. H., Zeng, J. Y., Liu, Y. Q.",
+      "title": "Target replacement strategy for selection of DNA aptamers against the Fc region of mouse IgG",
+      "journal": "Genetics and molecular research : GMR"
+    },
+    "posts": [
+      "_posts/IgG-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10074372",
+    "publication": {
+      "pmid": "10074372",
+      "year": "1999",
+      "authors": "Lebruska, L. L., & Maher, L. J., 3rd.",
+      "title": "Selection and characterization of an RNA decoy for transcription factor NF-kappa B",
+      "journal": "Biochemistry"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12886018",
+    "publication": {
+      "pmid": "12886018",
+      "year": "2003",
+      "authors": "Huang, D. B., Vu, D., Cassiday, L. A., Zimmerman, J. M., Maher, L. J., 3rd, & Ghosh, G.",
+      "title": "Crystal structure of NF-kappaB (p50)2 complexed to a high-affinity RNA aptamer",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12637683",
+    "publication": {
+      "pmid": "12637683",
+      "year": "2003",
+      "authors": "Cassiday, L. A., & Maher, L. J., 3rd.",
+      "title": "Yeast genetic selections to optimize RNA decoys for transcription factor NF-kappa B",
+      "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15263062",
+    "publication": {
+      "pmid": "15263062",
+      "year": "2004",
+      "authors": "Hoshika, S., Minakawa, N., & Matsuda, A.",
+      "title": "Synthesis and physical and physiological properties of 4'-thioRNA: application to post-modification of RNA aptamer toward NF-kappaB",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16517938",
+    "publication": {
+      "pmid": "16517938",
+      "year": "2006",
+      "authors": "Chan, R., Gilbert, M., Thompson, K. M., Marsh, H. N., Epstein, D. M., & Pendergrast, P. S.",
+      "title": "Co-expression of anti-NFkappaB RNA aptamers and siRNAs leads to maximal suppression of NFkappaB activity in mammalian cells",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18160411",
+    "publication": {
+      "pmid": "18160411",
+      "year": "2008",
+      "authors": "Reiter, N. J., Maher, L. J., 3rd, & Butcher, S. E.",
+      "title": "DNA mimicry by a high-affinity anti-NF-kappaB RNA aptamer",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18426920",
+    "publication": {
+      "pmid": "18426920",
+      "year": "2008",
+      "authors": "Wurster, S. E., & Maher, L. J., 3rd.",
+      "title": "Selection and characterization of anti-NF-kappaB p65 RNA aptamers",
+      "journal": "RNA (New York"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19696077",
+    "publication": {
+      "pmid": "19696077",
+      "year": "2009",
+      "authors": "Wurster, S. E., Bida, J. P., Her, Y. F., & Maher, L. J., 3rd.",
+      "title": "Characterization of anti-NF-kappaB RNA aptamer-binding specificity in vitro and in the yeast three-hybrid system",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/NF-kappaB-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7518917",
+    "publication": {
+      "pmid": "7518917",
+      "year": "1994",
+      "authors": "Kubik, M. F., Stephens, A. W., Schneider, D., Marlar, R. A., & Tasset, D.",
+      "title": "High-affinity RNA ligands to human alpha-thrombin",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Thrombin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11735341",
+    "publication": {
+      "pmid": "11735341",
+      "year": "2001",
+      "authors": "White, R., Rusconi, C., Scardino, E., Wolberg, A., Lawson, J., Hoffman, M., & Sullenger, B.",
+      "title": "Generation of species cross-reactive aptamers using \"toggle\" SELEX",
+      "journal": "Molecular therapy : the journal of the American Society of Gene Therapy"
+    },
+    "posts": [
+      "_posts/Thrombin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12214238",
+    "publication": {
+      "pmid": "12214238",
+      "year": "2002",
+      "authors": "Rusconi, C. P., Scardino, E., Layzer, J., Pitoc, G. A., Ortel, T. L., Monroe, D., & Sullenger, B. A.",
+      "title": "RNA aptamers as reversible antagonists of coagulation factor IXa",
+      "journal": "Nature"
+    },
+    "posts": [
+      "_posts/Thrombin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15196911",
+    "publication": {
+      "pmid": "15196911",
+      "year": "2004",
+      "authors": "Jeter, M. L., Ly, L. V., Fortenberry, Y. M., Whinna, H. C., White, R. R.",
+      "title": "RNA aptamer to thrombin binds anion-binding exosite-2 and alters protease inhibition by heparin-binding serpins",
+      "journal": "FEBS letters"
+    },
+    "posts": [
+      "_posts/Thrombin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18971322",
+    "publication": {
+      "pmid": "18971322",
+      "year": "2008",
+      "authors": "Long, S. B., Long, M. B., White, R. R., & Sullenger, B. A.",
+      "title": "Crystal structure of an RNA aptamer bound to thrombin",
+      "journal": "RNA"
+    },
+    "posts": [
+      "_posts/Thrombin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27566147",
+    "publication": {
+      "pmid": "27566147",
+      "year": "2016",
+      "authors": "Abeydeera, N. D., Egli, M., Cox, N., Mercier, K., Conde, J. N., Pallan, P. S.",
+      "title": "Evoking picomolar binding in RNA by a single phosphorodithioate linkage",
+      "journal": "Nucleic acids research"
+    },
+    "posts": [
+      "_posts/Thrombin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36097297",
+    "publication": null,
+    "posts": [
+      "_posts/FAD-aptamer.md",
+      "_posts/Riboflavin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12185247",
+    "publication": null,
+    "posts": [
+      "_posts/GTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "1697402",
+    "publication": null,
+    "posts": [
+      "_posts/B4-25-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27805569",
+    "publication": null,
+    "posts": [
+      "_posts/Tetracycline-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15687383",
+    "publication": null,
+    "posts": [
+      "_posts/eIF4A-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28945234",
+    "publication": null,
+    "posts": [
+      "_posts/Corn-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31631009",
+    "publication": null,
+    "posts": [
+      "_posts/Corn-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34028262",
+    "publication": null,
+    "posts": [
+      "_posts/Corn-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "37171156",
+    "publication": null,
+    "posts": [
+      "_posts/Corn-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23488798",
+    "publication": null,
+    "posts": [
+      "_posts/Spinach-RNA-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "4507620",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "6897195",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "1469719",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8440248",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9469847",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9461079",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10606647",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11162119",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15496523",
+    "publication": null,
+    "posts": [
+      "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "17038331",
+    "publication": null,
+    "posts": [
+      "_posts/Codeine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23678405",
+    "publication": null,
+    "posts": [
+      "_posts/Codeine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23830440",
+    "publication": null,
+    "posts": [
+      "_posts/Codeine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "27336666",
+    "publication": null,
+    "posts": [
+      "_posts/Codeine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29133961",
+    "publication": null,
+    "posts": [
+      "_posts/Codeine-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28845698",
+    "publication": null,
+    "posts": [
+      "_posts/AML1(RUNX1)-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "16513347",
+    "publication": null,
+    "posts": [
+      "_posts/Theophylline-aptamer_back1.md",
+      "_posts/Theophylline-aptamer_back2.md"
+    ]
+  },
+  {
+    "pmid": "17625118",
+    "publication": null,
+    "posts": [
+      "_posts/L-CCL2-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9056763",
+    "publication": null,
+    "posts": [
+      "_posts/Ribosomal-protein-S8-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "25140011",
+    "publication": null,
+    "posts": [
+      "_posts/Ribosomal-protein-S8-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29413905",
+    "publication": null,
+    "posts": [
+      "_posts/Ribosomal-protein-S8-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35320268",
+    "publication": null,
+    "posts": [
+      "_posts/Ribosomal-protein-S8-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36458023",
+    "publication": null,
+    "posts": [
+      "_posts/Ribosomal-protein-S8-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34937909",
+    "publication": null,
+    "posts": [
+      "_posts/Squash-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "34937911",
+    "publication": null,
+    "posts": [
+      "_posts/Squash-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20306311",
+    "publication": null,
+    "posts": [
+      "_posts/Ribostamycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20632338",
+    "publication": null,
+    "posts": [
+      "_posts/Ribostamycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23303774",
+    "publication": null,
+    "posts": [
+      "_posts/Ribostamycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "39902969",
+    "publication": null,
+    "posts": [
+      "_posts/Ribostamycin-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7687750",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "7521014",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8700212",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "8756406",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9081544",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9384529",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9257650",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "9159476",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14624002",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "12873145",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "15237981",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "29248297",
+    "publication": null,
+    "posts": [
+      "_posts/ATP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "30986047",
+    "publication": null,
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33574610",
+    "publication": null,
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "35486532",
+    "publication": null,
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "36658339",
+    "publication": null,
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "38760339",
+    "publication": null,
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "39803439",
+    "publication": null,
+    "posts": [
+      "_posts/TMR-DN-aptamer.md",
+      "_posts/TMR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "2459391",
+    "publication": null,
+    "posts": [
+      "_posts/GlnRs-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "2479982",
+    "publication": null,
+    "posts": [
+      "_posts/GlnRs-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10881199",
+    "publication": null,
+    "posts": [
+      "_posts/GlnRs-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "10860750",
+    "publication": null,
+    "posts": [
+      "_posts/GlnRs-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "14681579",
+    "publication": null,
+    "posts": [
+      "_posts/GlnRs-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24570482",
+    "publication": null,
+    "posts": [
+      "_posts/Lysozyme-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19246008",
+    "publication": null,
+    "posts": [
+      "_posts/TetR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "31504742",
+    "publication": null,
+    "posts": [
+      "_posts/TetR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "33148600",
+    "publication": null,
+    "posts": [
+      "_posts/TetR-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "28092358",
+    "publication": null,
+    "posts": [
+      "_posts/5HTP-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "11800555",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18029754",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19098441",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "18776312",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "19666719",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23180780",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "23104426",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "24803670",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "32188933",
+    "publication": null,
+    "posts": [
+      "_posts/Bovine-prion-protein-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "20022942",
+    "publication": null,
+    "posts": [
+      "_posts/Factor-Xa-aptamer.md"
+    ]
+  },
+  {
+    "pmid": "26584417",
+    "publication": null,
+    "posts": [
+      "_posts/Factor-Xa-aptamer.md"
+    ]
+  }
+]

--- a/postRef.json
+++ b/postRef.json
@@ -1,0 +1,5546 @@
+[
+  {
+    "pmid": "15629041",
+    "title": "Isolation and characterization of 2'-amino-modified RNA aptamers for human TNFalpha.",
+    "authors": "Yan X, Gao X, Zhang Z.",
+    "journal": "Genomics Proteomics Bioinformatics. 2(1):32-42. (2004)",
+    "source_file": "_posts/hTNF-α-aptamer.md"
+  },
+  {
+    "pmid": "15971588",
+    "title": "Screening and characterization of DNA aptamers with hTNF-alpha binding and neutralizing activity.",
+    "authors": "Guo KT, Yan XR, Huang GJ, Xu CX, Chai YS, Zhang ZQ.",
+    "journal": "Sheng Wu Gong Cheng Xue Bao. 19(6):730-3. (2003)",
+    "source_file": "_posts/hTNF-α-aptamer.md"
+  },
+  {
+    "pmid": "31989789",
+    "title": "Designing a new dimerized anti human TNF-α aptamer with blocking activity.",
+    "authors": "Mashayekhi K, Ganji A, Sankian M.",
+    "journal": "Biotechnol Prog. 36(4):e2969. (2020)",
+    "source_file": "_posts/hTNF-α-aptamer.md"
+  },
+  {
+    "pmid": "36097297",
+    "title": "An RNA aptamer that shifts the reduction potential of metabolic cofactors.",
+    "authors": "Samuelian, J.S., Gremminger, T.J., Song, Z., Poudyal, R.R., Li, J., Zhou, Y., Staller, S.A., Carballo, J.A., Roychowdhury-Saha, M., Chen, S.J., Burke, D.H., Heng, X., Baum, D.A.",
+    "journal": "Nature Chemical Biology 18, 1263–1269. (2022)",
+    "source_file": "_posts/FAD-aptamer.md"
+  },
+  {
+    "pmid": "9772167",
+    "title": "Functional requirements for specific ligand recognition by a biotin-binding RNA pseudoknot.",
+    "authors": "Wilson, C., Nix, J., & Szostak, J.",
+    "journal": "Biochemistry, 37(41), 14410–14419. (1998)",
+    "source_file": "_posts/Biotin-aptamer.md"
+  },
+  {
+    "pmid": "10089439",
+    "title": "Preliminary crystallographic characterization of an in vitro evolved biotin-binding RNA pseudoknot.",
+    "authors": "Nix, J. C., Newhoff, A. R., & Wilson, C.",
+    "journal": "Acta crystallographica. Section D, Biological crystallography, 55(Pt 1), 323–325. (1999)",
+    "source_file": "_posts/Biotin-aptamer.md"
+  },
+  {
+    "pmid": "10698630",
+    "title": "The 1.3 A crystal structure of a biotin-binding pseudoknot and the basis for RNA molecular recognition.",
+    "authors": "Nix, J., Sussman, D., & Wilson, C.",
+    "journal": "Journal of molecular biology, 296(5), 1235–1244. (2000)",
+    "source_file": "_posts/Biotin-aptamer.md"
+  },
+  {
+    "pmid": "26903199",
+    "title": "A replaceable liposomal aptamer for the ultrasensitive and rapid detection of biotin.",
+    "authors": "Sung, T. C., Chen, W. Y., Shah, P., & Chen, C. S.",
+    "journal": "Scientific reports, 6, 21369. (2016)",
+    "source_file": "_posts/Biotin-aptamer.md"
+  },
+  {
+    "pmid": "35340298",
+    "title": "Pull-down of Biotinylated RNA and Associated Proteins.",
+    "authors": "Uppala, J. K., Ghosh, C., Sabat, G., & Dey, M.",
+    "journal": "Bio-protocol, 12(4), e4331. (2022)",
+    "source_file": "_posts/Biotin-aptamer.md"
+  },
+  {
+    "pmid": "12024047",
+    "title": "Mitochondrial RNA import in Leishmania tropica: aptamers homologous to multiple tRNA domains that interact cooperatively or antagonistically at the inner membrane.",
+    "authors": "Bhattacharyya, S. N., Chatterjee, S., & Adhya, S.",
+    "journal": "Molecular and cellular biology, 22(12), 4372–4382. (2002)",
+    "source_file": "_posts/Mitochondrion-aptamer.md"
+  },
+  {
+    "pmid": "20348443",
+    "title": "Selection of RNA aptamers imported into yeast and human mitochondria.",
+    "authors": "Kolesnikova, O., Kazakova, H., Comte, C., Steinberg, S., Kamenski, P., Martin, R. P., Tarassov, I., & Entelis, N.",
+    "journal": "RNA (New York, N.Y.), 16(5), 926–941. (2010)",
+    "source_file": "_posts/Mitochondrion-aptamer.md"
+  },
+  {
+    "pmid": "25087963",
+    "title": "RNA aptamers for targeting mitochondria using a mitochondria-based SELEX method.",
+    "authors": "Tawaraya, Y., Hyodo, M., Ara, M. N., Yamada, Y., & Harashima, H.",
+    "journal": "Biological & pharmaceutical bulletin, 37(8), 1411–1415. (2014)",
+    "source_file": "_posts/Mitochondrion-aptamer.md"
+  },
+  {
+    "pmid": "27056631",
+    "title": "A Dual-Ligand Liposomal System Composed of a Cell-Penetrating Peptide and a Mitochondrial RNA Aptamer Synergistically Facilitates Cellular Uptake and Mitochondrial Targeting.",
+    "authors": "Yamada, Y., Furukawa, R., & Harashima, H.",
+    "journal": "Journal of pharmaceutical sciences, 105(5), 1705–1713. (2016)",
+    "source_file": "_posts/Mitochondrion-aptamer.md"
+  },
+  {
+    "pmid": "8532517",
+    "title": "Structural probing and damage selection of citrulline- and arginine-specific RNA aptamers identify base positions required for binding.",
+    "authors": "P Burgstaller, M Kochoyan, M Famulok",
+    "journal": "Nucleic acids research. 1995 Dec 11;23(23):4769-76. (1995)",
+    "source_file": "_posts/Citrulline-aptamer.md"
+  },
+  {
+    "pmid": "8604334",
+    "title": "RNA aptamers that bind L-arginine with sub-micromolar dissociation constants and high enantioselectivity.",
+    "authors": "A Geiger, P Burgstaller, H von der Eltz, A Roeder, M Famulok",
+    "journal": "Nucleic acids research. 1996 Mar 15;24(6):1029-36. (1996)",
+    "source_file": "_posts/Citrulline-aptamer.md"
+  },
+  {
+    "pmid": "8650546",
+    "title": "Structural basis of ligand discrimination by two related RNA aptamers resolved by NMR spectroscopy.",
+    "authors": "Y Yang, M Kochoyan, P Burgstaller, E Westhof, M Famulok",
+    "journal": "Science. 1996 May 31;272(5266):1343-7. (1996)",
+    "source_file": "_posts/Citrulline-aptamer.md"
+  },
+  {
+    "pmid": "9631062",
+    "title": "Mirror-design of L-oligonucleotide ligands binding to L-arginine.",
+    "authors": "A Nolte, S Klussmann, R Bald, V A Erdmann, J P Fürste",
+    "journal": "Nature biotechnology. 1996 Sep;14(9):1116-9. (1996)",
+    "source_file": "_posts/Citrulline-aptamer.md"
+  },
+  {
+    "pmid": "15801729",
+    "title": "Chiral stationary phase based on a biostable L-RNA aptamer.",
+    "authors": "Agnès Brumbt, Corinne Ravelet, Catherine Grosset, Anne Ravel, Annick Villet, Eric Peyrin",
+    "journal": "Analytical chemistry. 2005 Apr 1;77(7):1993-8. (2005)",
+    "source_file": "_posts/Citrulline-aptamer.md"
+  },
+  {
+    "pmid": "9586110",
+    "title": "In vitro selection of aptamers that bind to ribosome-inactivating toxins.",
+    "authors": "Hirao, I., Yoshinari, S., Yokoyama, S., Endo, Y., & Ellington, A. D.",
+    "journal": "Nucleic acids symposium series, (37), 283–284. (1997)",
+    "source_file": "_posts/Pepocin-aptamer.md"
+  },
+  {
+    "pmid": "10671532",
+    "title": "RNA aptamers that bind to and inhibit the ribosome-inactivating protein, pepocin.",
+    "authors": "Hirao, I., Madin, K., Endo, Y., Yokoyama, S., & Ellington, A. D.",
+    "journal": "The Journal of biological chemistry, 275(7), 4943–4948. (2000)",
+    "source_file": "_posts/Pepocin-aptamer.md"
+  },
+  {
+    "pmid": "12903331",
+    "title": "In vitro selection and analysis of RNA aptamer recognize arginine-rich motif (ARM) model peptide on a QCM.",
+    "authors": "Fukusho, S., Furusawa, H., & Okahata, Y.",
+    "journal": "Nucleic acids symposium series, (44), 187–188. (2000)",
+    "source_file": "_posts/R5-helix-peptide-aptamer.md"
+  },
+  {
+    "pmid": "12120324",
+    "title": "In vitro selection and evaluation of RNA aptamers that recognize arginine-rich-motif model peptide on a quartz-crystal microbalance.",
+    "authors": "Fukusho, S., Furusawa, H., & Okahata, Y.",
+    "journal": "Chemical communications (Cambridge, England), (1), 88–89. (2002)",
+    "source_file": "_posts/R5-helix-peptide-aptamer.md"
+  },
+  {
+    "pmid": "24623705",
+    "title": "Arginine arrangement of bacteriophage λ N-peptide plays a role as a core motif in GNRA tetraloop RNA binding.",
+    "authors": "Furusawa, H., Fukusho, S., & Okahata, Y.",
+    "journal": "Chembiochem : a European journal of chemical biology, 15(6), 865–871. (2014)",
+    "source_file": "_posts/R5-helix-peptide-aptamer.md"
+  },
+  {
+    "pmid": "21798953",
+    "title": "RNA mimics of green fluorescent protein.",
+    "authors": "Paige, J. S., Wu, K. Y., & Jaffrey, S. R.",
+    "journal": "Science (New York, N.Y.), 333(6042), 642–646. (2011)",
+    "source_file": "_posts/Chili-aptamer.md"
+  },
+  {
+    "pmid": "30485561",
+    "title": "A multicolor large stokes shift fluorogen-activating RNA aptamer with cationic chromophores.",
+    "authors": "Steinmetzger, C., Palanisamy, N., Gore, K. R., & Höbartner, C.",
+    "journal": "Chemistry (Weinheim an der Bergstrasse, Germany), 25(8), 1931–1935. (2019)",
+    "source_file": "_posts/Chili-aptamer.md"
+  },
+  {
+    "pmid": "31740962",
+    "title": "Structure-fluorescence activation relationships of a large Stokes shift fluorogenic RNA aptamer.",
+    "authors": "Steinmetzger, C., Bessi, I., Lenz, A. K., & Höbartner, C.",
+    "journal": "Nucleic acids research, 47(22), 11538–11550. (2019)",
+    "source_file": "_posts/Chili-aptamer.md"
+  },
+  {
+    "pmid": "34112799",
+    "title": "Large Stokes shift fluorescence activation in an RNA aptamer by intermolecular proton transfer to guanine.",
+    "authors": "Mieczkowski, M., Steinmetzger, C., Bessi, I., Lenz, A. K., Schmiedel, A., Holzapfel, M., Lambert, C., Pena, V., & Höbartner, C.",
+    "journal": "Nature communications, 12(1), 3549. (2021)",
+    "source_file": "_posts/Chili-aptamer.md"
+  },
+  {
+    "pmid": "37723244",
+    "title": "Large Stokes shift fluorescent RNAs for dual-emission fluorescence and bioluminescence imaging in live cells.",
+    "authors": "Trachman, R. J., 3rd, Autour, A., Jeng, S. C. Y., Abdolahzadeh, A., Andreoni, A., Cojocaru, R., Garipov, R., Dolgosheina, E. V., Knutson, Jiang, L., Xie, X., Su, N., Zhang, D., Chen, X., Xu, X., Zhang, B., Huang, K., Yu, J., Fang, M., Bao, B., Zuo, F., Yang, L., Zhang, R., Li, H., Huang, X., Chen, Z., Zeng, Q., Liu, R., Lin, Q., … Yang, Y.",
+    "journal": "Nature methods, 20(10), 1563–1572. (2023)",
+    "source_file": "_posts/Chili-aptamer.md"
+  },
+  {
+    "pmid": "15913532",
+    "title": "Selection of RNA aptamers against human influenza virus hemagglutinin using surface plasmon resonance.",
+    "authors": "Misono, T. S., & Kumar, P. K.",
+    "journal": "Analytical biochemistry, 342(2), 312–317. (2005)",
+    "source_file": "_posts/Hemagglutinin-aptamer.md"
+  },
+  {
+    "pmid": "6300098",
+    "title": "Receptor-mediated endocytosis of transferrin in K562 cells.",
+    "authors": "Klausner, R. D., Van Renswoude, J., Ashwell, G., Kempf, C., Schechter, A. N., Dean, A., & Bridges, K. R.",
+    "journal": "The Journal of biological chemistry, 258(8), 4715–4724. (1983)",
+    "source_file": "_posts/TfR-ECD-aptamer.md"
+  },
+  {
+    "pmid": "6300903",
+    "title": "pH and the recycling of transferrin during receptor-mediated endocytosis.",
+    "authors": "Dautry-Varsat, A., Ciechanover, A., & Lodish, H. F.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 80(8), 2258–2262. (1983)",
+    "source_file": "_posts/TfR-ECD-aptamer.md"
+  },
+  {
+    "pmid": "3681112",
+    "title": "Hereditary hypotransferrinemia with hemosiderosis, a murine disorder resembling human atransferrinemia.",
+    "authors": "Bernstein S. E.",
+    "journal": "The Journal of laboratory and clinical medicine, 110(6), 690–705. (1987)",
+    "source_file": "_posts/TfR-ECD-aptamer.md"
+  },
+  {
+    "pmid": "9546397",
+    "title": "Crystal structure of the hemochromatosis protein HFE and characterization of its interaction with transferrin receptor.",
+    "authors": "Lebrón, J. A., Bennett, M. J., Vaughn, D. E., Chirino, A. J., Snow, P. M., Mintier, G. A., Feder, J. N., & Bjorkman, P. J.",
+    "journal": "Cell, 93(1), 111–123. (1998)",
+    "source_file": "_posts/TfR-ECD-aptamer.md"
+  },
+  {
+    "pmid": "14617356",
+    "title": "Lipid rafts and caveolae as portals for endocytosis: new insights and common mechanisms.",
+    "authors": "Parton, R. G., & Richards, A. A.",
+    "journal": "Traffic (Copenhagen, Denmark), 4(11), 724–738. (2003)",
+    "source_file": "_posts/TfR-ECD-aptamer.md"
+  },
+  {
+    "pmid": "18838694",
+    "title": "Aptamer-based endocytosis of a lysosomal enzyme.",
+    "authors": "Chen, C. H., Dellamaggiore, K. R., Ouellette, C. P., Sedano, C. D., Lizadjohry, M., Chernis, G. A., Gonzales, M., Baltasar, F. E., Fan, A. L., Myerowitz, R., & Neufeld, E. F.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 105(41), 15908–15913. (2008)",
+    "source_file": "_posts/TfR-ECD-aptamer.md"
+  },
+  {
+    "pmid": "36097297",
+    "title": "An RNA aptamer that shifts the reduction potential of metabolic cofactors.",
+    "authors": "Samuelian, J.S., Gremminger, T.J., Song, Z., Poudyal, R.R., Li, J., Zhou, Y., Staller, S.A., Carballo, J.A., Roychowdhury-Saha, M., Chen, S.J., Burke, D.H., Heng, X., Baum, D.A.",
+    "journal": "Nature Chemical Biology 18, 1263–1269 (2022). (2022)",
+    "source_file": "_posts/Riboflavin-aptamer.md"
+  },
+  {
+    "pmid": "9383430",
+    "title": "Specific binding of aminoglycoside antibiotics to RNA.",
+    "authors": "Wang, Y., & Rando, R. R.",
+    "journal": "Chemistry & biology, 2(5), 281–290. (1995)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "9070426",
+    "title": "Accharide-RNA recognition in an aminoglycoside antibiotic-RNA aptamer complex.",
+    "authors": "Jiang, L., Suri, A. K., Fiala, R., & Patel, D. J.",
+    "journal": "SChemistry & biology, 4(1), 35–50. (1997)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "9731769",
+    "title": "Solution structure of the tobramycin-RNA aptamer complex.",
+    "authors": "Jiang, L., & Patel, D. J.",
+    "journal": "Nature structural biology, 5(9), 769–774. (1998)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "14769995",
+    "title": "Tobramycin affinity tag purification of spliceosomes.",
+    "authors": "Hartmuth, K., Vornlocher, H. P., & Lührmann, R.",
+    "journal": "Methods in molecular biology (Clifton, N.J.), 257, 47–64. (2004)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "16217837",
+    "title": "Electrospray ionization of nucleic acid aptamer/small molecule complexes for screening aptamer selectivity.",
+    "authors": "Keller, K. M., Breeden, M. M., Zhang, J., Ellington, A. D., & Brodbelt, J. S.",
+    "journal": "Journal of mass spectrometry : JMS, 40(10), 1327–1337. (2005)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "25337781",
+    "title": "Achieving reproducible performance of electrochemical, folding aptamer-based sensors on microelectrodes: challenges and prospects.",
+    "authors": "Liu, J., Wagan, S., Dávila Morris, M., Taylor, J., & White, R. J.",
+    "journal": "Analytical chemistry, 86(22), 11417–11424. (2014)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "25835184",
+    "title": "Rationally designing aptamer sequences with reduced affinity for controlled sensor performance.",
+    "authors": "Schoukroun-Barnes, L. R., & White, R. J.",
+    "journal": "Sensors (Basel, Switzerland), 15(4), 7754–7767. (2015)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "29594665",
+    "title": "Gold nanoparticle based photometric determination of tobramycin by using new specific DNA aptamers.",
+    "authors": "Han, X., Zhang, Y., Nie, J., Zhao, S., Tian, Y., & Zhou, N.",
+    "journal": "Mikrochimica acta, 185(1), 4. (2017)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "30356136",
+    "title": "Aptamer-enabled uptake of small molecule ligands.",
+    "authors": "Auwardt, S. L., Seo, Y. J., Ilgu, M., Ray, J., Feldges, R. R., Shubham, S., Bendickson, L., Levine, H. A., & Nilsen-Hamilton, M.",
+    "journal": "Scientific reports, 8(1), 15712. (2018)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "30268963",
+    "title": "Electrochemical detection of tobramycin based on enzymes-assisted dual signal amplification by using a novel truncated aptamer with high affinity.",
+    "authors": "Nie, J., Yuan, L., Jin, K., Han, X., Tian, Y., & Zhou, N.",
+    "journal": "Biosensors & bioelectronics, 122, 254–262. (2018)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "31625087",
+    "title": "Creening, Post-SELEX Optimization and Application of DNA Aptamers Specific for Tobramycin.",
+    "authors": "Zhou, N., Cai, R., & Han, X.  S.",
+    "journal": "Methods in molecular biology (Clifton, N.J.), 2070, 1–18 (2020)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "35217273",
+    "title": "Structure-switching aptamer triggering signal amplification strategy for tobramycin detection based on hybridization chain reaction and fluorescence synergism.",
+    "authors": "Wang, J., Li, H., Du, C., Li, Y., Ma, X., Yang, C., Xu, W., & Sun, C.",
+    "journal": "Talanta, 243, 123318. (2022)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "37791877",
+    "title": "Development of a novel tobramycin dependent riboswitch.",
+    "authors": "Kraus, L., Duchardt-Ferner, E., Bräuchle, E., Fürbacher, S., Kelvin, D., Marx, H., Boussebayle, A., Maurer, L. M., Bofill-Bosch, C., Wöhnert, J., & Suess, B.",
+    "journal": "Nucleic acids research, 51(20), 11375–11385. (2023)",
+    "source_file": "_posts/Tobramycin-aptamer.md"
+  },
+  {
+    "pmid": "11907208",
+    "title": "Selection of RNA aptamers that are specific and high-affinity ligands of the hepatitis C virus RNA-dependent RNA polymerase.",
+    "authors": "Biroccio, A., Hamm, J., Incitti, I., De Francesco, R., & Tomei, L.",
+    "journal": "Journal of virology, 76(8), 3688–3696. (2002)",
+    "source_file": "_posts/HCV-NS5BΔC55-aptamer.md"
+  },
+  {
+    "pmid": "12667800",
+    "title": "Identification of RNA ligands that bind hepatitis C virus polymerase selectively and inhibit its RNA synthesis from the natural viral RNA templates.",
+    "authors": "Vo, N. V., Oh, J. W., & Lai, M. M.",
+    "journal": "Virology, 307(2), 301–316. (2003)",
+    "source_file": "_posts/HCV-NS5BΔC55-aptamer.md"
+  },
+  {
+    "pmid": "22163979",
+    "title": "Label free inhibitor screening of hepatitis C virus (HCV) NS5B viral protein using RNA oligonucleotide.",
+    "authors": "Roh, C., Kim, S. E., & Jo, S. K.",
+    "journal": "Sensors (Basel, Switzerland), 11(7), 6685–6696. (2011)",
+    "source_file": "_posts/HCV-NS5BΔC55-aptamer.md"
+  },
+  {
+    "pmid": "23596299",
+    "title": "Inhibition of hepatitis C virus (HCV) replication by specific RNA aptamers against HCV NS5B RNA replicase.",
+    "authors": "Lee, C. H., Lee, Y. J., Kim, J. H., Lim, J. H., Kim, J. H., Han, W., Lee, S. H., Noh, G. J., & Lee, S. W.",
+    "journal": "Journal of virology, 87(12), 7064–7074. (2013)",
+    "source_file": "_posts/HCV-NS5BΔC55-aptamer.md"
+  },
+  {
+    "pmid": "26440598",
+    "title": "Pharmacokinetics of a Cholesterol-conjugated Aptamer Against the Hepatitis C Virus (HCV) NS5B Protein.",
+    "authors": "Lee, C. H., Lee, S. H., Kim, J. H., Noh, Y. H., Noh, G. J., & Lee, S. W.",
+    "journal": "Molecular therapy. Nucleic acids, 4(10), e254. (2015)",
+    "source_file": "_posts/HCV-NS5BΔC55-aptamer.md"
+  },
+  {
+    "pmid": "38027068",
+    "title": "Generation of hepatitis C virus-resistant liver cells by genome editing-mediated stable expression of RNA aptamer.",
+    "authors": "Kim, T. H., & Lee, S. W.",
+    "journal": "Molecular therapy. Methods & clinical development, 31, 101151. (2023)",
+    "source_file": "_posts/HCV-NS5BΔC55-aptamer.md"
+  },
+  {
+    "pmid": "12185247",
+    "title": "Isolation of high-affinity GTP aptamers from partially structured RNA libraries.",
+    "authors": "Jonathan H. Davis and Jack W. Szostak.",
+    "journal": "PNAS, 99 (18) 11616-11621 (2002)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "15099096",
+    "title": "Informational Complexity and Functional Activity of RNA Structures.",
+    "authors": "James M. Carothers, Stephanie C. Oestreich‡, Jonathan H. Davis, and Jack W. Szostak.",
+    "journal": "JACS, 126(16) 5130–5137 (2004)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "16510427",
+    "title": "Solution structure of an informationally complex high-affinity RNA aptamer to GTP.",
+    "authors": "Carothers, J. M., Davis, J. H., Chou, J. J., & Szostak, J. W.",
+    "journal": "RNA, 12(4), 567-579 (2006)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "23601641",
+    "title": "Discovery of widespread GTP-binding motifs in genomic DNA and RNA.",
+    "authors": "Curtis, E. A., & Liu, D. R.",
+    "journal": "Chemistry & biology, 20(4), 521-532 (2013)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "24824832",
+    "title": "A naturally occurring, noncanonical GTP aptamer made of simple tandem repeats.",
+    "authors": "Curtis, Edward A., and David R. Liu",
+    "journal": "RNA biology, 11(6), 682-692 (2014)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "27659052",
+    "title": "An intermolecular G-quadruplex as the basis for GTP recognition in the class V–GTP aptamer.",
+    "authors": "Nasiri, A. H., Wurm, J. P., Immer, C., Weickhmann, A. K., & Wöhnert, J.",
+    "journal": "RNA, 22(11), 1750-1759. (2016)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "27885761",
+    "title": "A stably protonated adenine nucleotide with a highly shifted pKa value stabilizes the tertiary structure of a GTP‐binding RNA aptamer.",
+    "authors": "Wolter, A. C., Weickhmann, A. K., Nasiri, A. H., Hantke, K., Ohlenschläger, O., Wunderlich, C. H. & Wöhnert, J.",
+    "journal": "Angewandte Chemie International Edition, 56(1), 401-404. (2017)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "31030336",
+    "title": "NMR resonance assignments for the GTP-binding RNA aptamer 9-12 in complex with GTP.",
+    "authors": "Wolter, A. C., Pianu, A., Kremser, J., Strebitzer, E., Schnieders, R., Fürtig, B.& Wöhnert, J.",
+    "journal": "Biomolecular NMR Assignments, 13, 281-286 (2019)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "38074198",
+    "title": "Emergence of ATP‐and GTP‐Binding Aptamers from Single RNA Sequences by Error‐Prone Replication and Selection.",
+    "authors": "Wachowius, F., Porebski, B. T., Johnson, C. M., & Holliger, P.",
+    "journal": "ChemSystemsChem, 5(5), e202300006. (2023)",
+    "source_file": "_posts/GTP-aptamer.md"
+  },
+  {
+    "pmid": "1697402",
+    "title": "In vitro selection of RNA molecules that bind specific ligands.",
+    "authors": "Ellington, A. D., & Szostak, J. W.",
+    "journal": "Nature, 346(6287), 818–822. (1990)",
+    "source_file": "_posts/B4-25-aptamer.md"
+  },
+  {
+    "pmid": "29666232",
+    "title": "Tunable cytotoxic aptamer-drug conjugates for the treatment of prostate cancer.",
+    "authors": "Powell Gray, B., Kelly, L., Ahrens, D. P., Barry, A. P., Kratschmer, C., Levy, M., & Sullenger, B. A.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 115(18), 4761–4766. (2018)",
+    "source_file": "_posts/E3-aptamer.md"
+  },
+  {
+    "pmid": "22125633",
+    "title": "A SELEX-screened aptamer of human hepatitis B virus RNA encapsidation signal suppresses viral replication.",
+    "authors": "Feng, H., Beck, J., Nassal, M., & Hu, K. H.",
+    "journal": "PloS one, 6(11), e27862. (2011)",
+    "source_file": "_posts/HBV-P-protein-aptamer.md"
+  },
+  {
+    "pmid": "7510417",
+    "title": "High-resolution molecular discrimination by RNA.",
+    "authors": "Jenison, R. D., Gill, S. C., Pardi, A., & Polisky, B.",
+    "journal": "Science (New York, N.Y.), 263(5152), 1425–1429. (1994)",
+    "source_file": "_posts/Theophylline-aptamer.md"
+  },
+  {
+    "pmid": "9224568",
+    "title": "Rational design of allosteric ribozymes.",
+    "authors": "Tang, J., & Breaker, R. R.",
+    "journal": "Chemistry & biology, 4(6), 453–459. (1997)",
+    "source_file": "_posts/Theophylline-aptamer.md"
+  },
+  {
+    "pmid": "10704308",
+    "title": "Structural studies of soluble oligomers of the Alzheimer beta-amyloid peptide.",
+    "authors": "Huang, T. H., Yang, D. S., Plaskos, N. P., Go, S., Yip, C. M., Fraser, P. E., & Chakrabartty, A.",
+    "journal": "ournal of molecular biology, 297(1), 73–87. (2000)",
+    "source_file": "_posts/E2-aptamer.md"
+  },
+  {
+    "pmid": "12176077",
+    "title": "Abeta toxicity in Alzheimer's disease: globular oligomers (ADDLs) as new vaccine and drug targets.",
+    "authors": "Klein W. L.",
+    "journal": "Neurochemistry international, 41(5), 345–352. (2002)",
+    "source_file": "_posts/E2-aptamer.md"
+  },
+  {
+    "pmid": "15919759",
+    "title": "Fine structure study of Abeta1-42 fibrillogenesis with atomic force microscopy.",
+    "authors": "Arimon, M., Díez-Pérez, I., Kogan, M. J., Durany, N., Giralt, E., Sanz, F., & Fernàndez-Busquets, X.",
+    "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology, 19(10), 1344–1346. (2005)",
+    "source_file": "_posts/E2-aptamer.md"
+  },
+  {
+    "pmid": "17008022",
+    "title": "High sensitivity analysis of amyloid-beta peptide composition in amyloid deposits from human and PS2APP mouse brain.",
+    "authors": "Güntert, A., Döbeli, H., & Bohrmann, B.",
+    "journal": "Neuroscience, 143(2), 461–475. (2006)",
+    "source_file": "_posts/E2-aptamer.md"
+  },
+  {
+    "pmid": "19668864",
+    "title": "RNA aptamers selected against amyloid beta-peptide (Abeta) inhibit the aggregation of Abeta.",
+    "authors": "Takahashi, T., Tada, K., & Mihara, H.",
+    "journal": "Molecular bioSystems, 5(9), 986–991. (2009)",
+    "source_file": "_posts/E2-aptamer.md"
+  },
+  {
+    "pmid": "11557342",
+    "title": "A tetracycline-binding RNA aptamer.",
+    "authors": "Berens, C., Thain, A. & Schroeder, R.",
+    "journal": "Bioorganic & medicinal chemistry, 9(10), 2549–2556 (2001)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "12950926",
+    "title": "Tetracycline-aptamer-mediated translational regulation in yeast.",
+    "authors": "Hanson, S., Berthelot, K., Fink, B., McCarthy, J. E. G. & Suess, B.",
+    "journal": "Molecular microbiology, 49(6), 1627–1637 (2003)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "15769877",
+    "title": "Molecular analysis of a synthetic tetracycline-binding riboswitch.",
+    "authors": "Hanson, S., Bauer, G., Fink, B. & Suess, B",
+    "journal": "RNA (New York, N.Y.), 11(4), 503–511 (2005)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "15723047",
+    "title": "Programmable ligand-controlled riboregulators of eukaryotic gene expression.",
+    "authors": "Bayer, T. S. & Smolke, C. D.",
+    "journal": "Nature biotechnology, 23(3), 337–343. (2005)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "16707663",
+    "title": "Thermodynamic characterization of an engineered tetracyline-binding riboswitch.",
+    "authors": "Müller, M., Weigand, J., Weichenrieder, O. & Suess, B",
+    "journal": "Nucleic acids research, 34(9), 2607–2617 (2006)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "17567606",
+    "title": "Tetracycline aptamer-controlled regulation of pre-mRNA splicing in yeast.",
+    "authors": "Weigand, J. E. & Suess, B",
+    "journal": "Nucleic acids research, 35(12), 4179–4185 (2007)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "18940672",
+    "title": "Structural basis for specific, high-affinity tetracycline binding by an in vitro evolved aptamer and artificial riboswitch.",
+    "authors": "Xiao, H., Edwards, T. E. & Ferré-D'Amaré, A. R.",
+    "journal": "Chemistry & biology, 15(10), 1125–1137 (2008)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "19592423",
+    "title": "A fast and efficient translational control system for conditional expression of yeast genes.",
+    "authors": "Xiao, H., Edwards, T. E. & Ferré-D'Amaré, A. R.",
+    "journal": "Nucleic acids research, 37(18), e1205 (2009)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "21603688",
+    "title": "Selection of tetracycline inducible self-cleaving ribozymes as synthetic devices for gene regulation in yeast.",
+    "authors": "Wittmann, A. & Suess, B",
+    "journal": "Molecular bioSystems, 7(8), 2419–2427 (2011)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "24678266",
+    "title": "Development of β -lactamase as a tool for monitoring conditional gene expression by a tetracycline-riboswitch in Methanosarcina acetivorans.",
+    "authors": "Demolli, S., Geist, M. M., Weigand, J. E., Matschiavelli, N., Suess, B., & Rother, M",
+    "journal": "Archaea (Vancouver, B.C.), 2014, 725610 (2014)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "25517161",
+    "title": "Tetracycline determines the conformation of its aptamer at physiological magnesium concentrations.",
+    "authors": "Reuss, A. J., Vogel, M., Weigand, J. E., Suess, B. & Wachtveitl, J",
+    "journal": "Biophysical journal, 107(12), 2962–2971 (2014)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "25265236",
+    "title": "Conditional control of mammalian gene expression by tetracycline-dependent hammerhead ribozymes.",
+    "authors": "Beilstein, K., Wittmann, A., Grez, M., & Suess, B",
+    "journal": "ACS synthetic biology, 4(5), 526–534 (2015)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "27805569",
+    "title": "Rational design of aptazyme riboswitches for efficient control of gene expression in mammalian cells.",
+    "authors": "Zhong, G., Wang, H., Bailey, C. C., Gao, G., & Farzan",
+    "journal": "eLife, 5, e18858 (2016)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "27595406",
+    "title": "Directing cellular information flow via CRISPR signal conductors.",
+    "authors": "Liu, Y., Zhan, Y., Chen, Z., He, A., Li, J., Wu, H., Liu, L., Zhuang, C., Lin, J., Guo, X., Zhang, Q., Huang, W., & Cai, Z",
+    "journal": "Nature methods, 13(11), 938–944 (2016)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "27994029",
+    "title": "Applicability of a computational design approach for synthetic riboswitches.",
+    "authors": "Domin, G., Findeiß, S., Wachsmuth, M., Will, S., Stadler, P. F., & Mörl, M",
+    "journal": "Nucleic acids research, 45(7), 4108–4119 (2017)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "29420816",
+    "title": "A small, portable RNA device for the control of exon skipping in mammalian cells.",
+    "authors": "Vogel, M., Weigand, J. E., Kluge, B., Grez, M., & Suess, B",
+    "journal": "Nucleic acids research, 46(8), e48 (2018)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "30337459",
+    "title": "Influence of Mg2+ on the conformational flexibility of a tetracycline aptamer.",
+    "authors": "Hetzke, T., Vogel, M., Gophane, D. B., Weigand, J. E., Suess, B., Sigurdsson, S. T., & Prisner, T. F",
+    "journal": "RNA (New York, N.Y.), 25(1), 158–167 (2019)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "30513199",
+    "title": "Tuning the Performance of Synthetic Riboswitches using Machine Learning.",
+    "authors": "Groher, A. C., Jager, S., Schneider, C., Groher, F., Hamacher, K., & Suess, B",
+    "journal": "ACS synthetic biology, 8(1), 34–44 (2019)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "32024835",
+    "title": "High-throughput identification of synthetic riboswitches by barcode-free amplicon-sequencing in human cells.",
+    "authors": "Strobel, B., Spöring, M., Klein, H., Blazevic, D., Rust, W., Sayols, S., Hartig, J. S., & Kreuz, S",
+    "journal": "Nature communications, 11(1), 714 (2020)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "37459466",
+    "title": "Tapping the potential of synthetic riboswitches: reviewing the versatility of the tetracycline aptamer.",
+    "authors": "Kelvin, D. & Suess, B",
+    "journal": "RNA biology, 20(1), 457–468 (2023)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "38168982",
+    "title": "Control of mammalian gene expression by modulation of polyA signal cleavage at 5' UTR.",
+    "authors": "Luo, L., Jea, J. D., Wang, Y., Chao, P. W., & Yen, L",
+    "journal": "Nature biotechnology, 10.1038/s41587-023-01989-0 (2024)",
+    "source_file": "_posts/Tetracycline-aptamer.md"
+  },
+  {
+    "pmid": "11329270",
+    "title": "Characterization of RNA aptamer binding by the Wilms' tumor suppressor protein WT1.",
+    "authors": "Zhai, G., Iskandar, M., Barilla, K., & Romaniuk, P. J.",
+    "journal": "Biochemistry, 40(7), 2032–2040. (2001)",
+    "source_file": "_posts/Wilms-tumor-protein-aptamer.md"
+  },
+  {
+    "pmid": "15359119",
+    "title": "In vitro selection of specific RNA aptamers for the NFAT DNA binding domain.",
+    "authors": "Cho JS, Lee YJ, Shin KS, Jeong S, Park J, Lee SW.",
+    "journal": "Mol Cells. 18(1):17-23. (2004)",
+    "source_file": "_posts/NFAT-aptamer.md"
+  },
+  {
+    "pmid": "12408978",
+    "title": "In vitro selection of specific RNA inhibitors of NFATc.",
+    "authors": "Bae SJ, Oum JH, Sharma S, Park J, Lee SW.",
+    "journal": "Biochem Biophys Res Commun. 298(4):486-92. (2002)",
+    "source_file": "_posts/NFAT-aptamer.md"
+  },
+  {
+    "pmid": "26350736",
+    "title": "[SOI-nanowire biosensor for the detection of D-NFAT 1 protein].",
+    "authors": "Malsagova KA, Ivanov YD, Pleshakova TO, Kozlov AF, Krohin NV, Kaysheva AL, Shumov ID, Popov VP, Naumova OV, Fomin BI, Nasimov DA.",
+    "journal": "Biomed Khim. 61(4):462-7. (2015)",
+    "source_file": "_posts/NFAT-aptamer.md"
+  },
+  {
+    "pmid": "31451750",
+    "title": "Regulator of calcineurin 1 is a novel RNA-binding protein to regulate neuronal apoptosis.",
+    "authors": "Yun Y, Zhang Y, Zhang C, Huang L, Tan S, Wang P, Vilariño-Gúell C, Song W, Sun X.",
+    "journal": "Mol Psychiatry. 26(4):1361-1375. (2021)",
+    "source_file": "_posts/NFAT-aptamer.md"
+  },
+  {
+    "pmid": "10348914",
+    "title": "Selection of an RNA molecule that specifically inhibits the protease activity of subtilisin.",
+    "authors": "Takeno, H., Yamamoto, S., Tanaka, T., Sakano, Y., & Kikuchi, Y.",
+    "journal": "Journal of biochemistry, 125(6), 1115–1119. (1999)",
+    "source_file": "_posts/Subtilisin-aptamer.md"
+  },
+  {
+    "pmid": "7778267",
+    "title": "Isolation of high-affinity RNA ligands to HIV-1 integrase from a random pool.",
+    "authors": "Allen, P., Worland, S., & Gold, L.",
+    "journal": "Virology, 209(2), 327–336. (1995)",
+    "source_file": "_posts/HIV-1-integrase-aptamer.md"
+  },
+  {
+    "pmid": "12649492",
+    "title": "RNA aptamers to initiation factor 4A helicase hinder cap-dependent translation by blocking ATP hydrolysis.",
+    "authors": "Oguro, A., Ohtsu, T., Svitkin, YV., Sonenberg, N., & Nakamura, Y.",
+    "journal": "RNA, 9(4):394-407. (2003)",
+    "source_file": "_posts/eIF4A-aptamer.md"
+  },
+  {
+    "pmid": "15687383",
+    "title": "NMR structures of double loops of an RNA aptamer against mammalian initiation factor 4A.",
+    "authors": "Sakamoto, T., Oguro, A., Kawai, G., Ohtsu, T., & Nakamura, Y.",
+    "journal": "Nucleic Acids Research, 33(2):745-54. (2005)",
+    "source_file": "_posts/eIF4A-aptamer.md"
+  },
+  {
+    "pmid": "9310370",
+    "title": "Selection of RNA aptamers that bind specifically to the NS3 protease of hepatitis C virus.",
+    "authors": "Urvil, P. T., Kakiuchi, N., Zhou, D. M., Shimotohno, K., Kumar, P. K., & Nishikawa, S.",
+    "journal": "European journal of biochemistry, 248(1), 130–138. (1997)",
+    "source_file": "_posts/10G-1-aptamer.md"
+  },
+  {
+    "pmid": "9356339",
+    "title": "Isolation of RNA aptamers specific to the NS3 protein of hepatitis C virus from a pool of completely random RNA.",
+    "authors": "Kumar, P. K., Machida, K., Urvil, P. T., Kakiuchi, N., Vishnuvardhan, D., Shimotohno, K., Taira, K., & Nishikawa, S.",
+    "journal": "Virology, 237(2), 270–282. (1997)",
+    "source_file": "_posts/10G-1-aptamer.md"
+  },
+  {
+    "pmid": "10848986",
+    "title": "Isolation and characterization of RNA aptamers specific for the hepatitis C virus nonstructural protein 3 protease.",
+    "authors": "Fukuda, K., Vishnuvardhan, D., Sekiya, S., Hwang, J., Kakiuchi, N., Taira, K., Shimotohno, K., Kumar, P. K., & Nishikawa, S.",
+    "journal": "European journal of biochemistry, 267(12), 3685–3694. (2000)",
+    "source_file": "_posts/10G-1-aptamer.md"
+  },
+  {
+    "pmid": "11118325",
+    "title": "The RNA aptamer-binding site of hepatitis C virus NS3 protease.",
+    "authors": "Hwang, J., Fauzi, H., Fukuda, K., Sekiya, S., Kakiuchi, N., Shimotohno, K., Taira, K., Kusakabe, I., & Nishikawa, S.",
+    "journal": "Biochemical and biophysical research communications, 279(2), 557–562. (2000)",
+    "source_file": "_posts/10G-1-aptamer.md"
+  },
+  {
+    "pmid": "12655010",
+    "title": "Inhibition of HCV NS3 protease by RNA aptamers in cells.",
+    "authors": "Nishikawa, F., Kakiuchi, N., Funaji, K., Fukuda, K., Sekiya, S., & Nishikawa, S.",
+    "journal": "Nucleic acids research, 31(7), 1935–1943. (2003)",
+    "source_file": "_posts/10G-1-aptamer.md"
+  },
+  {
+    "pmid": "15541341",
+    "title": "An RNA ligand inhibits hepatitis C virus NS3 protease and helicase activities.",
+    "authors": "Fukuda, K., Umehara, T., Sekiya, S., Kunio, K., Hasegawa, T., & Nishikawa, S.",
+    "journal": "Biochemical and biophysical research communications, 325(3), 670–675. (2004)",
+    "source_file": "_posts/10G-1-aptamer.md"
+  },
+  {
+    "pmid": "22814430",
+    "title": "RNA binding by the NS3 protease of the hepatitis C virus.",
+    "authors": "Vaughan, R., Li, Y., Fan, B., Ranjith-Kumar, C. T., & Kao, C. C.",
+    "journal": "Virus research, 169(1), 80–90. (2012)",
+    "source_file": "_posts/10G-1-aptamer.md"
+  },
+  {
+    "pmid": "8504070",
+    "title": "Three small ribooligonucleotides with specific arginine sites.",
+    "authors": "Connell, G. J., Illangesekare, M., & Yarus, M.",
+    "journal": "Biochemistry, 32(21), 5497–5502. (1993)",
+    "source_file": "_posts/A9g-RNA-aptamer.md"
+  },
+  {
+    "pmid": "12124337",
+    "title": "Identification and characterization of nuclease-stabilized RNA molecules that bind human prostate cancer cells via the prostate-specific membrane antigen.",
+    "authors": "Lupold, S. E., Hicke, B. J., Lin, Y., & Coffey, D. S.",
+    "journal": "Cancer research, 62(14), 4029–4033. (2002)",
+    "source_file": "_posts/A9g-RNA-aptamer.md"
+  },
+  {
+    "pmid": "16740739",
+    "title": "Aptamer mediated siRNA delivery.",
+    "authors": "Chu, T. C., Twu, K. Y., Ellington, A. D., & Levy, M.",
+    "journal": "Nucleic acids research, 34(10), e73. (2006)",
+    "source_file": "_posts/A9g-RNA-aptamer.md"
+  },
+  {
+    "pmid": "20550178",
+    "title": "A drug-loaded aptamer-gold nanoparticle bioconjugate for combined CT imaging and therapy of prostate cancer.",
+    "authors": "Kim, D., Jeong, Y. Y., & Jon, S.",
+    "journal": "ACS nano, 4(7), 3689–3696. (2010)",
+    "source_file": "_posts/A9g-RNA-aptamer.md"
+  },
+  {
+    "pmid": "22004414",
+    "title": "Rational truncation of an RNA aptamer to prostate-specific membrane antigen using computational structural modeling.",
+    "authors": "Rockey, W. M., Hernandez, F. J., Huang, S. Y., Cao, S., Howell, C. A., Thomas, G. S., Liu, X. Y., Lapteva, N., Spencer, D. M., McNamara, J. O., Zou, X., Chen, S. J., & Giangrande, P. H.",
+    "journal": "Nucleic acid therapeutics, 21(5), 299–314. (2011)",
+    "source_file": "_posts/A9g-RNA-aptamer.md"
+  },
+  {
+    "pmid": "25450401",
+    "title": "RNA aptamer-conjugated liposome as an efficient anticancer drug delivery vehicle targeting cancer cells in vivo.",
+    "authors": "Baek, S. E., Lee, K. H., Park, Y. S., Oh, D. K., Oh, S., Kim, K. S., & Kim, D. E.",
+    "journal": "Journal of controlled release : official journal of the Controlled Release Society, 196, 234–242. (2014)",
+    "source_file": "_posts/A9g-RNA-aptamer.md"
+  },
+  {
+    "pmid": "32525981",
+    "title": "Structural basis of prostate-specific membrane antigen recognition by the A9g RNA aptamer.",
+    "authors": "Ptacek, J., Zhang, D., Qiu, L., Kruspe, S., Motlova, L., Kolenko, P., Novakova, Z., Shubham, S., Havlinova, B., Baranova, P., Chen, S. J., Zou, X., Giangrande, P., & Barinka, C.",
+    "journal": "Nucleic acids research, 48(19), 11130–11145. (2020)",
+    "source_file": "_posts/A9g-RNA-aptamer.md"
+  },
+  {
+    "pmid": "16707660",
+    "title": "RNA aptamers selected against DNA polymerase beta inhibit the polymerase activities of DNA polymerases beta and kappa.",
+    "authors": "Gening, L. V., & Miller, H.",
+    "journal": "Nucleic acids research, 34(9), 2579–2586. (2006)",
+    "source_file": "_posts/polβ-aptamer.md"
+  },
+  {
+    "pmid": "35018437",
+    "title": "Selection and identification of an RNA aptamer that specifically binds the HIV-1 capsid lattice and inhibits viral replication.",
+    "authors": "Gruenke, P. R., Aneja, R., Welbourn, S., Ukah, O. B., Sarafianos, S. G., Burke, D. H., & Lange, M. J.",
+    "journal": "Nucleic acids research, 50(3), 1701–1717. (2022)",
+    "source_file": "_posts/HIV-1-CA-aptamer.md"
+  },
+  {
+    "pmid": "21203916",
+    "title": "Analyses of SELEX-derived ZAP-binding RNA aptamers suggest that the binding specificity is determined by both structure and sequence of the RNA.",
+    "authors": "Huang, Z., Wang, X., & Gao, G.",
+    "journal": "Protein Cell, 1(8), 752-9. (2010)",
+    "source_file": "_posts/ZAP-aptamer.md"
+  },
+  {
+    "pmid": "10097084",
+    "title": "Cytoplasmic RNA modulators of an inside-out signal-transduction cascade.",
+    "authors": "Blind, M., Kolanus, W., & Famulok, M.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 96(7), 3606–3610. (1999)",
+    "source_file": "_posts/Integrin-beta-chain-2-(CD18)-aptamer.md"
+  },
+  {
+    "pmid": "12453418",
+    "title": "MLL targets SET domain methyltransferase activity to Hox gene promoters.",
+    "authors": "Milne, T. A., Briggs, S. D., Brock, H. W., Martin, M. E., Gibbs, D., Allis, C. D., & Hess, J. L.",
+    "journal": "Mol. Cell, 10, 1107-1117. (2002)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "12482972",
+    "title": "Proteolytic cleavage of MLL generates a complex of N- and C-terminal fragments that confers protein stability and subnuclear localization.",
+    "authors": "Hsieh, J. J., Ernst, P., Erdjument-Bromage, H., Tempst, P., & Korsmeyer, S. J.",
+    "journal": "Mol. Cell. Biol., 23, 186-194. (2003)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "16199523",
+    "title": "MLL associates specifically with a subset of transcriptionally active target genes.",
+    "authors": "Milne, T. A., Dou, Y., Martin, M. E., Brock, H. W., Roeder, R. G., & Hess, J. L.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 102(41), 14765–14770. (2005)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "15949446",
+    "title": "Dynamic lysine methylation on histone H3 defines the regulatory phase of gene transcription.",
+    "authors": "Morillon, A., Karabetsou, N., Nair, A., & Mellor, J.",
+    "journal": "Mol. Cell, 18, 723-734. (2005)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "18224408",
+    "title": "Mechanisms of transcriptional regulation by MLL and its disruption in acute leukemia.",
+    "authors": "Dou, Y., & Hess, J. L.",
+    "journal": "International journal of hematology, 87(1), 10–18. (2008)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "16878130",
+    "title": "Regulation of MLL1 H3K4 methyltransferase activity by its core components.",
+    "authors": "Dou, Y., Milne, T. A., Ruthenburg, A. J., Lee, S., Lee, J. W., Verdine, G. L., Allis, C. D., & Roeder, R. G.",
+    "journal": "Nat. Struct. Mol. Biol., 13, 713-719. (2008)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "19187761",
+    "title": "Structural basis for the requirement of additional factors for MLL1 SET domain activity and recognition of epigenetic marks.",
+    "authors": "Southall, S. M., Wong, P. S., Odho, Z., Roe, S. M., & Wilson, J. R.",
+    "journal": "Mol. Cell, 33, 181-191. (2009)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "24288367",
+    "title": "Establishment of active chromatin structure at enhancer elements by mixed-lineage leukemia 1 to initiate estrogendependent gene expression. Nucleic Acids Res., 42, 2245-2256.",
+    "authors": "Jeong, K. W., Andreu-Vieyra, C., You, J. S., Jones, P. A., & Stallcup, M. R.",
+    "journal": "Nucleic Acids Res., 42, 2245-2256. (2013)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "23210835",
+    "title": "High-affinity, small-molecule peptidomimetic inhibitors of MLL1/WDR5 protein-protein interaction.",
+    "authors": "Karatas, H., Townsend, E. C., Cao, F., Chen, Y., Bernard, D., Liu, L., Lei, M., Dou, Y., & Wang, S.",
+    "journal": "Journal of the American Chemical Society, 135(2) (2013)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "24389101",
+    "title": "Targeting MLL1 H3K4 methyltransferase activity in mixed-lineage leukemia.",
+    "authors": "Cao, F., Townsend, E. C., Karatas, H., Xu, J., Li, L., Lee, S., Liu, L., Chen, Y., Ouillette, P., Zhu, J., Hess, J. L., Atadja, P., Lei, M., Qin, Z. S., Malek, S., Wang, S., & Dou, Y.",
+    "journal": "Molecular cell, 53(2), 247–261. (2014)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "30419633",
+    "title": "Isolation of MLL1 Inhibitory RNA Aptamers.",
+    "authors": "Ul-Haq, A., Jin, M. L., Jeong, K. W., Kim, H. M., & Chun, K. H.",
+    "journal": "Biomolecules & therapeutics, 27(2), 201–209. (2019)",
+    "source_file": "_posts/Mixed-lineage-leukemia-proteins-(MLL)-aptermer.md"
+  },
+  {
+    "pmid": "18557632",
+    "title": "RNA binding specificity of Drosophila muscleblind.",
+    "authors": "Goers, E. S., Voelker, R. B., Gates, D. P., & Berglund, J. A.",
+    "journal": "Biochemistry, 47(27), 7284–7294. (2008)",
+    "source_file": "_posts/Mbl-aptamer.md"
+  },
+  {
+    "pmid": "9222504",
+    "title": "Interacting RNA species identified by combinatorial selection.",
+    "authors": "Cho, B., Taylor, D. C., Nicholas, H. B., Jr, & Schmidt, F. J.",
+    "journal": "Bioorganic & medicinal chemistry, 5(6), 1107–1113. (1997)",
+    "source_file": "_posts/RNA-loop-aptamer.md"
+  },
+  {
+    "pmid": "2200121",
+    "title": "Systematic evolution of ligands by exponential enrichment: RNA ligands to bacteriophage T4 DNA polymerase.",
+    "authors": "Tuerk, C., & Gold, L.",
+    "journal": "Science (New York, N.Y.), 249(4968), 505–510. (1990)",
+    "source_file": "_posts/Gp43-aptamer.md"
+  },
+  {
+    "pmid": "28945233",
+    "title": "Imaging RNA polymerase III transcription using a photostable RNA–fluorophore complex.",
+    "authors": "Song, W., Filonov, G. S., Kim, H., Hirsch, M., Li, X., Moon, J. D., & Jaffrey, S. R.",
+    "journal": "Nature chemical biology, 13(11), 1187–1194. (2017)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "28945234",
+    "title": "A homodimer interface without base pairs in an  RNA mimic of red fluorescent protein.",
+    "authors": "Warner, K. D., Sjekloća, L., Song, W., Filonov, G. S., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature chemical biology, 13(11), 1195–1201. (2017)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "31178406",
+    "title": "Binding between G quadruplexes at the homodimer interface of the Corn RNA aptamer strongly activates thioflavin T fluorescence.",
+    "authors": "Sjekloća, L., & Ferré-D'Amaré, A. R.",
+    "journal": "Cell chemical biology, 26(8), 1159–1168.e4. (2019)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "31631009",
+    "title": "A fluorogenic RNA-based sensor activated by metabolite-induced RNA dimerization.",
+    "authors": "Kim, H., & Jaffrey, S. R.",
+    "journal": "Cell chemical biology, 26(12), 1725–1731.e6. (2019)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "34028262",
+    "title": "Living-cell microRNA imaging with self-assembling fragments of fluorescent protein-mimic RNA aptamer.",
+    "authors": "Gu, Y., Huang, L. J., Zhao, W., Zhang, T. T., Cui, M. R., Yang, X. J., Zhao, X. L., Chen, H. Y., & Xu, J. J.",
+    "journal": "ACS sensors, 6(6), 2339–2347. (2021)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "35294188",
+    "title": "Self-assembly of intracellular multivalent RNA complexes using dimeric Corn and beetroot aptamers.",
+    "authors": "Wu, J., Svensen, N., Song, W., Kim, H., Zhang, S., Li, X., & Jaffrey, S. R.",
+    "journal": "Journal of the American Chemical Society, 144(12), 5471–5477. (2022)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "37171156",
+    "title": "Corn-based fluorescent light-up biosensors with improved signal-to-background ratio for label-free detection of long noncoding RNAs.",
+    "authors": "Zhang, Q., Su, C., Tian, X., & Zhang, C. Y.",
+    "journal": "Analytical chemistry, 95(20), 8097–8104. (2023)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "37221204",
+    "title": "Co-crystal structures of the fluorogenic aptamer Beetroot show that close homology may not predict similar RNA architecture.",
+    "authors": "Passalacqua, L. F. M., Starich, M. R., Link, K. A., Wu, J., Knutson, J. R., Tjandra, N., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature communications, 14(1), 2969. (2023)",
+    "source_file": "_posts/Corn-aptamer.md"
+  },
+  {
+    "pmid": "1370372",
+    "title": "Divalent ion permeability of AMPA receptor channels is dominated by the edited form of a single subunit.",
+    "authors": "Burnashev, N., Monyer, H., Seeburg, P. H., & Sakmann, B.",
+    "journal": "Neuron 8, 189–198. (1992)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "8604042",
+    "title": "Evidence for multiple AMPA receptor complexes in hippocampal CA1/CA2 neurons.",
+    "authors": "Wenthold, R. J., Petralia, R. S., Blahos, J., II, & Niedzielski, A. S.",
+    "journal": "J. Neurosci. 16, 1982–1989. (1996)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "8522940",
+    "title": "The role of RNA editing in controlling glutamate receptor channel properties.",
+    "authors": "Seeburg, P. H.",
+    "journal": "J. Neurochem. 66, 1–5. (1996)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "8987736",
+    "title": "Single-channel properties of recombinant AMPA receptors depend on RNA editing, splice variation, and subunit composition.",
+    "authors": "Swanson, G. T., Kamboj, S. K., & Cull-Candy, S. G.",
+    "journal": "J. Neurosci. 17, 58–69. (1997)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "11124978",
+    "title": "Unequal expression of allelic kainate receptor GluR7 mRNAs in human brains.",
+    "authors": "Schiffer, H. H., Swanson, G. T., Masliah, E., & Heinemann, S. F.",
+    "journal": "J. Neurosci. 20, 9025–9033. (2000)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "14622580",
+    "title": "AMPA receptor tetramerization is mediated by Q/R editing.",
+    "authors": "Greger, I. H., Khatri, L., Kong, X., & Ziff, E. B.",
+    "journal": "Neuron. 40, 763–774. (2003)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "17929944",
+    "title": "RNA aptamers selected against the GluR2 glutamate receptor channel.",
+    "authors": "Huang, Z., Pei, W., Jayaseelan, S., Shi, H., & Niu, L.",
+    "journal": "Biochemistry, 46(44), 12648–12655. (2007)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "20518485",
+    "title": "Potent and selective inhibition of the open-channel conformation of AMPA receptors by an RNA aptamer.",
+    "authors": "Huang, Z., Han, Y., Wang, C., & Niu, L.",
+    "journal": "Biochemistry, 49(27), 5790–5798. (2010)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "21402710",
+    "title": "Potent and selective inhibition of a single alpha-amino-3-hydroxy-5-methyl-4-isoxazolepropionic acid (AMPA) receptor subunit by an RNA aptamer.",
+    "authors": "Park, J. S., Wang, C., Han, Y., Huang, Z., & Niu, L.",
+    "journal": "The Journal of biological chemistry, 286(17), 15608–15617. (2011)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "28872832",
+    "title": "Chemically Modified, α-Amino-3-hydroxy-5-methyl-4-isoxazole (AMPA) Receptor RNA Aptamers Designed for in Vivo Use.",
+    "authors": "Huang, Z., Wen, W., Wu, A., & Niu, L.",
+    "journal": "ACS chemical neuroscience, 8(11), 2437–2445. (2017)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "28325839",
+    "title": "Identification and characterization of RNA aptamers: A long aptamer blocks the AMPA receptor and a short aptamer blocks both AMPA and kainate receptors.",
+    "authors": "Jaremko, W. J., Huang, Z., Wen, W., Wu, A., Karl, N., & Niu, L.",
+    "journal": "The Journal of biological chemistry, 292(18), 7338–7347. (2017)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "34509496",
+    "title": "RNA aptamers for AMPA receptors.",
+    "authors": "Huang, Z., & Niu, L.",
+    "journal": "Neuropharmacology, 199, 108761. (2021)",
+    "source_file": "_posts/AB9-aptamer.md"
+  },
+  {
+    "pmid": "32222697",
+    "title": "Novel Aptamers Selected on Living Cells for Specific Recognition of Triple-Negative Breast Cancer.",
+    "authors": "Camorani, S., Granata, I., Collina, F., Leonetti, F., Cantile, M., Botti, G., Fedele, M., Guarracino, M. R., & Cerchia, L.",
+    "journal": "iScience, 23(4), 100979. (2020)",
+    "source_file": "_posts/TNBC-aptamer.md"
+  },
+  {
+    "pmid": "24588102",
+    "title": "In search of novel drug target sites on estrogen receptors using RNA aptamers.",
+    "authors": "Xu, D., Chatakonda, VK., Kourtidis, A., Conklin, DS., & Shi, H.",
+    "journal": "Nucleic Acid Therapeutics,24(3):226-38. (2014)",
+    "source_file": "_posts/ERα-aptamer.md"
+  },
+  {
+    "pmid": "16467303",
+    "title": "RNA aptamers targeting the cell death inhibitor CED-9 induce cell killing in Caenorhabditis elegans.",
+    "authors": "Yang, C., Yan, N., Parish, J., Wang, X., Shi, Y., & Xue, D.",
+    "journal": "The Journal of biological chemistry, 281(14), 9137–9144. (2006)",
+    "source_file": "_posts/CED-9-aptamer.md"
+  },
+  {
+    "pmid": "8946842",
+    "title": "Inhibition of cell proliferation by an RNA ligand that selectively blocks E2F function.",
+    "authors": "Ishizaki, J., Nevins, J. R., & Sullenger, B. A.",
+    "journal": "Nature medicine, 2(12), 1386–1389. (1996)",
+    "source_file": "_posts/E2F1-aptamer.md"
+  },
+  {
+    "pmid": "9873529",
+    "title": "In vitro selection of phosphorothiolated aptamers.",
+    "authors": "Jhaveri, S., Olwin, B., & Ellington, A. D.",
+    "journal": "Bioorganic & medicinal chemistry letters, 8(17), 2285–2290. (1998)",
+    "source_file": "_posts/Basic-fibroblast-growth-factor-aptamer.md"
+  },
+  {
+    "pmid": "8841594",
+    "title": "In vitro selection of RNA aptamers that can bind specifically to Tat protein of HIV-1.",
+    "authors": "Yamamoto, R., Toyoda, S., Viljanen, P., Machida, K., Nishikawa, S., Murakami, K., Taira, K., & Kumar, P. K.",
+    "journal": "Nucleic acids symposium series, (34), 145–146. (1995)",
+    "source_file": "_posts/Clone-31-aptamer.md"
+  },
+  {
+    "pmid": "10886365",
+    "title": "A novel RNA motif that binds efficiently and specifically to the Ttat protein of HIV and inhibits the trans-activation by Tat of transcription in vitro and in vivo.",
+    "authors": "Yamamoto, R., Katahira, M., Nishikawa, S., Baba, T., Taira, K., & Kumar, P. K.",
+    "journal": "Genes to cells : devoted to molecular & cellular mechanisms, 5(5), 371–388. (2000)",
+    "source_file": "_posts/Clone-31-aptamer.md"
+  },
+  {
+    "pmid": "12737819",
+    "title": "Structural basis of the highly efficient trapping of the HIV Tat protein by an RNA aptamer.",
+    "authors": "Matsugami, A., Kobayashi, S., Ouhashi, K., Uesugi, S., Yamamoto, R., Taira, K., Nishikawa, S., Kumar, P. K., & Katahira, M.",
+    "journal": "Structure (London, England : 1993), 11(5), 533–545. (2003)",
+    "source_file": "_posts/Clone-31-aptamer.md"
+  },
+  {
+    "pmid": "28620664",
+    "title": "Development of an RNA aptamer that acquires binding capacity against HIV-1 Tat protein via G-quadruplex formation in response to potassium ions.",
+    "authors": "Yamaoki, Y., Nagata, T., Mashima, T., & Katahira, M.",
+    "journal": "Chemical communications (Cambridge, England), 53(52), 7056–7059. (2017)",
+    "source_file": "_posts/Clone-31-aptamer.md"
+  },
+  {
+    "pmid": "31707021",
+    "title": "Spectrophotometric ellipsometry based Tat-protein RNA-aptasensor for HIV-1 diagnosis.",
+    "authors": "Caglayan, M. O., & Üstündağ, Z.",
+    "journal": "Spectrochimica acta. Part A, Molecular and biomolecular spectroscopy, 227, 117748. (2020)",
+    "source_file": "_posts/Clone-31-aptamer.md"
+  },
+  {
+    "pmid": "37240414",
+    "title": "Complex Formation of an RNA Aptamer with a Part of HIV-1 Tat through Induction of Base Triples in Living Human Cells Proven by In-Cell NMR.",
+    "authors": "Eladl, O., Yamaoki, Y., Kondo, K., Nagata, T., & Katahira, M.",
+    "journal": "International journal of molecular sciences, 24(10), 9069. (2023)",
+    "source_file": "_posts/Clone-31-aptamer.md"
+  },
+  {
+    "pmid": "38783134",
+    "title": "Imaging the dynamics of messenger RNA with a bright and stable green fluorescent RNA.",
+    "authors": "Zuo, F., Jiang, L., Su, N., Zhang, Y., Bao, B., Wang, L., Shi, Y., Yang, H., Huang, X., Li, R., Zeng, Q., Chen, Z., Lin, Q., Zhuang, Y., Zhao, Y., Chen, X., Zhu, L., & Yang, Y.",
+    "journal": "Nature chemical biology, 10.1038/s41589-024-01629-x. (2024)",
+    "source_file": "_posts/Okra-aptamer.md"
+  },
+  {
+    "pmid": "24334484",
+    "title": "Selection of an aptamer against mouse GP2 by SELEX.",
+    "authors": "Hanazato, M., Nakato, G., Nishikawa, F., Hase, K., Nishikawa, S., & Ohno, H",
+    "journal": "Cell structure and function, 39(1), 23-29. (2014)",
+    "source_file": "_posts/Glycoprotein-2-(GP2)-protein-aptamer.md"
+  },
+  {
+    "pmid": "35970037",
+    "title": "In vitro selection of RNA aptamers that bind to colicin E3 and structurally resemble the decoding site of 16S ribosomal RNA.",
+    "authors": "Hirao, I., Harada, Y., Nojima, T., Osawa, Y., Masaki, H., & Yokoyama, S.",
+    "journal": "Biochemistry, 43(11), 3214–3221. (2004)",
+    "source_file": "_posts/Colicin-E3-aptamer.md"
+  },
+  {
+    "pmid": "7504300",
+    "title": "High-affinity RNA ligands to basic fibroblast growth factor inhibit receptor binding.",
+    "authors": "Jellinek, D., Lynott, C. K., Rifkin, D. B., & Janjić, N.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 90(23), 11227–11231. (1993)",
+    "source_file": "_posts/bFGF-aptamer.md"
+  },
+  {
+    "pmid": "21798953",
+    "title": "RNA mimics of green fluorescent protein.",
+    "authors": "Paige, J. S., Wu, K. Y., & Jaffrey, S. R.",
+    "journal": "Science (New York, N.Y.), 333(6042), 642–646. (2011)",
+    "source_file": "_posts/Spinach-RNA-aptamer.md"
+  },
+  {
+    "pmid": "23488798",
+    "title": "RNA-based fluorescent biosensors for live cell imaging of second messengers cyclic di-GMP and cyclic AMP-GMP.",
+    "authors": "Kellenberger, C. A., Wilson, S. C., Sales-Lee, J., & Hammond, M. C.",
+    "journal": "Journal of the American Chemical Society, 135(13), 4906–4909. (2013)",
+    "source_file": "_posts/Spinach-RNA-aptamer.md"
+  },
+  {
+    "pmid": "24952597",
+    "title": "A G-quadruplex-containing RNA activates fluorescence in a GFP-like fluorophore.",
+    "authors": "Huang, H., Suslov, N. B., Li, N. S., Shelke, S. A., Evans, M. E., Koldobskaya, Y., Rice, P. A., & Piccirilli, J. A.",
+    "journal": "Nature chemical biology, 10(8), 686–691. (2014)",
+    "source_file": "_posts/Spinach-RNA-aptamer.md"
+  },
+  {
+    "pmid": "25964329",
+    "title": "Structural basis for activity of highly efficient RNA mimics of green fluorescent protein.",
+    "authors": "Warner, K. D., Chen, M. C., Song, W., Strack, R. L., Thorn, A., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature structural & molecular biology, 21(8), 658–663. (2014)",
+    "source_file": "_posts/Spinach-RNA-aptamer.md"
+  },
+  {
+    "pmid": "25964329",
+    "title": "Imaging metabolite dynamics in living cells using a Spinach-based riboswitch.",
+    "authors": "You, M., Litke, J. L., & Jaffrey, S. R.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 112(21), E2756–E2765. (2015)",
+    "source_file": "_posts/Spinach-RNA-aptamer.md"
+  },
+  {
+    "pmid": "29309709",
+    "title": "Affinity maturation of a portable Fab-RNA module for chaperone-assisted RNA crystallography.",
+    "authors": "Koirala, D., Shelke, S. A., Dupont, M., Ruiz, S., DasGupta, S., Bailey, L. J., Benner, S. A., & Piccirilli, J. A.",
+    "journal": "Nucleic acids research, 46(5), 2624–2635. (2018)",
+    "source_file": "_posts/Spinach-RNA-aptamer.md"
+  },
+  {
+    "pmid": "6320006",
+    "title": "Magnesium gates glutamate-activated channels in mouse central neurones.",
+    "authors": "Nowak, L., Bregestovski, P., Ascher, P., Herbet, A., & Prochiantz, A.",
+    "journal": "Nature, 307(5950), 462–465. (1984)",
+    "source_file": "_posts/AN58-aptamer.md"
+  },
+  {
+    "pmid": "11848921",
+    "title": "Kinetics and Mechanisms for the Cleavage and Isomerization of the Phosphodiester Bonds of RNA by Brønsted Acids and Bases.",
+    "authors": "Oivanen, M., Kuusela, S., & Lönnberg, H.",
+    "journal": "Chemical reviews, 98(3), 961–990. (1998)",
+    "source_file": "_posts/AN58-aptamer.md"
+  },
+  {
+    "pmid": "14567697",
+    "title": "Channel-opening kinetics of GluR2Q(flip) AMPA receptor: a laser-pulse photolysis study.",
+    "authors": "Li, G., Pei, W., & Niu, L.",
+    "journal": "Biochemistry, 42(42), 12358–12366. (2003)",
+    "source_file": "_posts/AN58-aptamer.md"
+  },
+  {
+    "pmid": "16540562",
+    "title": "Crystal structures of the kainate receptor GluR5 ligand binding core dimer with novel GluR5-selective antagonists.",
+    "authors": "Mayer, M. L., Ghosal, A., Dolman, N. P., & Jane, D. E.",
+    "journal": "The Journal of neuroscience : the official journal of the Society for Neuroscience, 26(11), 2852–2861. (2006)",
+    "source_file": "_posts/AN58-aptamer.md"
+  },
+  {
+    "pmid": "17929944",
+    "title": "RNA aptamers selected against the GluR2 glutamate receptor channel.",
+    "authors": "Huang, Z., Pei, W., Jayaseelan, S., Shi, H., & Niu, L.",
+    "journal": "Biochemistry, 46(44), 12648–12655. (2007)",
+    "source_file": "_posts/AN58-aptamer.md"
+  },
+  {
+    "pmid": "28872832",
+    "title": "Chemically Modified, α-Amino-3-hydroxy-5-methyl-4-isoxazole (AMPA) Receptor RNA Aptamers Designed for in Vivo Use.",
+    "authors": "Huang, Z., Wen, W., Wu, A., & Niu, L.",
+    "journal": "ACS chemical neuroscience, 8(11), 2437–2445. (2017)",
+    "source_file": "_posts/AN58-aptamer.md"
+  },
+  {
+    "pmid": "9245404",
+    "title": "In vitro selection of dopamine RNA ligands.",
+    "authors": "Mannironi C, Di Nardo A, Fruscoloni P, Tocchini-Valentini GP",
+    "journal": "Biochemistry. 1997 Aug 12;36(32):9726-34. (1997)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "21168553",
+    "title": "Development of direct competitive enzyme-linked aptamer assay for determination of dopamine in serum.",
+    "authors": "Park H, Paeng IR",
+    "journal": "Analytica chimica acta. 2011 Jan 24;685(1):65-73. (2011)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "23069733",
+    "title": "Construction of ratiometric fluorescent sensors by ribonucleopeptides.",
+    "authors": "Annoni C, Nakata E, Tamura T, Liew FF, Nakano S, Gelmi ML, Morii T",
+    "journal": "Organic & biomolecular chemistry. 2012 Nov 28;10(44):8767-9. (2012)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "23210972",
+    "title": "RNA aptamer-based electrochemical biosensor for selective and label-free analysis of dopamine.",
+    "authors": "Farjami E, Campos R, Nielsen JS, Gothelf KV, Kjems J, Ferapontova EE",
+    "journal": "Analytical chemistry. 2013 Jan 2;85(1):121-8. (2013)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "25882962",
+    "title": "Surface state of the dopamine RNA aptamer affects specific recognition and binding of dopamine by the aptamer-modified electrodes.",
+    "authors": "Álvarez-Martos I, Campos R, Ferapontova EE",
+    "journal": "The Analyst. 2015 Jun 21;140(12):4089-96. (2015)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "26916821",
+    "title": "Electrochemical Label-Free Aptasensor for Specific Analysis of Dopamine in Serum in the Presence of Structurally Related Neurotransmitters.",
+    "authors": "Álvarez-Martos I, Ferapontova EE",
+    "journal": "Analytical chemistry. 2016 Apr 5;88(7):3608-16. (2016)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "30605601",
+    "title": "Dopamine Binding and Analysis in Undiluted Human Serum and Blood by the RNA-Aptamer Electrode.",
+    "authors": "Álvarez-Martos I, Møller A, Ferapontova EE",
+    "journal": "ACS chemical neuroscience. 2019 Mar 20;10(3):1706-1715. (2019)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "35775197",
+    "title": "Engineering a Synthetic Dopamine-Responsive Riboswitch for In Vitro Biosensing.",
+    "authors": "Harbaugh SV, Silverman AD, Chushak YG, Zimlich K, Wolfe M, Thavarajah W, Jewett MC, Lucks JB, Chávez JL",
+    "journal": "ACS synthetic biology. 2022 Jul 15;11(7):2275-2283. (2022)",
+    "source_file": "_posts/Dopamine-aptamer.md"
+  },
+  {
+    "pmid": "16476969",
+    "title": "An RNA aptamer that distinguishes between closely related human influenza viruses and inhibits haemagglutinin-mediated membrane fusion.",
+    "authors": "Gopinath, S. C. B., Misono, T. S., Kawasaki, K., Mizuno, T., Imai, M., Odagiri, T., & Kumar, P. K. R.",
+    "journal": "The Journal of general virology, 87(Pt 3), 479–487. (2006)",
+    "source_file": "_posts/H3N2-aptamer.md"
+  },
+  {
+    "pmid": "25337688",
+    "title": "Broccoli: rapid selection of an RNA mimic of green fluorescent protein by fluorescence-based selection and directed evolution.",
+    "authors": "Filonov, G. S., Moon, J. D., Svensen, N., & Jaffrey, S. R.",
+    "journal": "Journal of the American Chemical Society, 136(46), 16299–16308. (2014)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "26000751",
+    "title": "In-gel imaging of RNA processing using broccoli reveals optimal aptamer expression strategies.",
+    "authors": "Filonov, G. S., Kam, C. W., Song, W., & Jaffrey, S. R.",
+    "journal": "Chemistry & biology, 22(5), 649–660. (2015)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "26995352",
+    "title": "RNA imaging with dimeric Broccoli in live bacterial and mammalian cells.",
+    "authors": "Filonov, G. S., & Jaffrey, S. R.",
+    "journal": "Current protocols in chemical biology, 8(1), 1–28. (2016)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "26877022",
+    "title": "Fluorescent RNA aptamers as a tool to study RNA-modifying enzymes.",
+    "authors": "Svensen, N., & Jaffrey, S. R.",
+    "journal": "Cell chemical biology, 23(3), 415–425. (2016)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "27467146",
+    "title": "Quadruplex-flanking stem structures modulate the stability and metal ion preferences of RNA mimics of GFP.",
+    "authors": "Ageely, E. A., Kartje, Z. J., Rohilla, K. J., Barkau, C. L., & Gagnon, K. T.",
+    "journal": "ACS chemical biology, 11(9), 2398–2406. (2016)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "28180326",
+    "title": "Use of baby Spinach and Broccoli for imaging of structured cellular RNAs.",
+    "authors": "Okuda, M., Fourmy, D., & Yoshizawa, S.",
+    "journal": "Nucleic acids research, 45(3), 1404–1415. (2017)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "28548488",
+    "title": "A fluorescent split aptamer for visualizing RNA-RNA assembly in vivo.",
+    "authors": "Alam, K. K., Tawiah, K. D., Lichte, M. F., Porciani, D., & Burke, D. H.",
+    "journal": "ACS synthetic biology, 6(9), 1710–1721. (2017)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "28991414",
+    "title": "In situ spatial complementation of aptamer-mediated recognition enables live-cell imaging of native RNA transcripts in real time.",
+    "authors": "Wang, Z., Luo, Y., Xie, X., Hu, X., Song, H., Zhao, Y., Shi, J., Wang, L., Glinsky, G., Chen, N., Lal, R., & Fan, C.",
+    "journal": "Angewandte Chemie, 57(4), 972–976. (2018)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "30513826",
+    "title": "Broccoli fluorets: split aptamers as a user-friendly fluorescent toolkit for dynamic RNA nanotechnology.",
+    "authors": "Chandler, M., Lyalina, T., Halman, J., Rackley, L., Lee, L., Dang, D., Ke, W., Sajja, S., Woods, S., Acharya, S., Baumgarten, E., Christopher, J., Elshalia, E., Hrebien, G., Kublank, K., Saleh, S., Stallings, B., Tafere, M., Striplin, C., & Afonin, K. A.",
+    "journal": "Molecules, 23(12), 3178. (2018)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "30962542",
+    "title": "Highly efficient expression of circular RNA aptamers in cells using autocatalytic transcripts.",
+    "authors": "Litke, J. L., & Jaffrey, S. R.",
+    "journal": "Nature biotechnology, 37(6), 667–675. (2019)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "31850609",
+    "title": "Fluorophore-promoted RNA folding and photostability enables imaging of single broccoli-tagged mRNAs in live mammalian cells.",
+    "authors": "Li, X., Kim, H., Litke, J. L., Wu, J., & Jaffrey, S. R.",
+    "journal": "Angewandte Chemie, 59(11), 4511–4518.  (2020)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "32698574",
+    "title": "Imaging intracellular S-adenosyl methionine dynamics in live mammalian cells with a genetically encoded red fluorescent RNA-based sensor.",
+    "authors": "Li, X., Mo, L., Litke, J. L., Dey, S. K., Suter, S. R., & Jaffrey, S. R.",
+    "journal": "Journal of the American Chemical Society, 142(33), 14117–14124. (2020)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "33303627",
+    "title": "Revisiting T7 RNA polymerase transcription in vitro with the Broccoli RNA aptamer as a simplified real-time fluorescent reporter.",
+    "authors": "Kartje, Z. J., Janis, H. I., Mukhopadhyay, S., & Gagnon, K. T.",
+    "journal": "The Journal of biological chemistry, 296, 100175. (2021)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "33342694",
+    "title": "Light-up RNA aptamer signaling-CRISPR-cas13a-based mix-and-read assays for profiling viable pathogenic bacteria.",
+    "authors": "Zhang, T., Zhou, W., Lin, X., Khan, M. R., Deng, S., Zhou, M., He, G., Wu, C., Deng, R., & He, Q.",
+    "journal": "Biosensors & bioelectronics, 176, 112906. (2021)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "34490956",
+    "title": "Engineering fluorophore recycling in a fluorogenic RNA aptamer.",
+    "authors": "Li, X., Wu, J., & Jaffrey, S. R.",
+    "journal": "Angewandte Chemie, 60(45), 24153–24161. (2021)",
+    "source_file": "_posts/DFHBI-1T-aptamer.md"
+  },
+  {
+    "pmid": "22484812",
+    "title": "Comparing human pancreatic cell secretomes by in vitro aptamer selection identifies cyclophilin B as a candidate pancreatic cancer biomarker.",
+    "authors": "Ray, P., Rialon-Guevara, KL., Veras, E., Sullenger, BA., & White, RR.",
+    "journal": "Journal of Clinical Investgation,122(5):1734-41. (2012)",
+    "source_file": "_posts/CypB-aptamer.md"
+  },
+  {
+    "pmid": "24152208",
+    "title": "Further characterization of the target of a potential aptamer biomarker for pancreatic cancer: cyclophilin B and its posttranslational modifications.",
+    "authors": "Ray, P., Sullenger, BA., & White, RR.",
+    "journal": "Nucleic Acid Therapeutics,23(6):435-42. (2013)",
+    "source_file": "_posts/CypB-aptamer.md"
+  },
+  {
+    "pmid": "26221481",
+    "title": "Development of RNA aptamers as molecular probes for HER2(+) breast cancer study using cell-SELEX.",
+    "authors": "Moosavian, S. A., Jaafari, M. R., Taghdisi, S. M., Mosaffa, F., Badiee, A., & Abnous, K.",
+    "journal": "Iranian journal of basic medical sciences, 18(6), 576–586. (2015)",
+    "source_file": "_posts/HER2-aptamer.md"
+  },
+  {
+    "pmid": "16131593",
+    "title": "RNA sequence and secondary structure participate in high-affinity CsrA-RNA interaction.",
+    "authors": "Dubey, A. K., Baker, C. S., Romeo, T., & Babitzke, P.",
+    "journal": "RNA (New York, N.Y.), 11(10), 1579–1587. (2005)",
+    "source_file": "_posts/CsrA-aptamer.md"
+  },
+  {
+    "pmid": "4507620",
+    "title": "Nucleotide sequence at the binding site for coat protein on RNA of bacteriophage R17.",
+    "authors": "Bernardi, A., & Spahr, P. F.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 69(10), 3033–3037. (1972).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "6897195",
+    "title": "Enzymatic synthesis of a 21-nucleotide coat protein binding fragment of R17 ribonucleic acid.",
+    "authors": "Krug, M., de Haseth, P. L., & Uhlenbeck, O. C.",
+    "journal": "Biochemistry, 21(19), 4713–4720. (1982).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "1469719",
+    "title": "Selection of high affinity RNA ligands to the bacteriophage R17 coat protein.",
+    "authors": "Schneider, D., Tuerk, C., & Gold, L.",
+    "journal": "Journal of molecular biology, 228(3), 862–869. (1992).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "8440248",
+    "title": "The RNA binding site of bacteriophage MS2 coat protein.",
+    "authors": "Peabody DS.",
+    "journal": "The EMBO journal ,12(2), 595–600. (1993).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "9469847",
+    "title": "Crystal structures of MS2 coat protein mutants in complex with wild-type RNA operator fragments.",
+    "authors": "van den Worm, S. H., Stonehouse, N. J., Valegârd, K., Murray, J. B., Walton, C., Fridborg, K., Stockley, P. G., & Liljas, L.",
+    "journal": "Nucleic acids research, 26(5), 1345–1351. (1998).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "9461079",
+    "title": "Crystal structure of an RNA aptamer-protein complex at 2.8 A resolution.",
+    "authors": "Convery, M. A., Rowsell, S., Stonehouse, N. J., Ellington, A. D., Hirao, I., Murray, J. B., Peabody, D. S., Phillips, S. E., & Stockley, P. G.",
+    "journal": "Nature structural biology, 5(2), 133–139. (1998).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "10606647",
+    "title": "RNA aptamers for the MS2 bacteriophage coat protein and the wild-type RNA operator have similar solution behaviour.",
+    "authors": "Parrott, A. M., Lago, H., Adams, C. J., Ashcroft, A. E., Stonehouse, N. J., & Stockley, P. G.",
+    "journal": "Nucleic acids research, 28(2), 489–497. (2000).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "11162119",
+    "title": "Probing the kinetics of formation of the bacteriophage MS2 translational operator complex: identification of a protein conformer unable to bind RNA.",
+    "authors": "Lago, H., Parrott, A. M., Moss, T., Stonehouse, N. J., & Stockley, P. G.",
+    "journal": "Journal of molecular biology, 305(5), 1131–1144. (2001).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "15496523",
+    "title": "The crystal structure of a high affinity RNA stem-loop complexed with the bacteriophage MS2 capsid: further challenges in the modeling of ligand-RNA interactions..",
+    "authors": "Horn, W. T., Convery, M. A., Stonehouse, N. J., Adams, C. J., Liljas, L., Phillips, S. E., & Stockley, P. G.",
+    "journal": "RNA (New York, N.Y.), 10(11), 1776–1782. (2004).",
+    "source_file": "_posts/bacteriophage-MS2-coat-protein-aptamer.md"
+  },
+  {
+    "pmid": "10212256",
+    "title": "DNA aptamers selected against the HIV-1 trans-activation-responsive RNA element form RNA-DNA kissing complexes.",
+    "authors": "Boiziau, C., Dausse, E., Yurchenko, L., & Toulmé, J. J.",
+    "journal": "J Biol Chem, 274(18), 12730-7. (1999)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "10606271",
+    "title": "In vitro selection identifies key determinants for loop-loop interactions: RNA aptamers selective for the TAR RNA element of HIV-1.",
+    "authors": "Ducongé F., & Toulmé, J. J.",
+    "journal": "RNA, 5(12), 1605-14. (1999)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "10954609",
+    "title": "NMR characterization of a kissing complex formed between the TAR RNA element of HIV-1 and a DNA aptamer.",
+    "authors": "Collin, D., van Heijenoort, C., Boiziau, C., Toulmé, J. J., & Guittet, E.",
+    "journal": "Nucleic Acids Res, 28(17), 3386–3391. (2000)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "12052182",
+    "title": "Driving in vitro selection of anti-HIV-1 TAR aptamers by magnesium concentration and temperature.",
+    "authors": "Darfeuille, F., Sekkai, D., Dausse, E., Kolb, G., Yurchenko, L., Boiziau, C., & Toulmé, J. J.",
+    "journal": "Comb Chem High Throughput Screen, 5(4), 313-25. (2002)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "12853646",
+    "title": "Molecular dynamics reveals the stabilizing role of loop closing residues in kissing interactions: comparison between TAR-TAR* and TAR-aptamer.",
+    "authors": "Beaurain, F., Di Primo, C., Toulmé, J. J., & Laguerre, M.",
+    "journal": "Nucleic Acids Res, 31(14), 4275-84. (2003)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "15181175",
+    "title": "LNA/DNA chimeric oligomers mimic RNA aptamers targeted to the TAR RNA element of HIV-1.",
+    "authors": "Darfeuille, F., Hansen, J. B., Orum, H., Di Primo, C., & Toulmé, J. J.",
+    "journal": "Nucleic Acids Res, 32(10), 3101–3107. (2004)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "15723535",
+    "title": "Hexitol nucleic acid-containing aptamers are efficient ligands of HIV-1 TAR RNA.",
+    "authors": "Kolb, G., Reigadas, S., Boiziau, C., van Aerschot, A., Arzumanov, A., Gait, M. J., Herdewijn, P., & Toulmé, J. J.",
+    "journal": "Biochemistry, 44(8), 2926-33. (2005)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "16445294",
+    "title": "Bimodal loop-loop interactions increase the affinity of RNA aptamers for HIV-1 RNA structures.",
+    "authors": "Boucard, D., Toulmé, J. J., & Di Primo, C.",
+    "journal": "Biochemistry, 45(5), 1518-24. (2006)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "17312962",
+    "title": "SELEX and dynamic combinatorial chemistry interplay for the selection of conjugated RNA aptamers.",
+    "authors": "Bugaut, A., Toulmé, J. J., & Rayner, B.",
+    "journal": "Org Biomol Chem, 4(22), 4082-8. (2006)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "17768146",
+    "title": "NMR structure of a kissing complex formed between the TAR RNA element of HIV-1 and a LNA-modified aptamer.",
+    "authors": "Lebars, I., Richard, T., Di Primo, C., & Toulmé, J. J.",
+    "journal": "Nucleic Acids Res, 35(18), 6103-14. (2007)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "18996893",
+    "title": "Exploring TAR–RNA aptamer loop–loop interaction by X-ray crystallography, UV spectroscopy and surface plasmon resonance.",
+    "authors": "Lebars, I., Legrand, P., Aimé, A., Pinaud, N., Fribourg, S., & Di Primo, C.",
+    "journal": "Nucleic Acids Res, 36(22), 7146-56. (2008)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "19496624",
+    "title": "In vitro selection of RNA aptamers derived from a genomic human library against the TAR RNA element of HIV-1.",
+    "authors": "Watrin, M., Von Pelchrzim, F., Dausse, E., Schroeder, R., & Toulmé, J. J.",
+    "journal": "Biochemistry, 48(26), 6278-84. (2009)",
+    "source_file": "_posts/HIV-1-TAR-RNA-aptamer.md"
+  },
+  {
+    "pmid": "27648925",
+    "title": "Targeting Insulin Receptor with a Novel Internalizing Aptamer.",
+    "authors": "Iaboni, M., Fontanella, R., Rienzo, A., Capuozzo, M., Nuzzo, S., Santamaria, G., Catuogno, S., Condorelli, G., de Franciscis, V., & Esposito, C. L.",
+    "journal": "Molecular therapy. Nucleic acids, 5(9), e365. (2016)",
+    "source_file": "_posts/GL56-aptamer.md"
+  },
+  {
+    "pmid": "9192624",
+    "title": "In vitro and in vivo characterization of novel mRNA motifs that bind special elongation factor SelB.",
+    "authors": "Klug, S. J., Hüttenhofer, A., Kromayer, M., & Famulok, M.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 94(13), 6676–6681. (1997)",
+    "source_file": "_posts/Elongation-factor-SelB-aptamer.md"
+  },
+  {
+    "pmid": "10496219",
+    "title": "In vitro selection of RNA aptamers that bind special elongation factor SelB, a protein with multiple RNA-binding sites, reveals one major interaction domain at the carboxyl terminus.",
+    "authors": "Klug, S. J., Hüttenhofer, A., & Famulok, M.",
+    "journal": "RNA (New York, N.Y.), 5(9), 1180–1190. (1999)",
+    "source_file": "_posts/Elongation-factor-SelB-aptamer.md"
+  },
+  {
+    "pmid": "8532517",
+    "title": "Structural probing and damage selection of citrulline- and arginine-specific RNA aptamers identify base positions required for binding.",
+    "authors": "P Burgstaller, M Kochoyan, M Famulok",
+    "journal": "Nucleic acids research. 1995 Dec 11;23(23):4769-76. (1995)",
+    "source_file": "_posts/Arginine-aptamer.md"
+  },
+  {
+    "pmid": "8604334",
+    "title": "RNA aptamers that bind L-arginine with sub-micromolar dissociation constants and high enantioselectivity.",
+    "authors": "A Geiger, P Burgstaller, H von der Eltz, A Roeder, M Famulok",
+    "journal": "Nucleic acids research. 1996 Mar 15;24(6):1029-36. (1996)",
+    "source_file": "_posts/Arginine-aptamer.md"
+  },
+  {
+    "pmid": "8650546",
+    "title": "Structural basis of ligand discrimination by two related RNA aptamers resolved by NMR spectroscopy.",
+    "authors": "Y Yang, M Kochoyan, P Burgstaller, E Westhof, M Famulok",
+    "journal": "Science. 1996 May 31;272(5266):1343-7. (1996)",
+    "source_file": "_posts/Arginine-aptamer.md"
+  },
+  {
+    "pmid": "9631062",
+    "title": "Mirror-design of L-oligonucleotide ligands binding to L-arginine.",
+    "authors": "A Nolte, S Klussmann, R Bald, V A Erdmann, J P Fürste",
+    "journal": "Nature biotechnology. 1996 Sep;14(9):1116-9. (1996)",
+    "source_file": "_posts/Arginine-aptamer.md"
+  },
+  {
+    "pmid": "15801729",
+    "title": "Chiral stationary phase based on a biostable L-RNA aptamer.",
+    "authors": "Agnès Brumbt, Corinne Ravelet, Catherine Grosset, Anne Ravel, Annick Villet, Eric Peyrin",
+    "journal": "Analytical chemistry. 2005 Apr 1;77(7):1993-8. (2005)",
+    "source_file": "_posts/Arginine-aptamer.md"
+  },
+  {
+    "pmid": "12692304",
+    "title": "Inhibition of rat corneal angiogenesis by a nuclease-resistant RNA aptamer specific for angiopoietin-2.",
+    "authors": "White, R. R., Shan, S., Rusconi, C. P., Shetty, G., Dewhirst, M. W., Kontos, C. D., & Sullenger, B. A.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 100(9), 5028–5033. (2003)",
+    "source_file": "_posts/Angiopoietin-2-aptamer.md"
+  },
+  {
+    "pmid": "31548726",
+    "title": "Visualizing RNA dynamics in live cells with bright and stable fluorescent RNAs.",
+    "authors": "Chen, X., Zhang, D., Su, N., Bao, B., Xie, X., Zuo, F., Yang, L., Wang, H., Jiang, L., Lin, Q., Fang, M., Li, N., Hua, X., Chen, Z., Bao, C., Xu, J., Du, W., Zhang, L., Zhao, Y., Zhu, L., Loscalzo, J., Yang, Y. Zhao, Y., Zhu, L., Loscalzo, J., Yang, Y.",
+    "journal": "Nature Biotechnology, 37(11) , 1287-1293. (2019)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "34725509",
+    "title": "Structure-based investigation of fluorogenic Pepper aptamer.",
+    "authors": "Huang, K., Chen, X., Li, C., Song, Q., Li, H., Zhu, L., Yang, Y., Ren, A.",
+    "journal": "Nature Chemical Biology, 17(12) , 1289-1295. (2021)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "35759696",
+    "title": "Structural basis for fluorescence activation by Pepper RNA.",
+    "authors": "Rees, H. C., Gogacz, W., Li, N.-S., Koirala, D., Piccirilli, J. A.",
+    "journal": "ACS chemical biology, 17(7) , 1866-1875. (2022)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "35580055",
+    "title": "Inert Pepper aptamer-mediated endogenous mRNA recognition and imaging in living cells.",
+    "authors": "Wang, Q., Xiao, F., Su, H., Liu, H., Xu, J., Tang, H., Qin, S., Fang, Z., Lu, Z., Wu, J., Weng, X., Zhou, X.",
+    "journal": "Nucleic Acids Research, 50(14) , e84. (2022)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "35921263",
+    "title": "Implementation of a novel optogenetic tool in mammalian cells based on a split t7 RNA polymerase.",
+    "authors": "Dionisi, S., Piera, K., Baumschlager, A., Khammash, M.",
+    "journal": "ACS synthetic biology, 11(8) , 2650-2661. (2022)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "37192858",
+    "title": "Multi-color RNA imaging with CRISPR-Cas13b systems in living cells.",
+    "authors": "Yang, L.-Z., Gao, B.-Q., Huang, Y., Wang, Y., Yang, L., Chen, L.-L.",
+    "journal": "Cell Insight, 1(4) , 100044. (2022)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "36999628",
+    "title": "RNA origami scaffolds facilitate cryo-EM characterization of a Broccoli-Pepper aptamer FRET pair.",
+    "authors": "Sampedro Vallina, N., McRae, E. K. S., Hansen, B. K., Boussebayle, A., Andersen, E. S.",
+    "journal": "Nucleic Acids Research, 51(9) , 4613-4624. (2023)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "37236014",
+    "title": "Imaging intracellular metabolite and protein changes in live mammalian cells with bright fluorescent RNA-based genetically encoded sensors.",
+    "authors": "Fang, M., Li, H., Xie, X., Wang, H., Jiang, Y., Li, T., Zhang, B., Jiang, X., Cao, Y., Zhang, R., Zhang, D., Zhao, Y., Zhu, L., Chen, X., Yang, Y.",
+    "journal": "Biosensors & Bioelectronics, 235 , 115411. (2023)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "37486780",
+    "title": "Genetically encoded RNA-based sensors with Pepper fluorogenic aptamer.",
+    "authors": "Chen, Z., Chen, W., Reheman, Z., Jiang, H., Wu, J., Li, X.",
+    "journal": "Nucleic Acids Research, 51(16) , 8322-8336. (2023)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "38098702",
+    "title": "A universal orthogonal imaging platform for living-cell RNA detection using fluorogenic RNA aptamers.",
+    "authors": "Yin, P., Ge, M., Xie, S., Zhang, L., Kuang, S., Nie, Z.",
+    "journal": "Chemical Science, 14(48) , 14131-14139. (2023)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "38105499",
+    "title": "An RNA Methylation-Sensitive AIEgen-Aptamer reporting system for quantitatively evaluating m6A methylase and demethylase activities.",
+    "authors": "Ying, X., Huang, C., Li, T., Li, T., Gao, M., Wang, F., Cao, J., Liu, J.",
+    "journal": "ACS chemical biology, 19(1) , 162-172. (2024)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "38295291",
+    "title": "Optimization of RNA Pepper sensors for the detection of arbitrary RNA targets.",
+    "authors": "Tang, A. A., Afasizheva, A., Cano, C. T., Plath, K., Black, D., Franco, E.",
+    "journal": "ACS synthetic biology, 13(2) , 498-508. (2024)",
+    "source_file": "_posts/Pepper-aptamer.md"
+  },
+  {
+    "pmid": "28644615",
+    "title": "Fluoromodules consisting of a promiscuous RNA aptamer and red or blue fluorogenic cyanine dyes: Selection, characterization, and bioimaging.",
+    "authors": "Tan, X., Constantin, T. P., Sloane, K. L., Waggoner, A. S., Bruchez, M. P., & Armitage, B. A.",
+    "journal": "Journal of the American Chemical Society, 139(26), 9001–9009. (2017)",
+    "source_file": "_posts/DIR2s-apt-aptamer.md"
+  },
+  {
+    "pmid": "30382099",
+    "title": "Structural basis for activation of fluorogenic dyes by an RNA aptamer lacking a G-quadruplex motif.",
+    "authors": "Shelke, S. A., Shao, Y., Laski, A., Koirala, D., Weissman, B. P., Fuller, J. R., Tan, X., Constantin, T. P., Waggoner, A. S., Bruchez, M. P., Armitage, B. A., & Piccirilli, J. A.",
+    "journal": "Nature communications, 9(1), 4542. (2018)",
+    "source_file": "_posts/DIR2s-apt-aptamer.md"
+  },
+  {
+    "pmid": "22943666",
+    "title": "Inhibition of Hirame rhabdovirus growth by RNA aptamers.",
+    "authors": "Hwang, S. D., Midorikawa, N., Punnarak, P., Kikuchi, Y., Kondo, H., Hirono, I., & Aoki, T.",
+    "journal": "Journal of fish diseases, 35(12), 927–934. (2012)",
+    "source_file": "_posts/HIRRV-aptamer.md"
+  },
+  {
+    "pmid": "9603938",
+    "title": "RNA molecules that bind to and inhibit the active site of a tyrosine phosphatase.",
+    "authors": "Bell, S. D., Denu, J. M., Dixon, J. E., & Ellington, A. D.",
+    "journal": "The Journal of biological chemistry, 273(23), 14309–14314. (1998)",
+    "source_file": "_posts/Protein-tyrosine-phosphatases-aptamer.md"
+  },
+  {
+    "pmid": "10449422",
+    "title": "tRNA prefers to kiss.",
+    "authors": "Scarabino, D., Crisari, A., Lorenzini, S., Williams, K., & Tocchini-Valentini, G. P.",
+    "journal": "The EMBO journal, 18(16), 4571–4578. (1999)",
+    "source_file": "_posts/tRNA-aptamer.md"
+  },
+  {
+    "pmid": "9883908",
+    "title": "RNA aptamers that specifically bind to the Ras-binding domain of Raf-1.",
+    "authors": "Kimoto, M., Sakamoto, K., Shirouzu, M., Hirao, I., & Yokoyama, S.",
+    "journal": "FEBS letters, 441(2), 322–326. (1998)",
+    "source_file": "_posts/Raf-1-aptamer.md"
+  },
+  {
+    "pmid": "3893430",
+    "title": "new form of amyloid protein associated with chronic hemodialysis was identified as beta 2-microglobulin.",
+    "authors": "Gejyo, F., Yamada, T., Odani, S., Nakagawa, Y., Arakawa, M., Kunitomo, T., Kataoka, H., Suzuki, M., Hirasawa, Y., & Shirahama, T.",
+    "journal": "Biochemical and biophysical research communications, 129(3), 701–706. (1985)",
+    "source_file": "_posts/WL-2-aptamer.md"
+  },
+  {
+    "pmid": "2871446",
+    "title": "Beta 2-microglobulin-associated amyloidosis in chronic haemodialysis patients.",
+    "authors": "Chanard, J., Lavaud, S., Toupance, O., Melin, J. P., Gillery, P., & Revillard, J. P.",
+    "journal": "Lancet (London, England), 1(8491), 1212. (1986)",
+    "source_file": "_posts/WL-2-aptamer.md"
+  },
+  {
+    "pmid": "9356260",
+    "title": "Common core structure of amyloid fibrils by synchrotron X-ray diffraction.",
+    "authors": "Sunde, M., Serpell, L. C., Bartlam, M., Fraser, P. E., Pepys, M. B., & Blake, C. C.",
+    "journal": "Journal of molecular biology, 273(3), 729–739.  (1997)",
+    "source_file": "_posts/WL-2-aptamer.md"
+  },
+  {
+    "pmid": "11818542",
+    "title": "Conformational Abs recognizing a generic amyloid fibril epitope.",
+    "authors": "O'Nuallain, B., & Wetzel, R.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 99(3), 1485–1490. (2002)",
+    "source_file": "_posts/WL-2-aptamer.md"
+  },
+  {
+    "pmid": "11820803",
+    "title": "Selection of RNA aptamers to the Alzheimer's disease amyloid peptide.",
+    "authors": "Ylera, F., Lurz, R., Erdmann, V. A., & Fürste, J. P.",
+    "journal": "Biochemical and biophysical research communications, 290(5), 1583–1588. (2002)",
+    "source_file": "_posts/WL-2-aptamer.md"
+  },
+  {
+    "pmid": "17878167",
+    "title": "Production and characterization of RNA aptamers specific for amyloid fibril epitopes.",
+    "authors": "Bunka, D. H., Mantle, B. J., Morten, I. J., Tennent, G. A., Radford, S. E., & Stockley, P. G.",
+    "journal": "The Journal of biological chemistry, 282(47), 34500–34509. (2007)",
+    "source_file": "_posts/WL-2-aptamer.md"
+  },
+  {
+    "pmid": "15277685",
+    "title": "Discriminatory aptamer reveals serum response element transcription regulated by cytohesin-2.",
+    "authors": "Theis MG, Knorre A, Kellersch B, Moelleken J, Wieland F, Kolanus W, Famulok M.",
+    "journal": "Proc Natl Acad Sci U S A. 101(31):11221-6. (2004)",
+    "source_file": "_posts/Cytohesin-2-aptamer.md"
+  },
+  {
+    "pmid": "19854646",
+    "title": "From selection to caged aptamers: identification of light-dependent ssDNA aptamers targeting cytohesin.",
+    "authors": "Mayer G, Lohberger A, Butzen S, Pofahl M, Blind M, Heckel A.",
+    "journal": "Bioorg Med Chem Lett. 19(23):6561-4. (2009)",
+    "source_file": "_posts/Cytohesin-2-aptamer.md"
+  },
+  {
+    "pmid": "23757206",
+    "title": "RNA-aptamers that modulate the RhoGEF activity of Tiam1.",
+    "authors": "Niebel B, Wosnitza CI, Famulok M.",
+    "journal": "Bioorg Med Chem. 21(20):6239-46. (2013)",
+    "source_file": "_posts/Cytohesin-2-aptamer.md"
+  },
+  {
+    "pmid": "8650187",
+    "title": "Calcium-dependent oligonucleotide antagonists specific for L-selectin.",
+    "authors": "O'Connell, D., Koenig, A., Jennings, S., Hicke, B., Han, H. L., Fitzwater, T., Chang, Y. F., Varki, N., Parma, D., & Varki, A.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 93(12), 5883–5887. (1996)",
+    "source_file": "_posts/L-selectin-aptamer.md"
+  },
+  {
+    "pmid": "8504070",
+    "title": "Three small ribooligonucleotides with specific arginine sites.",
+    "authors": "Connell, G. J., Illangesekare, M., & Yarus, M.",
+    "journal": "Biochemistry, 32(21), 5497–5502. (1993)",
+    "source_file": "_posts/PSMA-aptamer.md"
+  },
+  {
+    "pmid": "12124337",
+    "title": "Identification and characterization of nuclease-stabilized RNA molecules that bind human prostate cancer cells via the prostate-specific membrane antigen.",
+    "authors": "Lupold, S. E., Hicke, B. J., Lin, Y., & Coffey, D. S.",
+    "journal": "Cancer research, 62(14), 4029–4033. (2002)",
+    "source_file": "_posts/PSMA-aptamer.md"
+  },
+  {
+    "pmid": "16740739",
+    "title": "Aptamer mediated siRNA delivery.",
+    "authors": "Chu, T. C., Twu, K. Y., Ellington, A. D., & Levy, M.",
+    "journal": "Nucleic acids research, 34(10), e73. (2006)",
+    "source_file": "_posts/PSMA-aptamer.md"
+  },
+  {
+    "pmid": "20550178",
+    "title": "A drug-loaded aptamer-gold nanoparticle bioconjugate for combined CT imaging and therapy of prostate cancer.",
+    "authors": "Kim, D., Jeong, Y. Y., & Jon, S.",
+    "journal": "ACS nano, 4(7), 3689–3696. (2010)",
+    "source_file": "_posts/PSMA-aptamer.md"
+  },
+  {
+    "pmid": "22004414",
+    "title": "Rational truncation of an RNA aptamer to prostate-specific membrane antigen using computational structural modeling.",
+    "authors": "Rockey, W. M., Hernandez, F. J., Huang, S. Y., Cao, S., Howell, C. A., Thomas, G. S., Liu, X. Y., Lapteva, N., Spencer, D. M., McNamara, J. O., Zou, X., Chen, S. J., & Giangrande, P. H.",
+    "journal": "Nucleic acid therapeutics, 21(5), 299–314. (2011)",
+    "source_file": "_posts/PSMA-aptamer.md"
+  },
+  {
+    "pmid": "25450401",
+    "title": "RNA aptamer-conjugated liposome as an efficient anticancer drug delivery vehicle targeting cancer cells in vivo.",
+    "authors": "Baek, S. E., Lee, K. H., Park, Y. S., Oh, D. K., Oh, S., Kim, K. S., & Kim, D. E.",
+    "journal": "Journal of controlled release : official journal of the Controlled Release Society, 196, 234–242. (2014)",
+    "source_file": "_posts/PSMA-aptamer.md"
+  },
+  {
+    "pmid": "32525981",
+    "title": "Structural basis of prostate-specific membrane antigen recognition by the A9g RNA aptamer.",
+    "authors": "Ptacek, J., Zhang, D., Qiu, L., Kruspe, S., Motlova, L., Kolenko, P., Novakova, Z., Shubham, S., Havlinova, B., Baranova, P., Chen, S. J., Zou, X., Giangrande, P., & Barinka, C.",
+    "journal": "Nucleic acids research, 48(19), 11130–11145. (2020)",
+    "source_file": "_posts/PSMA-aptamer.md"
+  },
+  {
+    "pmid": "11756401",
+    "title": "A Y2 receptor mimetic aptamer directed against neuropeptide Y.",
+    "authors": "Proske D, Höfliger M, Söll RM, Beck-Sickinger AG, Famulok M",
+    "journal": "The Journal of biological chemistry. 2002 Mar 29;277(13):11416-22. (2002)",
+    "source_file": "_posts/DP3-aptamer.md"
+  },
+  {
+    "pmid": "15984861",
+    "title": "In vitro selection of aptamers with affinity for neuropeptide Y using capillary electrophoresis.",
+    "authors": "Mendonsa SD, Bowser MT",
+    "journal": "Journal of the American Chemical Society. 2005 Jul 6;127(26):9382-3. (2005)",
+    "source_file": "_posts/DP3-aptamer.md"
+  },
+  {
+    "pmid": "33297678",
+    "title": "Measurement of Neuropeptide Y Using Aptamer-Modified Microelectrodes by Electrochemical Impedance Spectroscopy.",
+    "authors": "López L, Hernández N, Reyes Morales J, Cruz J, Flores K, González-Amoretti J, Rivera V, Cunci L",
+    "journal": "Analytical chemistry. 2021 Jan 19;93(2):973-980. (2021)",
+    "source_file": "_posts/DP3-aptamer.md"
+  },
+  {
+    "pmid": "38033269",
+    "title": "Development of an Electrochemical, Aptamer-Based Sensor for Dynamic Detection of Neuropeptide Y.",
+    "authors": "Seibold JM, Abeykoon SW, Ross AE, White RJ",
+    "journal": "ACS sensors. 2023 Dec 22;8(12):4504-4511. (2023)",
+    "source_file": "_posts/DP3-aptamer.md"
+  },
+  {
+    "pmid": "38709872",
+    "title": "Development of a Neuropeptide Y-Sensitive Implantable Microelectrode for Continuous Measurements.",
+    "authors": "Fernández-Vega L, Meléndez-Rodríguez DE, Ospina-Alejandro M, Casanova K, Vázquez Y, Cunci L",
+    "journal": "ACS sensors. 2024 May 24;9(5):2645-2652. (2024)",
+    "source_file": "_posts/DP3-aptamer.md"
+  },
+  {
+    "pmid": "9436913",
+    "title": "In vitro selection and characterization of streptomycin-binding RNAs: recognition discrimination between antibiotics.",
+    "authors": "Wallace, S. T., & Schroeder, R.",
+    "journal": "RNA (New York, N.Y.), 4(1), 112–123. (1998)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "12618190",
+    "title": "Encapsulating streptomycin within a small 40-mer RNA.",
+    "authors": "Tereshko, V., Skripkin, E., & Patel, D. J.",
+    "journal": "Chemistry & biology, 10(2), 175–187. (2003)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "16621675",
+    "title": "Aptamer therapeutics advance.",
+    "authors": "Lee, J. F., Stovall, G. M., & Ellington, A. D.",
+    "journal": "Current opinion in chemical biology, 10(3), 282–289. (2006)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "17355135",
+    "title": "Modified-RNA aptamer-based sensor for competitive impedimetric assay of neomycin B.",
+    "authors": "de-los-Santos-Alvarez, N., Lobo-Castañón, M. J., Miranda-Ordieres, A. J., & Tuñón-Blanco, P.",
+    "journal": "Journal of the American Chemical Society, 129(13), 3808–3809 (2007)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "18388495",
+    "title": "Isolation of small RNA-binding proteins from E. coli: evidence for frequent interaction of RNAs with RNA polymerase.",
+    "authors": "Windbichler, N., von Pelchrzim, F., Mayer, O., Csaszar, E., & Schroeder, R.",
+    "journal": "RNA biology, 5(1), 30–40. (2008)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "20426747",
+    "title": "Aptamers biosensors for pharmaceutical compounds.",
+    "authors": "Tombelli, S., & Mascini, M.",
+    "journal": "Combinatorial chemistry & high throughput screening, 13(7), 641–649. (2010)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "22173871",
+    "title": "The tuberculosis drug streptomycin as a potential cancer therapeutic: inhibition of miR-21 function by directly targeting its precursor.",
+    "authors": "Bose, D., Jayaraj, G., Suryawanshi, H., Agarwala, P., Pore, S. K., Banerjee, R., & Maiti, S.",
+    "journal": "Angewandte Chemie (International ed. in English), 51(4), 1019–1023. (2012)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "22793869",
+    "title": "Toggled RNA aptamers against aminoglycosides allowing facile detection of antibiotics using gold nanoparticle assays.",
+    "authors": "Derbyshire, N., White, S. J., Bunka, D. H., Song, L., Stead, S., Tarbin, J., Sharman, M., Zhou, D., & Stockley, P. G.",
+    "journal": "Analytical chemistry, 84(15), 6595–6602 (2012)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "23601877",
+    "title": "Selection and identification of streptomycin-specific single-stranded DNA aptamers and the application in the detection of streptomycin in honey.",
+    "authors": "Zhou, N., Wang, J., Zhang, J., Li, C., Tian, Y., & Wang, J.",
+    "journal": "Talanta, 108, 109–116. (2013)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "23192876",
+    "title": "Tombusvirus Y-shaped translational enhancer forms a complex with eIF4F and can be functionally replaced by heterologous translational enhancers.",
+    "authors": "Nicholson, B. L., Zaslaver, O., Mayberry, L. K., Browning, K. S., & White, K. A.",
+    "journal": "Journal of virology, 87(3), 1872–1883. (2013)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "27281393",
+    "title": "Stability of a Split Streptomycin Binding Aptamer.",
+    "authors": "Nick, T. A., de Oliveira, T. E., Pilat, D. W., Spenkuch, F., Butt, H. J., Helm, M., Netz, P. A., & Berger, R.",
+    "journal": "The journal of physical chemistry. B, 120(27), 6479–6489. (2016)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "28965053",
+    "title": "Point-of-care testing for streptomycin based on aptamer recognizing and digital image colorimetry by smartphone.",
+    "authors": "Lin, B., Yu, Y., Cao, Y., Guo, M., Zhu, D., Dai, J., & Zheng, M.",
+    "journal": "Biosensors & bioelectronics, 100, 482–489. (2018)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "31757139",
+    "title": "Single molecule force spectroscopy of a streptomycin-binding RNA aptamer: An out-of-equilibrium molecular dynamics study.",
+    "authors": "Baptista, L. A., & Netz, P. A.",
+    "journal": "The Journal of chemical physics, 151(19), 195102. (2019)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "35297324",
+    "title": "Three-dimensional modeling of streptomycin binding single-stranded DNA for aptamer-based biosensors, a molecular dynamics simulation approach.",
+    "authors": "Nosrati, M., & Roushani, M.",
+    "journal": "Journal of biomolecular structure & dynamics, 41(8), 3430–3439. (2023)",
+    "source_file": "_posts/Streptomycin-aptamer.md"
+  },
+  {
+    "pmid": "12649492",
+    "title": "RNA aptamers to initiation factor 4A helicase hinder cap-dependent translation by blocking ATP hydrolysis.",
+    "authors": "Oguro A, Ohtsu T, Svitkin YV, Sonenberg N, Nakamura Y.",
+    "journal": "RNA. 9(4):394-407. (2003)",
+    "source_file": "_posts/No.21-aptamer.md"
+  },
+  {
+    "pmid": "16940549",
+    "title": "RNA aptamers to mammalian initiation factor 4G inhibit cap-dependent translation by blocking the formation of initiation factor complexes.",
+    "authors": "Miyakawa S, Oguro A, Ohtsu T, Imataka H, Sonenberg N, Nakamura Y.",
+    "journal": "RNA. 12(10):1825-34. (2006)",
+    "source_file": "_posts/No.21-aptamer.md"
+  },
+  {
+    "pmid": "28945233",
+    "title": "Imaging RNA polymerase III transcription using a photostable RNA-fluorophore complex.",
+    "authors": "Song, W., Filonov, G. S., Kim, H., Hirsch, M., Li, X., Moon, J. D., & Jaffrey, S. R.",
+    "journal": "Nature chemical biology, 13(11), 1187–1194. (2017)",
+    "source_file": "_posts/Beetroot-aptamer.md"
+  },
+  {
+    "pmid": "31178406",
+    "title": "Binding between G quadruplexes at the homodimer interface of the corn RNA aptamer strongly activates thioflavin T fluorescence.",
+    "authors": "Sjekloća, L., & Ferré-D'Amaré, A. R.",
+    "journal": "Cell chemical biology, 26(8), 1159–1168.e4. (2019)",
+    "source_file": "_posts/Beetroot-aptamer.md"
+  },
+  {
+    "pmid": "35294188",
+    "title": "Self-assembly of intracellular multivalent RNA complexes using dimeric Corn and Beetroot Aptamers.",
+    "authors": "Wu, J., Svensen, N., Song, W., Kim, H., Zhang, S., Li, X., & Jaffrey, S. R.",
+    "journal": "Journal of the American Chemical Society, 144(12), 5471–5477. (2022)",
+    "source_file": "_posts/Beetroot-aptamer.md"
+  },
+  {
+    "pmid": "37221204",
+    "title": "Co-crystal structures of the fluorogenic aptamer Beetroot show that close homology may not predict similar RNA architecture.",
+    "authors": "Passalacqua, L. F. M., Starich, M. R., Link, K. A., Wu, J., Knutson, J. R., Tjandra, N., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature communications, 14(1), 2969. (2023)",
+    "source_file": "_posts/Beetroot-aptamer.md"
+  },
+  {
+    "pmid": "12054450",
+    "title": "Generation of RNA aptamers to the G-protein-coupled receptor for neurotensin, NTS-1.",
+    "authors": "Daniels, D. A., Sohal, A. K., Rees, S., & Grisshammer, R.",
+    "journal": "Analytical biochemistry, 305(2), 214–226. (2002)",
+    "source_file": "_posts/Neurotensin-receptor-NTS-1-aptamer.md"
+  },
+  {
+    "pmid": "6375662",
+    "title": "Alzheimer’s disease: initial report of the purification and characterization of a novel cerebrovascular amyloid protein.",
+    "authors": "Glennera, G. G., & Wong, C. W.",
+    "journal": "Biochemical and biophysical research communications, 120(3), 885–890.  (1984)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "3159021",
+    "title": "Amyloid plaque core protein in Alzheimer disease and Down syndrome.",
+    "authors": "Masters, C. L., Simms, G., Weinman, N. A., Multhaup, G., McDonald, B. L., & Beyreuther, K.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 82(12), 4245–4249. (1985)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "9190286",
+    "title": "Observation of metastable Aβ amyloid protofibrils by atomic force microscopy.",
+    "authors": "Harper, J. D., Wong, S. S., Lieber, C. M., & Lansbury, P. T.",
+    "journal": "Chemistry & biology, 4(2), 119–125. (1997)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "9268388",
+    "title": "Amyloid beta-protein fibrillogenesis. Detection of a protofibrillar intermediate.",
+    "authors": "Walsh, D. M., Lomakin, A., Benedek, G. B., Condron, M. M., & Teplow, D. B.",
+    "journal": "The Journal of biological chemistry, 272(35), 22364–22372. (1997)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "9600986",
+    "title": "Diffusible, nonfibrillar ligands derived from Abeta1-42 are potent central nervous system neurotoxins.",
+    "authors": "Lambert, M. P., Barlow, A. K., Chromy, B. A., Edwards, C., Freed, R., Liosatos, M., Morgan, T. E., Rozovsky, I., Trommer, B., Viola, K. L., Wals, P., Zhang, C., Finch, C. E., Krafft, G. A., & Klein, W. L.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 95(11), 6448–6453. (1998)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "11820803",
+    "title": "Selection of RNA aptamers to the Alzheimer's disease amyloid peptide.",
+    "authors": "Ylera, F., Lurz, R., Erdmann, V. A., & Fürste, J. P.",
+    "journal": "Biochemical and biophysical research communications, 290(5), 1583–1588.  (2002)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "12750461",
+    "title": "Spherical aggregates of beta-amyloid (amylospheroid) show high neurotoxicity and activate tau protein kinase I/glycogen synthase kinase-3beta.",
+    "authors": "Hoshi, M., Sato, M., Matsumoto, S., Noguchi, A., Yasutake, K., Yoshida, N., & Sato, K.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 100(11), 6370–6375. (2003)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "17245412",
+    "title": "Soluble protein oligomers in neurodegeneration: lessons from the Alzheimer's amyloid beta-peptide.",
+    "authors": "Haass, C., & Selkoe, D. J.",
+    "journal": "Nature reviews. Molecular cell biology, 8(2), 101–112. (2007)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "18845536",
+    "title": "Amyloid β-protein assembly and Alzheimer disease.",
+    "authors": "Roychaudhuri, R., Yang, M., Hoshi, M. M., & Teplow, D. B.",
+    "journal": "The Journal of biological chemistry, 284(8), 4749–4753. (2009)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "27162352",
+    "title": "High-speed atomic force microscopy reveals structural dynamics of amyloid β1-42 aggregates.",
+    "authors": "Watanabe-Nakayama, T., Ono, K., Itami, M., Takahashi, R., Teplow, D. B., & Yamada, M.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 113(21), 5835–5840. (2016)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "32127399",
+    "title": "An RNA aptamer with potent affinity for a toxic dimer of amyloid β42 has potential utility for histochemical studies of Alzheimer's disease.",
+    "authors": "Murakami, K., Obata, Y., Sekikawa, A., Ueda, H., Izuo, N., Awano, T., Takabe, K., Shimizu, T., & Irie, K.",
+    "journal": "The Journal of biological chemistry, 295(15), 4870–4880.  (2020)",
+    "source_file": "_posts/Aβ42-aptamer.md"
+  },
+  {
+    "pmid": "7489503",
+    "title": "Dissecting protein:protein interactions between transcription factors with an RNA aptamer.",
+    "authors": "Tian, Y., Adya, N., Wagner, S., Giam, C. Z., Green, M. R., & Ellington, A. D.",
+    "journal": "RNA (New York, N.Y.), 1(3), 317–326.  (1995)",
+    "source_file": "_posts/YT1-aptamer.md"
+  },
+  {
+    "pmid": "20445260",
+    "title": "Expression, crystallization and preliminary crystallographic analysis of RNA-binding protein Hfq (YmaH) from Bacillus subtilis in complex with an RNA.",
+    "authors": "Baba, S., Someya, T., Kawai, G., Nakamura, K., & Kumasaka, T.",
+    "journal": "Acta crystallographica. Section F, Structural biology and crystallization communications, 66(Pt 5), 563–566. (2010)",
+    "source_file": "_posts/Hfq-aptamer.md"
+  },
+  {
+    "pmid": "22053080",
+    "title": "Crystal structure of Hfq from Bacillus subtilis in complex with SELEX-derived RNA aptamer: insight into RNA-binding properties of bacterial Hfq.",
+    "authors": "Someya, T., Baba, S., Fujimoto, M., Kawai, G., Kumasaka, T., & Nakamura, K.",
+    "journal": "Nucleic acids research, 40(4), 1856-1867. (2012)",
+    "source_file": "_posts/Hfq-aptamer.md"
+  },
+  {
+    "pmid": "22965117",
+    "title": "Structural mechanism of Staphylococcus aureus Hfq binding to an RNA A-tract.",
+    "authors": "Horstmann, N., Orans, J., Valentin-Hansen, P., Shelburne, S. A., 3rd, & Brennan, R. G.",
+    "journal": "Nucleic acids research, 40(21), 11023–11035. (2012)",
+    "source_file": "_posts/Hfq-aptamer.md"
+  },
+  {
+    "pmid": "24828406",
+    "title": "RNA binding by Hfq and ring-forming (L)Sm proteins: a trade-off between optimal sequence readout and RNA backbone conformation.",
+    "authors": "Weichenrieder O.",
+    "journal": "RNA biology, 11(5), 537–549. (2014)",
+    "source_file": "_posts/Hfq-aptamer.md"
+  },
+  {
+    "pmid": "37942477",
+    "title": "Models of Hfq interactions with small non-coding RNA in Gram-negative and Gram-positive bacteria.",
+    "authors": "Watkins, D., & Arya, D.",
+    "journal": "Frontiers in cellular and infection microbiology, 13, 1282258. (2023)",
+    "source_file": "_posts/Hfq-aptamer.md"
+  },
+  {
+    "pmid": "3930479",
+    "title": "Endothelial cells produce a latent inhibitor of plasminogen activators that can be activated by denaturants.",
+    "authors": "Hekman, C. M., & Loskutoff, D. J.",
+    "journal": "The Journal of biological chemistry, 260(21), 11581–11587. (1985)",
+    "source_file": "_posts/PAI-1-aptamer.md"
+  },
+  {
+    "pmid": "2459123",
+    "title": "Purification and characterization of a plasminogen activator inhibitor 1 binding protein from human plasma. Identification as a multimeric form of S protein (vitronectin).",
+    "authors": "Declerck, P. J., De Mol, M., Alessi, M. C., Baudner, S., Pâques, E. P., Preissner, K. T., Müller-Berghaus, G., & Collen, D.",
+    "journal": "The Journal of biological chemistry, 263(30), 15454–15461. (1988)",
+    "source_file": "_posts/PAI-1-aptamer.md"
+  },
+  {
+    "pmid": "8662688",
+    "title": "Structural and functional analysis of the plasminogen activator inhibitor-1 binding motif in the somatomedin B domain of vitronectin.",
+    "authors": "Deng, G., Royle, G., Wang, S., Crain, K., & Loskutoff, D. J.",
+    "journal": "The Journal of biological chemistry, 271(22), 12716–12723. (1996)",
+    "source_file": "_posts/PAI-1-aptamer.md"
+  },
+  {
+    "pmid": "9168821",
+    "title": "Plasminogen activator inhibitor-1 represses integrin- and vitronectin-mediated cell migration independently of its function as an inhibitor of plasminogen activation.",
+    "authors": "Kjøller, L., Kanse, S. M., Kirkegaard, T., Rodenburg, K. W., Rønne, E., Goodman, S. L., Preissner, K. T., Ossowski, L., & Andreasen, P. A.",
+    "journal": "Experimental cell research, 232(2), 420–429. (1997)",
+    "source_file": "_posts/PAI-1-aptamer.md"
+  },
+  {
+    "pmid": "15138609",
+    "title": "Plasminogen activator inhibitor type-1: its structure, biological activity and role in tumorigenesis (Review).",
+    "authors": "Chorostowska-Wynimko, J., Skrzypczak-Jankun, E., & Jankun, J.",
+    "journal": "International journal of molecular medicine, 13(6), 759–766. (2004)",
+    "source_file": "_posts/PAI-1-aptamer.md"
+  },
+  {
+    "pmid": "19284310",
+    "title": "Antimetastatic potential of PAI-1-specific RNA aptamers.",
+    "authors": "Blake, C. M., Sullenger, B. A., Lawrence, D. A., & Fortenberry, Y. M.",
+    "journal": "Oligonucleotides, 19(2), 117–128. (2009)",
+    "source_file": "_posts/PAI-1-aptamer.md"
+  },
+  {
+    "pmid": "23113766",
+    "title": "Identification and characterization of an agonistic aptamer against the T cell costimulatory receptor, OX40.",
+    "authors": "Pratico, ED., Sullenger, BA., & Nair, SK.",
+    "journal": "Nucleic Acid Therapeutics, 23(1):35-43. (2013)",
+    "source_file": "_posts/OX40-aptamer.md"
+  },
+  {
+    "pmid": "10908352",
+    "title": "RNA aptamers that specifically bind to a 16S ribosomal RNA decoding region construct.",
+    "authors": "Tok, J. B., Cho, J., & Rando, R. R.",
+    "journal": "Nucleic acids research, 28(15), 2902–2910. (2000)",
+    "source_file": "_posts/16S-rRNA-decoding-region-aptamer.md"
+  },
+  {
+    "pmid": "10233958",
+    "title": "Anti-Rex aptamers as mimics of the Rex-binding element.",
+    "authors": "Baskerville, S., Zapp, M., & Ellington, A. D.",
+    "journal": "Journal of virology, 73(6), 4962–4971. (1999)",
+    "source_file": "_posts/Rex-protein-aptamer.md"
+  },
+  {
+    "pmid": "10647177",
+    "title": "Anchoring an extended HTLV-1 Rex peptide within an RNA major groove containing junctional base triples.",
+    "authors": "Jiang, F., Gorin, A., Hu, W., Majumdar, A., Baskerville, S., Xu, W., Ellington, A., & Patel, D. J.",
+    "journal": "Structure (London, England : 1993), 7(12), 1461–1472. (1999)",
+    "source_file": "_posts/Rex-protein-aptamer.md"
+  },
+  {
+    "pmid": "12925996",
+    "title": "Fluorescence-based methods for evaluating the RNA affinity and specificity of HIV-1 Rev-RRE inhibitors.",
+    "authors": "Luedtke, N. W., & Tor, Y.",
+    "journal": "Biopolymers, 70(1), 103–119. (2003)",
+    "source_file": "_posts/Rex-protein-aptamer.md"
+  },
+  {
+    "pmid": "18351707",
+    "title": "Amino acid requirement for the high affinity binding of a selected arginine-rich peptide with the HIV Rev-response element RNA.",
+    "authors": "Sugaya, M., Nishino, N., Katoh, A., & Harada, K.",
+    "journal": "Journal of peptide science : an official publication of the European Peptide Society, 14(8), 924–935.  (2008)",
+    "source_file": "_posts/Rex-protein-aptamer.md"
+  },
+  {
+    "pmid": "26896646",
+    "title": "Bioavailable inhibitors of HIV-1 RNA biogenesis identified through a Rev-based screen.",
+    "authors": "Prado, S., Beltrán, M., Coiras, M., Bedoya, L. M., Alcamí, J., & Gallego, J.",
+    "journal": "Biochemical pharmacology, 107, 14–28. (2016)",
+    "source_file": "_posts/Rex-protein-aptamer.md"
+  },
+  {
+    "pmid": "18726014",
+    "title": "Transcription monitoring using fused RNA with a dye-binding light-up aptamer as a tag: a blue fluorescent RNA.",
+    "authors": "Sando, S., Narita, A., Hayami, M., & Aoyama, Y.",
+    "journal": "Chemical communications, (33), 3858–3860. (2008)",
+    "source_file": "_posts/II-mini3-4-aptamer.md"
+  },
+  {
+    "pmid": "17038331",
+    "title": "Codeine-binding RNA aptamers and rapid determination of their binding constants using a direct coupling surface plasmon resonance assay.",
+    "authors": "Win, M. N., Klein, J. S., & Smolke, C. D.",
+    "journal": "Nucleic acids research, 34(19), 5670–5682. (2006)",
+    "source_file": "_posts/Codeine-aptamer.md"
+  },
+  {
+    "pmid": "23678405",
+    "title": "Aptamer-based Nanosensors: Juglone as an Attached-Redox Molecule for Detection of Small Molecules.",
+    "authors": "Saberian, M., Hamzeiy, H., Aghanejad, A., & Asgari, D.",
+    "journal": "BioImpacts : BI, 1(1), 31–36. (2011)",
+    "source_file": "_posts/Codeine-aptamer.md"
+  },
+  {
+    "pmid": "23830440",
+    "title": "A label-free electrochemical biosensor based on a DNA aptamer against codeine.",
+    "authors": "Huang, L., Yang, X., Qi, C., Niu, X., Zhao, C., Zhao, X., Shangguan, D., & Yang, Y.",
+    "journal": "Analytica chimica acta, 787, 203–210. (2013)",
+    "source_file": "_posts/Codeine-aptamer.md"
+  },
+  {
+    "pmid": "27336666",
+    "title": "An aptamer folding-based sensory platform decorated with nanoparticles for simple cocaine testing.",
+    "authors": "Guler, E., Bozokalfa, G., Demir, B., Gumus, Z. P., Guler, B., Aldemir, E., Timur, S., & Coskunol, H.",
+    "journal": "Drug testing and analysis, 9(4), 578–587. (2017)",
+    "source_file": "_posts/Codeine-aptamer.md"
+  },
+  {
+    "pmid": "29133961",
+    "title": "Triplex-quadruplex structural scaffold: a new binding structure of aptamer.",
+    "authors": "Bing, T., Zheng, W., Zhang, X., Shen, L., Liu, X., Wang, F., Cui, J., Cao, Z., & Shangguan, D.",
+    "journal": "Scientific reports, 7(1), 15467. (2017)",
+    "source_file": "_posts/Codeine-aptamer.md"
+  },
+  {
+    "pmid": "24835440",
+    "title": "An RNA aptamer that specifically binds to the glycosylated hemagglutinin of avian influenza virus and suppresses viral infection in cells.",
+    "authors": "Kwon, H. M., Lee, K. H., Han, B. W., Han, M. R., Kim, D. H., & Kim, D. E.",
+    "journal": "PloS one, 9(5), e97574. (2014)",
+    "source_file": "_posts/Hemagglutinin-(HA)-protein-aptamer.md"
+  },
+  {
+    "pmid": "12737819",
+    "title": "Structural basis of the highly efficient trapping of the HIV Tat protein by an RNA aptamer.",
+    "authors": "Matsugami, A., Kobayashi, S., Ouhashi, K., Uesugi, S., Yamamoto, R., Taira, K., Nishikawa, S., Kumar, P. K., & Katahira, M.",
+    "journal": "Structure (London, England : 1993), 11(5), 533–545. (2003)",
+    "source_file": "_posts/HIV-Tat-aptamer.md"
+  },
+  {
+    "pmid": "16027048",
+    "title": "Aptamer-based biosensors for the detection of HIV-1 Tat protein.",
+    "authors": "Tombelli, S., Minunni, M., Luzi, E., & Mascini, M.",
+    "journal": "Bioelectrochemistry (Amsterdam, Netherlands), 67(2), 135–141. (2005)",
+    "source_file": "_posts/HIV-Tat-aptamer.md"
+  },
+  {
+    "pmid": "22975093",
+    "title": "Effects of diamond-FET-based RNA aptamer sensing for detection of real sample of HIV-1 Tat protein.",
+    "authors": "Rahim Ruslinda, A., Tanabe, K., Ibori, S., Wang, X., & Kawarada, H.",
+    "journal": "Biosensors & bioelectronics, 40(1), 277–282. (2013)",
+    "source_file": "_posts/HIV-Tat-aptamer.md"
+  },
+  {
+    "pmid": "31707021",
+    "title": "Spectrophotometric ellipsometry based Tat-protein RNA-aptasensor for HIV-1 diagnosis.",
+    "authors": "Caglayan, M. O., & Üstündağ, Z.",
+    "journal": "Spectrochimica acta. Part A, Molecular and biomolecular spectroscopy, 227, 117748. (2020)",
+    "source_file": "_posts/HIV-Tat-aptamer.md"
+  },
+  {
+    "pmid": "37240414",
+    "title": "Complex Formation of an RNA Aptamer with a Part of HIV-1 Tat through Induction of Base Triples in Living Human Cells Proven by In-Cell NMR.",
+    "authors": "Eladl, O., Yamaoki, Y., Kondo, K., Nagata, T., & Katahira, M.",
+    "journal": "International journal of molecular sciences, 24(10), 9069. (2023)",
+    "source_file": "_posts/HIV-Tat-aptamer.md"
+  },
+  {
+    "pmid": "20729797",
+    "title": "Development of a sphingosylphosphorylcholine detection system using RNA aptamers.",
+    "authors": "Horii, K., Omi, K., Yoshida, Y., Imai, Y., Sakai, N., Oka, A., Masuda, H., Furuichi, M., Tanimoto, T., & Waga, I.",
+    "journal": "Molecules, 15(8):5742-55. (2010)",
+    "source_file": "_posts/SPC-aptamer.md"
+  },
+  {
+    "pmid": "19684916",
+    "title": "RNA aptamer-based sensitive detection of SARS coronavirus nucleocapsid protein.",
+    "authors": "Ahn, D. G., Jeon, I. J., Kim, J. D., Song, M. S., Han, S. R., Lee, S. W., Jung, H., & Oh, J. W.",
+    "journal": "The Analyst, 134(9), 1896–1901. (2009)",
+    "source_file": "_posts/SARS-CoV-N-protein-aptamer.md"
+  },
+  {
+    "pmid": "22166202",
+    "title": "In vitro selection of Escherichia coli O157:H7-specific RNA aptamer.",
+    "authors": "Lee, YJ., Han, SR., Maeng, JS., Cho, YJ., & Lee, SW.",
+    "journal": "Biochemical and Biophysical Research Communications,417(1):414-20. (2012)",
+    "source_file": "_posts/Escherichia-coli-aptamer.md"
+  },
+  {
+    "pmid": "12604126",
+    "title": "The role of a Runt domain transcription factor AML1/RUNX1 in leukemogenesis and its clinical implications.",
+    "authors": "Asou N.",
+    "journal": "Critical reviews in oncology/hematology, 45(2), 129–150. (2003)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "20140822",
+    "title": "AS-1411, a guanosine-rich oligonucleotide aptamer targeting nucleolin for the potential treatment of cancer, including acute myeloid leukemia.",
+    "authors": "Mongelard, F., & Bouvet, P",
+    "journal": "Current opinion in molecular therapeutics, 12(1), 107–114 (2010)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "23997091",
+    "title": "Solution structure of a DNA mimicking motif of an RNA aptamer against transcription factor AML1 Runt domain.",
+    "authors": "Nomura, Y., Tanaka, Y., Fukunaga, J., Fujiwara, K., Chiba, M., Iibuchi, H., Tanaka, T., Nakamura, Y., Kawai, G., Kozu, T., & Sakamoto, T",
+    "journal": "Journal of biochemistry, 154(6), 513–519 (2013)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "26204224",
+    "title": "Oligonucleotide aptamer-drug conjugates for targeted therapy of acute myeloid leukemia.",
+    "authors": "Zhao, N., Pei, S. N., Qi, J., Zeng, Z., Iyer, S. P., Lin, P., Tung, C. H., & Zu, Y",
+    "journal": "Biomaterials, 67, 42–51. (2015)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "27514505",
+    "title": "Coinhibition of overexpressed genes in acute myeloid leukemia subtype M2 by gold nanoparticles functionalized with five antisense oligonucleotides and one anti-CD33(+)/CD34(+) aptamer.",
+    "authors": "Zaimy, M. A., Jebali, A., Bazrafshan, B., Mehrtashfar, S., Shabani, S., Tavakoli, A., Hekmatimoghaddam, S. H., Sarli, A., Azizi, H., Izadi, P., Kazemi, B., Shojaei, A., Abdalaian, A., & Tavakkoly-Bazzaz, J",
+    "journal": "Cancer gene therapy, 23(9), 315–320 (2016)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "27766833",
+    "title": "Kinetic and Thermodynamic Analyses of Interaction between a High-Affinity RNA Aptamer and Its Target Protein.",
+    "authors": "Amano, R., Takada, K., Tanaka, Y., Nakamura, Y., Kawai, G., Kozu, T., & Sakamoto, T",
+    "journal": "Biochemistry, 55(45), 6221–6229 (2016)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "26972431",
+    "title": "Peptide aptamer identified by molecular docking targeting translationally controlled tumor protein in leukemia cells.",
+    "authors": "Kadioglu, O., & Efferth, T",
+    "journal": "Investigational new drugs, 34(4), 515–521 (2016)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "27766833",
+    "title": "Kinetic and Thermodynamic Analyses of Interaction between a High-Affinity RNA Aptamer and Its Target Protein.",
+    "authors": "Amano, R., Takada, K., Tanaka, Y., Nakamura, Y., Kawai, G., Kozu, T., & Sakamoto, T",
+    "journal": "Biochemistry, 55(45), 6221–6229 (2016)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "28845698",
+    "title": "Novel CD123-aptamer-originated targeted drug trains for selectively delivering cytotoxic agent to tumor cells in acute myeloid leukemia theranostics.",
+    "authors": "Wu, H., Wang, M., Dai, B., Zhang, Y., Yang, Y., Li, Q., Duan, M., Zhang, X., Wang, X., Li, A., & Zhang, L",
+    "journal": "Drug delivery, 24(1), 1216–1229 (2017)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "30519686",
+    "title": "Rapid identification of specific DNA aptamers precisely targeting CD33 positive leukemia cells through a paired cell-based approach.",
+    "authors": "Yang, C., , Wang, Y., , Ge, M. H., , Fu, Y. J., , Hao, R., , Islam, K., , Huang, P., , Chen, F., , Sun, J., , Hong, F., , & Naranmandura, H.,",
+    "journal": "Biomaterials science, 7(3), 938–950 (2019)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "31824168",
+    "title": "Nucleic Acid Aptamer: A Novel Potential Diagnostic and Therapeutic Tool for Leukemia.",
+    "authors": "Tan, Y., Li, Y., & Tang, F",
+    "journal": "OncoTargets and therapy, 12, 10597–10613 (2019)",
+    "source_file": "_posts/AML1(RUNX1)-aptamer.md"
+  },
+  {
+    "pmid": "9383458",
+    "title": "A novel RNA motif for neomycin recognition.",
+    "authors": "Wallis, M. G., von Ahsen, U., Schroeder, R., & Famulok, M.",
+    "journal": "Chemistry & biology, 2(8), 543–552 (1995)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "10425683",
+    "title": "Saccharide-RNA recognition in a complex formed between neomycin B and an RNA aptamer.",
+    "authors": "Jiang, L., Majumdar, A., Hu, W., Jaishree, T. J., Xu, W., & Patel, D. J.",
+    "journal": "Structure (London, England : 1993), 7(7), 817–827 (1999)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "10908357",
+    "title": "Recognition of a cognate RNA aptamer by neomycin B: quantitative evaluation of hydrogen bonding and electrostatic interactions.",
+    "authors": "Cowan, J. A., Ohyama, T., Wang, D., & Natarajan, K",
+    "journal": "Nucleic acids research, 28(15), 2935–2942. (2000)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "18000033",
+    "title": "Screening for engineered neomycin riboswitches that control translation initiation.",
+    "authors": "Weigand, J. E., Sanchez, M., Gunnesch, E. B., Zeiher, S., Schroeder, R., & Suess, B.",
+    "journal": "RNA (New York, N.Y.), 14(1), 89–97 (2008)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "19217276",
+    "title": "SPR sensing of small molecules with modified RNA aptamers: detection of neomycin B.",
+    "authors": "de-los-Santos-Alvarez, N., Lobo-Castañón, M. J., Miranda-Ordieres, A. J., & Tuñón-Blanco, P.",
+    "journal": "Biosensors & bioelectronics, 24(8), 2547–2553. (2009)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "20478079",
+    "title": "Fluorescent nucleic acid base analogues.",
+    "authors": "Wilhelmsson L. M.  Quarterly reviews of biophysics, 43(2), 159–183.",
+    "journal": "Quarterly reviews of biophysics, 43(2), 159–183 (2010)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "22951899",
+    "title": "A strategy to enhance the binding affinity of fluorophore-aptamer pairs for RNA tagging with neomycin conjugation.",
+    "authors": "Jeon, J., Lee, K. H., & Rao, J.",
+    "journal": "Chemical communications (Cambridge, England), 48(80), 10034–10036. (2012)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "24757168",
+    "title": "An adaptable pentaloop defines a robust neomycin-B RNA aptamer with conditional ligand-bound structures.",
+    "authors": "Ilgu, M., Fulton, D. B., Yennamalli, R. M., Lamm, M. H., Sen, T. Z., & Nilsen-Hamilton, M..",
+    "journal": "RNA (New York, N.Y.), 20(6), 815–824. (2014)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "26661511",
+    "title": "What a Difference an OH Makes: Conformational Dynamics as the Basis for the Ligand Specificity of the Neomycin-Sensing Riboswitch.",
+    "authors": "Duchardt-Ferner, E., Gottstein-Schmidtke, S. R., Weigand, J. E., Ohlenschläger, O., Wurm, J. P., Hammann, C., Suess, B., & Wöhnert, J",
+    "journal": "Angewandte Chemie (International ed. in English), 55(4), 1527–1530. (2016)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "26942739",
+    "title": "A self-assembling RNA aptamer-based nanoparticle sensor for fluorometric detection of Neomycin B in milk.",
+    "authors": "Ling, K., Jiang, H., Zhang, L., Li, Y., Yang, L., Qiu, C., & Li, F. R.",
+    "journal": "Analytical and bioanalytical chemistry, 408(13), 3593–3600. (2016)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "30462266",
+    "title": "Structure guided fluorescence labeling reveals a two-step binding mechanism of neomycin to its RNA aptamer.",
+    "authors": "Gustmann, H., Segler, A. J., Gophane, D. B., Reuss, A. J., Grünewald, C., Braun, M., Weigand, J. E., Sigurdsson, S. T., & Wachtveitl, J.",
+    "journal": "Nucleic acids research, 47(1), 15–28. (2019)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "33237073",
+    "title": "Aptamer protective groups tolerate different reagents and reactions for regioselective modification of neomycin B.",
+    "authors": "Bastian, A. A., Gruszka, A., Jung, P., & Herrmann, A",
+    "journal": "Organic & biomolecular chemistry, 18(47), 9606–9610 (2020)",
+    "source_file": "_posts/NeomycinB-aptamer.md"
+  },
+  {
+    "pmid": "26184872",
+    "title": "RNA aptamer inhibitors of a restriction endonuclease.",
+    "authors": "Mondragón, E., & Maher III, L. J.",
+    "journal": "Nucleic acids research, 43(15), 7544-7555. (2015)",
+    "source_file": "_posts/Restriction-endonucleases-(REases)-KpnI-aptamer.md"
+  },
+  {
+    "pmid": "16888322",
+    "title": "RNA aptamers selectively modulate protein recruitment to the cytoplasmic domain of beta-secretase BACE1 in vitro.",
+    "authors": "Rentmeister, & Famulok, M.",
+    "journal": "RNA (New York, N.Y.), 12(9), 1650–1660. (2006)",
+    "source_file": "_posts/B1-CT-aptamer.md"
+  },
+  {
+    "pmid": "16540230",
+    "title": "Selection of RNA aptamers against recombinant transforming growth factor-beta type III receptor displayed on cell surface.",
+    "authors": "Ohuchi, S. P., Ohtsu, T., & Nakamura, Y.",
+    "journal": "Biochimie, 88(7), 897–904. (2006)",
+    "source_file": "_posts/TbRIII-aptamer.md"
+  },
+  {
+    "pmid": "26383776",
+    "title": "RAID3-An interleukin-6 receptor-binding aptamer with post-selective modification-resistant affinity.",
+    "authors": "Mittelberger, F., Meyer, C., Waetzig, G. H., Zacharias, M., Valentini, E., Svergun, D. I., ... & Hahn, U.",
+    "journal": "RNA biology, 12(9), 1043-1053. (2015)",
+    "source_file": "_posts/Interleukin-6-receptor-domain-3-(IL-6R-D3)-aptamer.md"
+  },
+  {
+    "pmid": "7510417",
+    "title": "High-resolution molecular discrimination by RNA.",
+    "authors": "Jenison, R. D., Gill, S. C., Pardi, A., & Polisky, B.",
+    "journal": "Science (New York, N.Y.), 263(5152), 1425–1429. (1994)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "9224568",
+    "title": "Rational design of allosteric ribozymes.",
+    "authors": "Tang, J., & Breaker, R. R.",
+    "journal": "Chemistry & biology, 4(6), 453–459. (1997)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "9253414",
+    "title": "Interlocking structural motifs mediate molecular discrimination by a theophylline-binding RNA.",
+    "authors": "Zimmermann, G. R., Jenison, R. D., Wick, C. L., Simorre, J. P., & Pardi, A.",
+    "journal": "Nature structural biology, 4(8), 644–649. (1997)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "9636066",
+    "title": "A semiconserved residue inhibits complex formation by stabilizing interactions in the free state of a theophylline-binding RNA.",
+    "authors": "Zimmermann, G. R., Shields, T. P., Jenison, R. D., Wick, C. L., & Pardi, A.",
+    "journal": "Biochemistry, 37(25), 9186–919. (1998)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "10097080",
+    "title": "Engineering precision RNA molecular switches.",
+    "authors": "Soukup, G. A., & Breaker, R. R.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 96(7), 3584–3589. (1999)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "10425680",
+    "title": "Design of allosteric hammerhead ribozymes activated by ligand-induced structure stabilization.",
+    "authors": "Soukup, G. A., & Breaker, R. R.",
+    "journal": "Structure (London, England : 1993), 7(7), 783–791. (1999)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "10836787",
+    "title": "Molecular interactions and metal binding in the theophylline-binding core of an RNA aptamer.",
+    "authors": "Zimmermann, G. R., Wick, C. L., Shields, T. P., Jenison, R. D., & Pardi, A.",
+    "journal": "RNA (New York, N.Y.), 6(5), 659–667. (2000)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "11266567",
+    "title": "Cooperative binding of effectors by an allosteric ribozyme.",
+    "authors": "Jose, A. M., Soukup, G. A., & Breaker, R. R.",
+    "journal": "Nucleic acids research, 29(7), 1631–1637. (2001)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "15109659",
+    "title": "Unnatural base pairs mediate the site-specific incorporation of an unnatural hydrophobic component into RNA transcripts.",
+    "authors": "Endo, M., Mitsui, T., Okuni, T., Kimoto, M., Hirao, I., & Yokoyama, S.",
+    "journal": "Bioorganic & medicinal chemistry letters, 14(10), 2593–2596. (2004)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "15004248",
+    "title": "A theophylline responsive riboswitch based on helix slipping controls gene expression in vivo.",
+    "authors": "Suess, B., Fink, B., Berens, C., Stentz, R., & Hillen, W.",
+    "journal": "Nucleic acids research, 32(4), 1610–1614. (2004)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "15723047",
+    "title": "Programmable ligand-controlled riboregulators of eukaryotic gene expression.",
+    "authors": "Bayer, T. S., & Smolke, C. D.",
+    "journal": "Nature biotechnology, 23(3), 337–343. (2005)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "16513347",
+    "title": "Photochemical hammerhead ribozyme activation.",
+    "authors": "Young, D. D., & Deiters, A.",
+    "journal": "Bioorganic & medicinal chemistry letters, 16(10), 2658–2661. (2006)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "16996258",
+    "title": "Computational selection of nucleic acid biosensors via a slip structure model.",
+    "authors": "Hall, B., Hesselberth, J. R., & Ellington, A. D.",
+    "journal": "Biosensors & bioelectronics, 22(9-10), 1939–1947. (2007)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "17317571",
+    "title": "A high-throughput screen for synthetic riboswitches reveals mechanistic insights into their function.",
+    "authors": "Lynch, S. A., Desai, S. K., Sajja, H. K., & Gallivan, J. P.",
+    "journal": "Chemistry & biology, 14(2), 173–184. (2007)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "19033367",
+    "title": "A flow cytometry-based screen for synthetic riboswitches.",
+    "authors": "Lynch, S. A., & Gallivan, J. P.",
+    "journal": "Nucleic acids research, 37(1), 184–192.  (2009)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "20041206",
+    "title": "Design principles for ligand-sensing, conformation-switching ribozymes.",
+    "authors": "Chen, X., & Ellington, A. D.",
+    "journal": "PLoS computational biology, 5(12), e1000620. (2009)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "22733807",
+    "title": "Kinetic analysis of aptazyme-regulated gene expression in a cell-free translation system: modeling of ligand-dependent and -independent expression.",
+    "authors": "Kobori, S., Ichihashi, N., Kazuta, Y., Matsuura, T., & Yomo, T.",
+    "journal": "RNA (New York, N.Y.), 18(8), 1458–1465. (2012)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "23452219",
+    "title": "Computational design and biosensor applications of small molecule-sensing allosteric ribozymes.",
+    "authors": "Penchovsky R.",
+    "journal": "Biomacromolecules, 14(4), 1240–1249. (2013)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "23969558",
+    "title": "Theophylline-dependent riboswitch as a novel genetic tool for strict regulation of protein expression in Cyanobacterium Synechococcus elongatus PCC 7942.",
+    "authors": "Nakahira, Y., Ogawa, A., Asano, H., Oyama, T., & Tozawa, Y.",
+    "journal": "Plant & cell physiology, 54(10), 1724–1735. (2013)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "23654267",
+    "title": "Modularity of select riboswitch expression platforms enables facile engineering of novel genetic regulatory devices.",
+    "authors": "Ceres, P., Garst, A. D., Marcano-Velázquez, J. G., & Batey, R. T.",
+    "journal": "ACS synthetic biology, 2(8), 463–472. (2013)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "25726466",
+    "title": "Thermodynamic and kinetic folding of riboswitches.",
+    "authors": "Badelt, S., Hammer, S., Flamm, C., & Hofacker, I. L.",
+    "journal": "Methods in enzymology, 553, 193–213. (2015)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "26594238",
+    "title": "Engineering dynamic cell cycle control with synthetic small molecule-responsive RNA devices.",
+    "authors": "Wei, K. Y., & Smolke, C. D",
+    "journal": "Journal of biological engineering,  9, 21. (2015)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "26642994",
+    "title": "Searching the Sequence Space for Potent Aptamers Using SELEX in Silico.",
+    "authors": "Zhou, Q., Xia, X., Luo, Z., Liang, H., & Shakhnovich, E.",
+    "journal": "Journal of chemical theory and computation, 11(12), 5939–5946. (2015)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "30119599",
+    "title": "Engineering Riboswitches in Vivo Using Dual Genetic Selection and Fluorescence-Activated Cell Sorting.",
+    "authors": "Page, K., Shaffer, J., Lin, S., Zhang, M., & Liu, J. M.",
+    "journal": "ACS synthetic biology, 7(9), 2000–2006. (2018)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "30773480",
+    "title": "Detection of Low-Abundance Metabolites in Live Cells Using an RNA Integrator.",
+    "authors": "You, M., Litke, J. L., Wu, R., & Jaffrey, S. R.",
+    "journal": "Cell chemical biology, 26(4), 471–481.e3. (2019)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "31490060",
+    "title": "Controlling Heterogeneity and Increasing Titer from Riboswitch-Regulated Bacillus subtilis Spores for Time-Delayed Protein Expression Applications.",
+    "authors": "Tamiev, D., Lantz, A., Vezeau, G., Salis, H., & Reuel, N. F.",
+    "journal": "ACS synthetic biology, 8(10), 2336–2346. (2019)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "32142605",
+    "title": "The Theophylline Aptamer: 25 Years as an Important Tool in Cellular Engineering Research.",
+    "authors": "Wrist, A., Sun, W., & Summers, R. M.",
+    "journal": "ACS synthetic biology, 9(4), 682–697. (2020)",
+    "source_file": "_posts/Theophylline-aptamer_back1.md"
+  },
+  {
+    "pmid": "17625118",
+    "title": "Spiegelmer inhibition of CCL2/MCP-1 ameliorates lupus nephritis in MRL-(Fas)lpr mice.",
+    "authors": "Kulkarni, O., Pawar, R. D., Purschke, W., Eulberg, D., Selve, N., Buchner, K., Ninichuk, V., Segerer, S., Vielhauer, V., Klussmann, S., & Anders, H. J.",
+    "journal": "Journal of the American Society of Nephrology : JASN, 18(8), 2350–2358. (2007)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "18776253",
+    "title": "Physicochemical stability of NOX-E36, a 40mer L-RNA (Spiegelmer) for therapeutic applications.",
+    "authors": "Maasch, C. , Buchner, K. , Eulberg, D. , Vonhoff, S. , & Klussmann, S.",
+    "journal": "Nucleic acids symposium series, (52), 61–62. (2008)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "18258851",
+    "title": "Late onset of Ccl2 blockade with the Spiegelmer mNOX-E36-3'PEG prevents glomerulosclerosis and improves glomerular filtration rate in db/db mice.",
+    "authors": "Ninichuk, V. , Clauss, S. , Kulkarni, O. , Schmid, H. , Segerer, S. , Radomska, E. , Eulberg, D. , Buchner, K. , Selve, N. , Klussmann, S. , & Anders, H. J",
+    "journal": "The American journal of pathology, 172(3), 628–637. (2008)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "19156777",
+    "title": "Ccl2/Mcp-1 blockade reduces glomerular and interstitial macrophages but does not ameliorate renal pathology in collagen4A3-deficient mice with autosomal recessive Alport nephropathy.",
+    "authors": "Clauss, S. , Gross, O. , Kulkarni, O. , Avila-Ferrufino, A. , Radomska, E. , Segerer, S. , Eulberg, D. , Klussmann, S. , & Anders, H. J.",
+    "journal": "The Journal of pathology, 218(1), 40–47. (2009)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "21813474",
+    "title": "Pharmacological inhibition of the chemokine CCL2 (MCP-1) diminishes liver macrophage infiltration and steatohepatitis in chronic hepatic injury.",
+    "authors": "Baeck, C. , Wehr, A. , Karlmark, K. R. , Heymann, F. , Vucur, M. , Gassler, N. , Huss, S. , Klussmann, S. , Eulberg, D. , Luedde, T. , Trautwein, C. , & Tacke, F.",
+    "journal": "Gut,61(3), 416–426. (2012)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "24561613",
+    "title": "CCL2-dependent infiltrating macrophages promote angiogenesis in progressive liver fibrosis.",
+    "authors": "Ehling, J. , Bartneck, M. , Wei, X. , Gremse, F. , Fech, V. , Möckel, D. , Baeck, C. , Hittatiya, K. , Eulberg, D. , Luedde, T. , Kiessling, F. , Trautwein, C. , Lammers, T. , & Tacke, F.",
+    "journal": "Gut,63(12), 1960–1971. (2014)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "24481979",
+    "title": "Pharmacological inhibition of the chemokine C-C motif chemokine ligand 2 (monocyte chemoattractant protein 1) accelerates liver fibrosis regression by suppressing Ly-6C(+) macrophage infiltration in mice.",
+    "authors": "Baeck, C. , Wei, X. , Bartneck, M. , Fech, V. , Heymann, F. , Gassler, N. , Hittatiya, K. , Eulberg, D. , Luedde, T. , Trautwein, C. , & Tacke, F.",
+    "journal": "Hepatology (Baltimore, Md.), 59(3), 1060–1072. (2014)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "25901662",
+    "title": "Crystal structure of a mirror-image L-RNA aptamer (Spiegelmer) in complex with the natural L-protein target CCL2.",
+    "authors": "Oberthür D, Achenbach J, Gabdulkhakov A, Buchner K, Maasch C, Falke S, Rehders D, Klussmann S, Betzel C.",
+    "journal": "Nat Commun, 6:6923 (2015)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "25970072",
+    "title": "Spiegelmer Inhibition of MCP-1/CCR2--Potential as an Adjunct Immunosuppressive Therapy in Transplantation.",
+    "authors": "Kalnins, A. , Thomas, M. N. , Andrassy, M. , Müller, S. , Wagner, A. , Pratschke, S. , Rentsch, M. , Klussmann, S. , Kauke, T. , Angele, M. K. , Bazhin, A. V. , Fischereder, M. , Werner, J. , Guba, M. , & Andrassy, J.",
+    "journal": "Scandinavian journal of immunology, 82(2), 102–109. (2015)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "28186566",
+    "title": "C-C motif-ligand 2 inhibition with emapticap pegol (NOX-E36) in type 2 diabetic patients with albuminuria.",
+    "authors": "Menne, J., Eulberg, D., Beyer, D., Baumann, M., Saudek, F., Valkusz, Z., Więcek, A., Haller, H., & Emapticap Study Group",
+    "journal": "Nephrology, dialysis, transplantation : official publication of the European Dialysis and Transplant Association - European Renal Association,  32(2), 307–315.  (2017)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "28837800",
+    "title": "Systemic Monocyte Chemotactic Protein-1 Inhibition Modifies Renal Macrophages and Restores Glomerular Endothelial Glycocalyx and Barrier Function in Diabetic Nephropathy.",
+    "authors": "Boels, M. G. S. , Koudijs, A. , Avramut, M. C. , Sol, W. M. P. J. , Wang, G. , van Oeveren-Rietdijk, A. M. , van Zonneveld, A. J. , de Boer, H. C. , van der Vlag, J. , van Kooten, C. , Eulberg, D. , van den Berg, B. M. , IJpelaar, D. H. T. , & Rabelink, T. J.",
+    "journal": "The American journal of pathology, 187(11), 2430–2440. (2017)",
+    "source_file": "_posts/L-CCL2-aptamer.md"
+  },
+  {
+    "pmid": "21565620",
+    "title": "Isolation and characterization of an RNA aptamer for the HPV-16 E7 oncoprotein.",
+    "authors": "Toscano-Garibay, J. D., Benítez-Hess, M. L., & Alvarez-Salas, L. M.",
+    "journal": "Archives of medical research, 42(2), 88–96. (2011)",
+    "source_file": "_posts/HPV-16-E7-oncoprotein-aptamer.md"
+  },
+  {
+    "pmid": "9056763",
+    "title": "The RNA binding site of S8 ribosomal protein of Escherichia coli: Selex and hydroxyl radical probing studies.",
+    "authors": "Moine, H., Cachia, C., Westhof, E., Ehresmann, B., & Ehresmann, C.",
+    "journal": "RNA (New York, N.Y.), 3(3), 255–268. (1997)",
+    "source_file": "_posts/Ribosomal-protein-S8-aptamer.md"
+  },
+  {
+    "pmid": "25140011",
+    "title": "Structure analysis of free and bound states of an RNA aptamer against ribosomal protein S8 from Bacillus anthracis.",
+    "authors": "Davlieva, M., Donarski, J., Wang, J., Shamoo, Y., & Nikonowicz, E. P.",
+    "journal": "Nucleic acids research, 42(16), 10795–10808. (2014)",
+    "source_file": "_posts/Ribosomal-protein-S8-aptamer.md"
+  },
+  {
+    "pmid": "29413905",
+    "title": "The intrinsic flexibility of the aptamer targeting the ribosomal protein S8 is a key factor for the molecular recognition.",
+    "authors": "Autiero, I., Ruvo, M., Improta, R., & Vitagliano, L.",
+    "journal": "Biochimica et Biophysica Acta (BBA)-General Subjects, 1862(4), 1006-1016. (2018)",
+    "source_file": "_posts/Ribosomal-protein-S8-aptamer.md"
+  },
+  {
+    "pmid": "35320268",
+    "title": "Modelling aptamers with nucleic acid mimics (NAM): From sequence to three-dimensional docking.",
+    "authors": "Oliveira, R., Pinho, E., Sousa, A. L., Dias, Ó., Azevedo, N. F., & Almeida, C.",
+    "journal": "PloS one, 17(3), e0264701. (2022)",
+    "source_file": "_posts/Ribosomal-protein-S8-aptamer.md"
+  },
+  {
+    "pmid": "36458023",
+    "title": "Investigating RNA-protein recognition mechanisms through supervised molecular dynamics (SuMD) simulations.",
+    "authors": "Pavan, M., Bassani, D., Sturlese, M., & Moro, S.",
+    "journal": "NAR genomics and bioinformatics, 4(4), lqac088. (2022)",
+    "source_file": "_posts/Ribosomal-protein-S8-aptamer.md"
+  },
+  {
+    "pmid": "34937909",
+    "title": "Repurposing an adenine riboswitch into a fluorogenic imaging and sensing tag.",
+    "authors": "Dey, S. K., Filonov, G. S., Olarerin-George, A. O., Jackson, B. T., Finley, L. W. S., & Jaffrey, S. R.",
+    "journal": "Nature chemical biology, 18(2), 180–190. (2022)",
+    "source_file": "_posts/Squash-aptamer.md"
+  },
+  {
+    "pmid": "34937911",
+    "title": "The fluorescent aptamer Squash extensively repurposes the adenine riboswitch fold.",
+    "authors": "Truong, L., Kooshapur, H., Dey, S. K., Li, X., Tjandra, N., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature chemical biology, 18(2), 191–198. (2022)",
+    "source_file": "_posts/Squash-aptamer.md"
+  },
+  {
+    "pmid": "38098702",
+    "title": "A universal orthogonal imaging platform for living-cell RNA detection using fluorogenic RNA aptamers.",
+    "authors": "Yin, P., Ge, M., Xie, S., Zhang, L., Kuang, S., & Nie, Z.",
+    "journal": "Chemical science, 14(48), 14131–14139. (2023)",
+    "source_file": "_posts/Squash-aptamer.md"
+  },
+  {
+    "pmid": "16189080",
+    "title": "Aptamers that preferentially bind type IVB pili and inhibit human monocytic-cell invasion by Salmonella enterica serovar typhi.",
+    "authors": "Pan, Q., Zhang, X. L., Wu, H. Y., He, P. W., Wang, F., Zhang, M. S., Hu, J. M., Xia, B., & Wu, J.",
+    "journal": "Antimicrobial agents and chemotherapy, 49(10), 4052–4060. (2005)",
+    "source_file": "_posts/Type-IVB-Pili-aptamer.md"
+  },
+  {
+    "pmid": "11820803",
+    "title": "Selection of RNA aptamers to the Alzheimer's disease amyloid peptide.",
+    "authors": "Ylera F, Lurz R, Erdmann VA, Fürste JP",
+    "journal": "Biochemical and biophysical research communications. 2002 Feb 8;290(5):1583-8. (2002)",
+    "source_file": "_posts/β55-aptamer.md"
+  },
+  {
+    "pmid": "19668864",
+    "title": "RNA aptamers selected against amyloid beta-peptide (Abeta) inhibit the aggregation of Abeta.",
+    "authors": "Takahashi T, Tada K, Mihara H",
+    "journal": "Molecular bioSystems. 2009 Sep;5(9):986-91. (2009)",
+    "source_file": "_posts/β55-aptamer.md"
+  },
+  {
+    "pmid": "19901993",
+    "title": "RNA aptamers generated against oligomeric Abeta40 recognize common amyloid aptatopes with low specificity but high sensitivity.",
+    "authors": "Rahimi F, Murakami K, Summers JL, Chen CH, Bitan G",
+    "journal": "PLoS One. 2009 Nov 10;4(11):e7694. (2009)",
+    "source_file": "_posts/β55-aptamer.md"
+  },
+  {
+    "pmid": "25618678",
+    "title": "Sensing and inhibition of amyloid-β based on the simple luminescent aptamer-ruthenium complex system.",
+    "authors": "Babu E, Muthu Mareeswaran P, Sathish V, Singaravadivel S, Rajagopal S",
+    "journal": "Talanta. 2015 Mar;134:348-353. (2015)",
+    "source_file": "_posts/β55-aptamer.md"
+  },
+  {
+    "pmid": "30642129",
+    "title": "Selection of Membrane RNA Aptamers to Amyloid Beta Peptide: Implications for Exosome-Based Antioxidant Strategies.",
+    "authors": "Janas T, Sapoń K, Stowell MHB, Janas T",
+    "journal": "International journal of molecular sciences. 2019 Jan 13;20(2):299. (2019)",
+    "source_file": "_posts/β55-aptamer.md"
+  },
+  {
+    "pmid": "32127399",
+    "title": "An RNA aptamer with potent affinity for a toxic dimer of amyloid β42 has potential utility for histochemical studies of Alzheimer's disease.",
+    "authors": "Murakami K, Obata Y, Sekikawa A, Ueda H, Izuo N, Awano T, Takabe K, Shimizu T, Irie K",
+    "journal": "The Journal of biological chemistry. 2020 Apr 10;295(15):4870-4880. (2020)",
+    "source_file": "_posts/β55-aptamer.md"
+  },
+  {
+    "pmid": "16246910",
+    "title": "Binding of herpes simplex virus-1 US11 to specific RNA sequences.",
+    "authors": "Bryant, K. F., Cox, J. C., Wang, H., Hogle, J. M., Ellington, A. D., & Coen, D. M.",
+    "journal": "Nucleic acids research, 33(19), 6090–6100. (2005)",
+    "source_file": "_posts/HSV-1-US11-aptamer.md"
+  },
+  {
+    "pmid": "20572251",
+    "title": "An RNA aptamer that selectively inhibits the enzymatic activity of protein tyrosine phosphatase 1B in vitro.",
+    "authors": "Townshend, B., Aubry, I., Marcellus, R. C., Gehring, K., & Tremblay, M. L.",
+    "journal": "Chembiochem : a European journal of chemical biology, 11(11), 1583–1593. (2010)",
+    "source_file": "_posts/PTP1B-aptamer.md"
+  },
+  {
+    "pmid": "10074372",
+    "title": "Selection and characterization of an RNA decoy for transcription factor NF-kappa B.",
+    "authors": "Lebruska, L. L., & Maher, L. J., 3rd.",
+    "journal": "Biochemistry, 38(10), 3168–3174. (1999)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "12886018",
+    "title": "Crystal structure of NF-kappaB (p50)2 complexed to a high-affinity RNA aptamer.",
+    "authors": "Huang, D. B., Vu, D., Cassiday, L. A., Zimmerman, J. M., Maher, L. J., 3rd, & Ghosh, G.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 100(16), 9268–9273. (2003)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "12637683",
+    "title": "Yeast genetic selections to optimize RNA decoys for transcription factor NF-kappa B.",
+    "authors": "Cassiday, L. A., & Maher, L. J., 3rd.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 100(7), 3930–3935. (2003)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "15263062",
+    "title": "Synthesis and physical and physiological properties of 4'-thioRNA: application to post-modification of RNA aptamer toward NF-kappaB.",
+    "authors": "Hoshika, S., Minakawa, N., & Matsuda, A.",
+    "journal": "Nucleic acids research, 32(13), 3815–3825. (2004)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "16517938",
+    "title": "Co-expression of anti-NFkappaB RNA aptamers and siRNAs leads to maximal suppression of NFkappaB activity in mammalian cells.",
+    "authors": "Chan, R., Gilbert, M., Thompson, K. M., Marsh, H. N., Epstein, D. M., & Pendergrast, P. S.",
+    "journal": "Nucleic acids research, 34(5), e36. (2006)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "18160411",
+    "title": "DNA mimicry by a high-affinity anti-NF-kappaB RNA aptamer.",
+    "authors": "Reiter, N. J., Maher, L. J., 3rd, & Butcher, S. E.",
+    "journal": "Nucleic acids research, 36(4), 1227–1236. (2008)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "18426920",
+    "title": "Selection and characterization of anti-NF-kappaB p65 RNA aptamers.",
+    "authors": "Wurster, S. E., & Maher, L. J., 3rd.",
+    "journal": "RNA (New York, N.Y.), 14(6), 1037–1047. (2008)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "19696077",
+    "title": "Characterization of anti-NF-kappaB RNA aptamer-binding specificity in vitro and in the yeast three-hybrid system.",
+    "authors": "Wurster, S. E., Bida, J. P., Her, Y. F., & Maher, L. J., 3rd.",
+    "journal": "Nucleic acids research, 37(18), 6214–6224. (2009)",
+    "source_file": "_posts/NF-kappaB-aptamer.md"
+  },
+  {
+    "pmid": "18000033",
+    "title": "Screening for engineered neomycin riboswitches that control translation initiation.",
+    "authors": "Weigand, J. E., Sanchez, M., Gunnesch, E. B., Zeiher, S., Schroeder, R., & Suess, B.",
+    "journal": "RNA (New York, N.Y.), 14(1), 89–97. (2008)",
+    "source_file": "_posts/Ribostamycin-aptamer.md"
+  },
+  {
+    "pmid": "20306311",
+    "title": "NMR resonance assignments of an engineered neomycin-sensing riboswitch RNA bound to ribostamycin and tobramycin.",
+    "authors": "Schmidtke, S. R., Duchardt-Ferner, E., Weigand, J. E., Suess, B., & Wöhnert, J.",
+    "journal": "Biomolecular NMR assignments, 4(1), 115–118. (2010)",
+    "source_file": "_posts/Ribostamycin-aptamer.md"
+  },
+  {
+    "pmid": "20632338",
+    "title": "Highly modular structure and ligand binding by conformational capture in a minimalistic riboswitch.",
+    "authors": "Duchardt-Ferner, E., Weigand, J. E., Ohlenschläger, O., Schmidtke, S. R., Suess, B., & Wöhnert, J.",
+    "journal": "Angewandte Chemie (International ed. in English), 49(35), 6216–6219. (2010)",
+    "source_file": "_posts/Ribostamycin-aptamer.md"
+  },
+  {
+    "pmid": "23303774",
+    "title": "Sequence-specific inhibition of Dicer measured with a force-based microarray for RNA ligands.",
+    "authors": "Limmer, K., Aschenbrenner, D., & Gaub, H. E.",
+    "journal": "Nucleic acids research, 41(6), e69. (2013)",
+    "source_file": "_posts/Ribostamycin-aptamer.md"
+  },
+  {
+    "pmid": "26661511",
+    "title": "What a Difference an OH Makes: Conformational Dynamics as the Basis for the Ligand Specificity of the Neomycin-Sensing Riboswitch.",
+    "authors": "Duchardt-Ferner, E., Gottstein-Schmidtke, S. R., Weigand, J. E., Ohlenschläger, O., Wurm, J. P., Hammann, C., Suess, B., & Wöhnert, J.",
+    "journal": "Angewandte Chemie (International ed. in English), 55(4), 1527–1530. (2016)",
+    "source_file": "_posts/Ribostamycin-aptamer.md"
+  },
+  {
+    "pmid": "39902969",
+    "title": "Synthetic Dual-Input Hybrid Riboswitches─Optimized Genetic Regulators in Yeast.",
+    "authors": "Kelvin, D., Arias Rodriguez, J., Groher, A. C., Petras, K., & Suess, B.",
+    "journal": "ACS synthetic biology, 14(2), 497–509. (2025)",
+    "source_file": "_posts/Ribostamycin-aptamer.md"
+  },
+  {
+    "pmid": "25101481",
+    "title": "RNA mango aptamer-fluorophore: a bright, high-affinity complex for RNA labeling and tracking.",
+    "authors": "Dolgosheina, E. V., Jeng, S. C., Panchapakesan, S. S., Cojocaru, R., Chen, P. S., Wilson, P. D., Hawkins, N., Wiggins, P. A., & Unrau, P. J.",
+    "journal": "ACS chemical biology, 9(10), 2412–2420. (2014)",
+    "source_file": "_posts/Mango-III-aptamer(YO3).md"
+  },
+  {
+    "pmid": "29295996",
+    "title": "Development of a genetically encodable FRET system using fluorescent RNA aptamers.",
+    "authors": "Jepsen, M. D. E., Sparvath, S. M., Nielsen, T. B., Langvad, A. H., Grossi, G., Gothelf, K. V., & Andersen, E. S.",
+    "journal": "Nature communications, 9(1), 18. (2018)",
+    "source_file": "_posts/Mango-III-aptamer(YO3).md"
+  },
+  {
+    "pmid": "33376189",
+    "title": "Fluorogenic aptamers resolve the flexibility of RNA junctions using orientation-dependent FRET.",
+    "authors": "Jeng, S. C. Y., Trachman, R. J., 3rd, Weissenboeck, F., Truong, L., Link, K. A., Jepsen, M. D. E., Knutson, J. R., Andersen, E. S., Ferré-D'Amaré, A. R., & Unrau, P. J.",
+    "journal": "RNA (New York, N.Y.), 27(4), 433–444. (2021)",
+    "source_file": "_posts/Mango-III-aptamer(YO3).md"
+  },
+  {
+    "pmid": "36227560",
+    "title": "Characterizing fluorescence properties of turn-on RNA aptamers.",
+    "authors": "Trachman, R. J., 3rd, Link, K. A., Knutson, J. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Methods in molecular biology (Clifton, N.J.), 2568, 25–36. (2023)",
+    "source_file": "_posts/Mango-III-aptamer(YO3).md"
+  },
+  {
+    "pmid": "9343239",
+    "title": "RNA aptamers specifically interact with the prion protein PrP.",
+    "authors": "Weiss, S., Proske, D., Neumann, M., Groschup, M. H., Kretzschmar, H. A., Famulok, M., & Winnacker, E. L.",
+    "journal": "Journal of virology, 71(11), 8790–8797. (1997)",
+    "source_file": "_posts/Prion-protein1-aptamer.md"
+  },
+  {
+    "pmid": "28513534",
+    "title": "Unraveling Prion Protein Interactions with Aptamers and Other PrP-Binding Nucleic Acids.",
+    "authors": "Macedo, B., & Cordeiro, Y.",
+    "journal": "International journal of molecular sciences, 18(5), 1023. (2017)",
+    "source_file": "_posts/Prion-protein1-aptamer.md"
+  },
+  {
+    "pmid": "11904188",
+    "title": "RNA aptamers directed against release factor 1 from Thermus thermophilus.",
+    "authors": "Szkaradkiewicz, K., Nanninga, M., Nesper-Brock, M., Gerrits, M., Erdmann, V. A., & Sprinzl, M.",
+    "journal": "FEBS letters, 514(1), 90–95. (2002)",
+    "source_file": "_posts/Peptide-release-factor-1-aptamer.md"
+  },
+  {
+    "pmid": "8523524",
+    "title": "RNA aptamers selected to bind human immunodeficiency virus type 1 Rev in vitro are Rev responsive in vivo.",
+    "authors": "Symensma, T. L., Giver, L., Zapp, M., Takle, G. B., & Ellington, A. D.",
+    "journal": "Journal of virology, 70(1), 179–187. (1996)",
+    "source_file": "_posts/C52-aptamer.md"
+  },
+  {
+    "pmid": "8755498",
+    "title": "Anti-peptide aptamers recognize amino acid sequence and bind a protein epitope.",
+    "authors": "Xu, W., & Ellington, A. D.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 93(15), 7475–7480. (1996)",
+    "source_file": "_posts/C52-aptamer.md"
+  },
+  {
+    "pmid": "8946856",
+    "title": "Deep penetration of an alpha-helix into a widened RNA major groove in the HIV-1 rev peptide-RNA aptamer complex.",
+    "authors": "Ye, X., Gorin, A., Ellington, A. D., & Patel, D. J.",
+    "journal": "Nature structural biology, 3(12), 1026–1033. (1996)",
+    "source_file": "_posts/C52-aptamer.md"
+  },
+  {
+    "pmid": "9713975",
+    "title": "Receptor ligand-facilitated cationic liposome delivery of anti-HIV-1 Rev-binding aptamer and ribozyme DNAs.",
+    "authors": "Konopka, K., Düzgüneş, N., Rossi, J., & Lee, N. S.",
+    "journal": "Journal of drug targeting, 5(4), 247–259. (1998)",
+    "source_file": "_posts/C52-aptamer.md"
+  },
+  {
+    "pmid": "15610009",
+    "title": "Retention of conformational flexibility in HIV-1 Rev-RNA complexes.",
+    "authors": "Wilkinson, T. A., Zhu, L., Hu, W., & Chen, Y.",
+    "journal": "Biochemistry, 43(51), 16153–16160. (2004)",
+    "source_file": "_posts/C52-aptamer.md"
+  },
+  {
+    "pmid": "30017564",
+    "title": "Structure of an RNA Aptamer that Can Inhibit HIV-1 by Blocking Rev-Cognate RNA (RRE) Binding and Rev-Rev Association.",
+    "authors": "Dearborn, A. D., Eren, E., Watts, N. R., Palmer, I. W., Kaufman, J. D., Steven, A. C., & Wingfield, P. T.",
+    "journal": "Structure (London, England : 1993), 26(9), 1187–1195.e4. (2018)",
+    "source_file": "_posts/C52-aptamer.md"
+  },
+  {
+    "pmid": "9546673",
+    "title": "Selection of a RNA aptamer that binds to human activated protein C and inhibits its protease function.",
+    "authors": "Gal, S. W., Amontov, S., Urvil, P. T., Vishnuvardhan, D., Nishikawa, F., Kumar, P. K., & Nishikawa, S.",
+    "journal": "European journal of biochemistry, 252(3), 553–562. (1998)",
+    "source_file": "_posts/Human-activated-protein-C-aptamer.md"
+  },
+  {
+    "pmid": "17588619",
+    "title": "Water soluble RNA based antagonist of AMPA receptors.",
+    "authors": "Du, M., Ulrich, H., Zhao, X., Aronowski, J., & Jayaraman, V.",
+    "journal": "Neuropharmacology, 53(2), 242–251. (2007)",
+    "source_file": "_posts/AMPA-receptors-Aptamer.md"
+  },
+  {
+    "pmid": "16868550",
+    "title": "The biology of interleukin-2 and interleukin-15: implications for cancer therapy and vaccine design.",
+    "authors": "Waldmann T. A.",
+    "journal": "Nature reviews. Immunology, 6(8), 595–601. (2006)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "20732639",
+    "title": "Interleukin-2 receptor signaling: at the interface between tolerance and immunity.",
+    "authors": "Malek, T. R., & Castro, I.",
+    "journal": "Immunity, 33(2), 153–165. (2010)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "23675235",
+    "title": "Interleukin-2 functions in anaplastic large cell lymphoma cells through augmentation of extracellular signal-regulated kinases 1/2 activation.",
+    "authors": "Ito, M., Zhao, N., Zeng, Z., Zhou, X., Chang, C. C., & Zu, Y.",
+    "journal": "International journal of biomedical science : IJBS, 7(3), 181–190. (2011)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "21719603",
+    "title": "Soluble IL-2Ralpha facilitates IL-2-mediated immune responses and predicts reduced survival in follicular B-cell non-Hodgkin lymphoma.",
+    "authors": "Yang, Z. Z., Grote, D. M., Ziesmer, S. C., Manske, M. K., Witzig, T. E., Novak, A. J., & Ansell, S. M.",
+    "journal": "Blood, 118(10), 2809–2820. (2011)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "22849383",
+    "title": "Induced and natural regulatory T cells in human cancer.",
+    "authors": "Whiteside TL, Schuler P, Schilling B.",
+    "journal": "Expert opinion on biological therapy, 12(10), 1383–1397. (2012)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "25422100",
+    "title": "Elevated serum levels of IL-2R, IL-1RA, and CXCL9 are associated with a poor prognosis in follicular lymphoma.",
+    "authors": "Mir, M. A., Maurer, M. J., Ziesmer, S. C., Slager, S. L., Habermann, T., Macon, W. R., Link, B. K., Syrbu, S., Witzig, T., Friedberg, J. W., Press, O., LeBlanc, M., Cerhan, J. R., Novak, A., & Ansell, S. M.",
+    "journal": "Blood, 125(6), 992–998. (2015)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "26205340",
+    "title": "Evolving synergistic combinations of targeted immunotherapies to combat cancer.",
+    "authors": "Melero, I., Berman, D. M., Aznar, M. A., Korman, A. J., Pérez Gracia, J. L., & Haanen, J.",
+    "journal": "Nature reviews. Cancer, 15(8), 457–472. (2015)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "25561050",
+    "title": "Nucleic acid aptamers in cancer research, diagnosis and therapy.",
+    "authors": "Ma, H., Liu, J., Ali, M. M., Mahmood, M. A., Labanieh, L., Lu, M., Iqbal, S. M., Zhang, Q., Zhao, W., & Wan, Y.",
+    "journal": "Nucleic acid aptamers in cancer research, diagnosis and therapy. Chemical Society reviews, 44(5), 1240–1256. (2015)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "28383112",
+    "title": "Associations between elevated pre-treatment serum cytokines and peripheral blood cellular markers of immunosuppression in patients with lymphoma.",
+    "authors": "Binder, M., O'Byrne, M. M., Maurer, M. J., Ansell, S., Feldman, A. L., Cerhan, J., Novak, A., Porrata, L. F., Markovic, S., Link, B. K., & Witzig, T. E.",
+    "journal": "American journal of hematology, 92(8), 752–758. (2017)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "31383650",
+    "title": "An RNA Aptamer-Based Biomarker Platform Demonstrates High Soluble CD25 Occupancy by IL2 in the Serum of Follicular Lymphoma Patients.",
+    "authors": "Veeramani, S., Blackwell, S. E., Thiel, W. H., Yang, Z. Z., Ansell, S. M., Giangrande, P. H., & Weiner, G. J.",
+    "journal": "Cancer immunology research, 7(9), 1511–1522. (2019)",
+    "source_file": "_posts/IL2-CD25-aptermer.md"
+  },
+  {
+    "pmid": "12874383",
+    "title": "Inhibition of heregulin signaling by an aptamer that preferentially binds to the oligomeric form of human epidermal growth factor receptor-3.",
+    "authors": "Chen CH, Chernis GA, Hoang VQ, Landgraf R.",
+    "journal": "Proc Natl Acad Sci U S A, 100(16):9226-31. (2003)",
+    "source_file": "_posts/A30-aptamer.md"
+  },
+  {
+    "pmid": "29499944",
+    "title": "Targeting EGFR/HER2/HER3 with a Three-in-One Aptamer-siRNA Chimera Confers Superior Activity against HER2+ Breast Cancer.",
+    "authors": "Yu X, Ghamande S, Liu H, Xue L, Zhao S, Tan W, Zhao L, Tang SC, Wu D, Korkaya H, Maihle NJ, Liu HY.",
+    "journal": "Mol Ther Nucleic Acids, 10:317-330. (2017)",
+    "source_file": "_posts/A30-aptamer.md"
+  },
+  {
+    "pmid": "7687750",
+    "title": "An RNA motif that binds ATP.",
+    "authors": "Sassanfar, M., & Szostak, J. W.",
+    "journal": "Nature, 364(6437), 550–553 (1993)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "7521014",
+    "title": "In vitro evolution of new ribozymes with polynucleotide kinase activity.",
+    "authors": "Lorsch, J. R., & Szostak, J. W.",
+    "journal": "Nature, 371(6492), 31–36 (1994)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "8700212",
+    "title": "Structural basis of RNA folding and recognition in an AMP-RNA aptamer complex.",
+    "authors": "Jiang, F., Kumar, R. A., Jones, R. A., & Patel, D. J.",
+    "journal": "Nature, 382(6587), 183–186 (1996)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "8756406",
+    "title": "Solution structure of an ATP-binding RNA aptamer reveals a novel fold.",
+    "authors": "Dieckmann, T., Suzuki, E., Nakamura, G. K., & Feigon, J.",
+    "journal": "RNA (New York, N.Y.), 2(7), 628–640. (1996)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "9081544",
+    "title": "Specific labeling approaches to guanine and adenine imino and amino proton assignments in the AMP-RNA aptamer complex.",
+    "authors": "Jiang, F., Patel, D. J., Zhang, X., Zhao, H., & Jones, R. A",
+    "journal": "Journal of biomolecular NMR, 9(1), 55–62. (1997)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "9384529",
+    "title": "Structural basis of DNA folding and recognition in an AMP-DNA aptamer complex: distinct architectures but common recognition motifs for DNA and RNA aptamers complexed to AMP.",
+    "authors": "Lin, C. H., & Patel, D. J.",
+    "journal": "Chemistry & biology, 4(11), 817–832. (1997)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "9257650",
+    "title": "Examination of the catalytic fitness of the hammerhead ribozyme by in vitro selection.",
+    "authors": "Tang, J., & Breaker, R. R.",
+    "journal": "RNA (New York, N.Y.), 3(8), 914–925 (1997)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "9159476",
+    "title": "Imino proton exchange and base-pair kinetics in the AMP-RNA aptamer complex.",
+    "authors": "Nonin, S., Jiang, F., & Patel, D. J.",
+    "journal": "Journal of molecular biology, 268(2), 359–374. (1997)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "14624002",
+    "title": "Evolution of aptamers with a new specificity and new secondary structures from an ATP aptamer.",
+    "authors": "Huang, Z., & Szostak, J. W.",
+    "journal": "RNA (New York, N.Y.), 9(12), 1456–1463. (2003)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "12873145",
+    "title": "A novel, modification-dependent ATP-binding aptamer selected from an RNA library incorporating a cationic functionality.",
+    "authors": "Vaish, N. K., Larralde, R., Fraley, A. W., Szostak, J. W., & McLaughlin, L. W.",
+    "journal": "Biochemistry, 42(29), 8842–8851. (2003)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "15237981",
+    "title": "A small aptamer with strong and specific recognition of the triphosphate of ATP.",
+    "authors": "Sazani, P. L., Larralde, R., & Szostak, J. W.",
+    "journal": "Journal of the American Chemical Society, 126(27), 8370–8371. (2004)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "29248297",
+    "title": "Facile conversion of ATP-binding RNA aptamer to quencher-free molecular aptamer beacon.",
+    "authors": "Park, Y., Nim-Anussornkul, D., Vilaivan, T., Morii, T., & Kim, B. H.",
+    "journal": "Bioorganic & medicinal chemistry letters, 28(2), 77–80. (2018)",
+    "source_file": "_posts/ATP-aptamer.md"
+  },
+  {
+    "pmid": "29103909",
+    "title": "RNA aptamers recognizing murine CCL17 inhibit T cell chemotaxis and reduce contact hypersensitivity in vivo.",
+    "authors": "Fülle, L., Steiner, N., Funke, M., Gondorf, F., Pfeiffer, F., Siegl, J., ... & Förster, I.",
+    "journal": "Molecular Therapy, 26(1), 95-104. (2018)",
+    "source_file": "_posts/Chemokine-CCL17-aptamer.md"
+  },
+  {
+    "pmid": "10089440",
+    "title": "Preliminary characterization of crystals of an in vitro evolved cyanocobalamin (vitamin B12) binding RNA.",
+    "authors": "Sussman D, Greensides D, Reilly K, Wilson C",
+    "journal": "Acta crystallographica. Section D, Biological crystallography. 1999 Jan;55(Pt 1):326-8. (1999)",
+    "source_file": "_posts/Vitamin-B12-aptamer.md"
+  },
+  {
+    "pmid": "10625428",
+    "title": "The structural basis for molecular recognition by the vitamin B 12 RNA aptamer.",
+    "authors": "Sussman D, Nix JC, Wilson C",
+    "journal": "Nature structural biology. 2000 Jan;7(1):53-7. (2000)",
+    "source_file": "_posts/Vitamin-B12-aptamer.md"
+  },
+  {
+    "pmid": "10903943",
+    "title": "A water channel in the core of the vitamin B(12) RNA aptamer.",
+    "authors": "Sussman D, Wilson C",
+    "journal": "Structure. 2000 Jul 15;8(7):719-27. (2000)",
+    "source_file": "_posts/Vitamin-B12-aptamer.md"
+  },
+  {
+    "pmid": "18672888",
+    "title": "Influence of nanometric holes on the sensitivity of a waveguide-mode sensor: label-free nanosensor for the analysis of RNA aptamer-ligand interactions.",
+    "authors": "Gopinath SC, Awazu K, Fujimaki M, Sugimoto K, Ohki Y, Komatsubara T, Tominaga J, Gupta KC, Kumar PK",
+    "journal": "Analytical chemistry. 2008 Sep 1;80(17):6602-9. (2008)",
+    "source_file": "_posts/Vitamin-B12-aptamer.md"
+  },
+  {
+    "pmid": "22658959",
+    "title": "Nano RNA aptamer wire for analysis of vitamin B₁₂.",
+    "authors": "Selvakumar LS, Thakur MS",
+    "journal": "Analytical biochemistry. 2012 Aug 15;427(2):151-7. (2012)",
+    "source_file": "_posts/Vitamin-B12-aptamer.md"
+  },
+  {
+    "pmid": "20159999",
+    "title": "Selecting RNA aptamers for synthetic biology: investigating magnesium dependence and predicting binding affinity.",
+    "authors": "Carothers, J. M., Goler, J. A., Kapoor, Y., Lara, L., & Keasling, J. D.",
+    "journal": "Nucleic acids research, 38(8), 2736–2747. (2010)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "27730489",
+    "title": "NMR resonance assignments for the tetramethylrhodamine binding RNA aptamer 3 in complex with the ligand 5-carboxy-tetramethylrhodamine.",
+    "authors": "Duchardt-Ferner, E., Juen, M., Kreutz, C., & Wöhnert, J.",
+    "journal": "Biomolecular NMR assignments, 11(1), 29–34. (2017)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "30986047",
+    "title": "SiRA: A Silicon Rhodamine-Binding Aptamer for Live-Cell Super-Resolution RNA Imaging.",
+    "authors": "Wirth, R., Gao, P., Nienhaus, G. U., Sunbul, M., & Jäschke, A.",
+    "journal": "Journal of the American Chemical Society, 141(18), 7562–7571. (2019)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "31754719",
+    "title": "Structure of an RNA aptamer in complex with the  fluorophore tetramethylrhodamine.",
+    "authors": "Duchardt-Ferner, E., Juen, M., Bourgeois, B., Madl, T., Kreutz, C., Ohlenschläger, O., & Wöhnert, J.",
+    "journal": "Nucleic acids research, 48(2), 949–961. (2020)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "33574610",
+    "title": "Super-resolution RNA imaging using a rhodamine-binding aptamer with fast exchange kinetics.",
+    "authors": "Sunbul, M., Lackner, J., Martin, A., Englert, D., Hacene, B., Grün, F., Nienhaus, K., Nienhaus, G. U., & Jäschke, A.",
+    "journal": "Nature biotechnology, 39(6), 686–690. (2021)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "35486532",
+    "title": "Rational Design of Self-Quenched Rhodamine Dimers as Fluorogenic Aptamer Probes for Live-Cell RNA Imaging.",
+    "authors": "Fam, K. T., Pelletier, R., Bouhedda, F., Ryckelynck, M., Collot, M., & Klymchenko, A. S.",
+    "journal": "Analytical chemistry, 94(18), 6657–6664. (2022)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "36658339",
+    "title": "Avidity-based bright and photostable light-up aptamers for single-molecule mRNA imaging.",
+    "authors": "Bühler, B., Schokolowski, J., Benderoth, A., Englert, D., Grün, F., Jäschke, A., & Sunbul, M.",
+    "journal": "Nature chemical biology, 19(4), 478–487. (2023)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "38760339",
+    "title": "Structural mechanisms for binding and activation of a contact-quenched fluorophore by RhoBAST.",
+    "authors": "Zhang, Y., Xu, Z., Xiao, Y., Jiang, H., Zuo, X., Li, X., & Fang, X.",
+    "journal": "Nature communications, 15(1), 4206. (2024)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "39803439",
+    "title": "Structural basis for ring-opening fluorescence by the RhoBAST RNA aptamer.",
+    "authors": "Siwik, S. H., Wierzba, A. J., Lennon, S. R., Olenginski, L. T., Palmer, A. E., & Batey, R. T.",
+    "journal": "bioRxiv : the preprint server for biology, 2024.12.30.630784. (2024)",
+    "source_file": "_posts/TMR-DN-aptamer.md"
+  },
+  {
+    "pmid": "18230760",
+    "title": "An RNA molecule that specifically inhibits G-protein-coupled receptor kinase 2 in vitro.",
+    "authors": "Mayer, G., Wulffen, B., Huber, C., Brockmann, J., Flicke, B., Neumann, L., Hafenbradl, D., Klebl, B. M., Lohse, M. J., Krasel, C., & Blind, M.",
+    "journal": "RNA (New York, N.Y.), 14(3), 524–534. (2008)",
+    "source_file": "_posts/GRK2-aptamer.md"
+  },
+  {
+    "pmid": "22727813",
+    "title": "Molecular mechanism for inhibition of g protein-coupled receptor kinase 2 by a selective RNA aptamer.",
+    "authors": "Tesmer, V. M., Lennarz, S., Mayer, G., & Tesmer, J. J.",
+    "journal": "Structure (London, England : 1993), 20(8), 1300–1309. (2012)",
+    "source_file": "_posts/GRK2-aptamer.md"
+  },
+  {
+    "pmid": "26552823",
+    "title": "Crystallographic Pursuit of a Protein-RNA Aptamer Complex.",
+    "authors": "Tesmer J. J.",
+    "journal": "Methods in molecular biology (Clifton, N.J.), 1380, 151–160. (2016)",
+    "source_file": "_posts/GRK2-aptamer.md"
+  },
+  {
+    "pmid": "10212256",
+    "title": "DNA aptamers selected against the HIV-1 trans-activation-responsive RNA element form RNA-DNA kissing complexes.",
+    "authors": "Boiziau, C., Dausse, E., Yurchenko, L., & Toulmé, J. J.",
+    "journal": "J Biol Chem, 274(18), 12730-7. (1999)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "10606271",
+    "title": "In vitro selection identifies key determinants for loop-loop interactions: RNA aptamers selective for the TAR RNA element of HIV-1.",
+    "authors": "Ducongé F., & Toulmé, J. J.",
+    "journal": "RNA, 5(12), 1605-14. (1999)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "10954609",
+    "title": "NMR characterization of a kissing complex formed between the TAR RNA element of HIV-1 and a DNA aptamer.",
+    "authors": "Collin, D., van Heijenoort, C., Boiziau, C., Toulmé, J. J., & Guittet, E.",
+    "journal": "Nucleic Acids Res, 28(17), 3386–3391. (2000)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "12052182",
+    "title": "Driving in vitro selection of anti-HIV-1 TAR aptamers by magnesium concentration and temperature.",
+    "authors": "Darfeuille, F., Sekkai, D., Dausse, E., Kolb, G., Yurchenko, L., Boiziau, C., & Toulmé, J. J.",
+    "journal": "Comb Chem High Throughput Screen, 5(4), 313-25. (2002)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "12853646",
+    "title": "Molecular dynamics reveals the stabilizing role of loop closing residues in kissing interactions: comparison between TAR-TAR* and TAR-aptamer.",
+    "authors": "Beaurain, F., Di Primo, C., Toulmé, J. J., & Laguerre, M.",
+    "journal": "Nucleic Acids Res, 31(14), 4275-84. (2003)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "15181175",
+    "title": "LNA/DNA chimeric oligomers mimic RNA aptamers targeted to the TAR RNA element of HIV-1.",
+    "authors": "Darfeuille, F., Hansen, J. B., Orum, H., Di Primo, C., & Toulmé, J. J.",
+    "journal": "Nucleic Acids Res, 32(10), 3101–3107. (2004)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "15723535",
+    "title": "Hexitol nucleic acid-containing aptamers are efficient ligands of HIV-1 TAR RNA.",
+    "authors": "Kolb, G., Reigadas, S., Boiziau, C., van Aerschot, A., Arzumanov, A., Gait, M. J., Herdewijn, P., & Toulmé, J. J.",
+    "journal": "Biochemistry, 44(8), 2926-33. (2005)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "16445294",
+    "title": "Bimodal loop-loop interactions increase the affinity of RNA aptamers for HIV-1 RNA structures.",
+    "authors": "Boucard, D., Toulmé, J. J., & Di Primo, C.",
+    "journal": "Biochemistry, 45(5), 1518-24. (2006)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "17312962",
+    "title": "SELEX and dynamic combinatorial chemistry interplay for the selection of conjugated RNA aptamers.",
+    "authors": "Bugaut, A., Toulmé, J. J., & Rayner, B.",
+    "journal": "Org Biomol Chem, 4(22), 4082-8. (2006)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "17768146",
+    "title": "NMR structure of a kissing complex formed between the TAR RNA element of HIV-1 and a LNA-modified aptamer.",
+    "authors": "Lebars, I., Richard, T., Di Primo, C., & Toulmé, J. J.",
+    "journal": "Nucleic Acids Res, 35(18), 6103-14. (2007)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "18996893",
+    "title": "Exploring TAR–RNA aptamer loop–loop interaction by X-ray crystallography, UV spectroscopy and surface plasmon resonance.",
+    "authors": "Lebars, I., Legrand, P., Aimé, A., Pinaud, N., Fribourg, S., & Di Primo, C.",
+    "journal": "Nucleic Acids Res, 36(22), 7146-56. (2008)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "19496624",
+    "title": "In vitro selection of RNA aptamers derived from a genomic human library against the TAR RNA element of HIV-1.",
+    "authors": "Watrin, M., Von Pelchrzim, F., Dausse, E., Schroeder, R., & Toulmé, J. J.",
+    "journal": "Biochemistry, 48(26), 6278-84. (2009)",
+    "source_file": "_posts/LR06-aptamer.md"
+  },
+  {
+    "pmid": "7528207",
+    "title": "Isozyme-specific inhibition of protein kinase C by RNA aptamers.",
+    "authors": "Conrad, R., Keranen, L. M., Ellington, A. D., & Newton, A. C.",
+    "journal": "The Journal of biological chemistry, 269(51), 32051–32054. (1994)",
+    "source_file": "_posts/PKC-aptamer.md"
+  },
+  {
+    "pmid": "8937571",
+    "title": "Detecting immobilized protein kinase C isozymes with RNA aptamers.",
+    "authors": "Conrad, R., & Ellington, A. D.",
+    "journal": "Analytical biochemistry, 242(2), 261–265. (1996)",
+    "source_file": "_posts/PKC-aptamer.md"
+  },
+  {
+    "pmid": "9889155",
+    "title": "Isolation and characterization of fluorophore-binding RNA aptamers.",
+    "authors": "Holeman, L. A., Robinson, S. L., Szostak, J. W., & Wilson, C.",
+    "journal": "Folding & design, 3(6), 423–431. (1998)",
+    "source_file": "_posts/FB-1-aptamer.md"
+  },
+  {
+    "pmid": "2459391",
+    "title": "Overproduction and purification of Escherichia coli tRNA(2Gln) and its use in crystallization of the glutaminyl-tRNA synthetase-tRNA(Gln) complex.",
+    "authors": "Perona, J. J., Swanson, R., Steitz, T. A., & Söll, D.",
+    "journal": "Journal of molecular biology, 202(1), 121–126. (1988)",
+    "source_file": "_posts/GlnRs-aptamer.md"
+  },
+  {
+    "pmid": "2479982",
+    "title": "Structure of E. coli glutaminyl-tRNA synthetase complexed with tRNA(Gln) and ATP at 2.8 A resolution.",
+    "authors": "Rould, M. A., Perona, J. J., Söll, D., & Steitz, T. A.",
+    "journal": "Science (New York, N.Y.), 246(4934), 1135–1142. (1989)",
+    "source_file": "_posts/GlnRs-aptamer.md"
+  },
+  {
+    "pmid": "10881199",
+    "title": "Tertiary core rearrangements in a tight binding transfer RNA aptamer.",
+    "authors": "Bullock, T. L., Sherlin, L. D., & Perona, J. J.",
+    "journal": "Nature structural biology, 7(6), 497–504. (2000)",
+    "source_file": "_posts/GlnRs-aptamer.md"
+  },
+  {
+    "pmid": "10860750",
+    "title": "Influence of transfer RNA tertiary structure on aminoacylation efficiency by glutaminyl and cysteinyl-tRNA synthetases.",
+    "authors": "Sherlin, L. D., Bullock, T. L., Newberry, K. J., Lipman, R. S., Hou, Y. M., Beijer, B., Sproat, B. S., & Perona, J. J.",
+    "journal": "Journal of molecular biology, 299(2), 431–446. (2000)",
+    "source_file": "_posts/GlnRs-aptamer.md"
+  },
+  {
+    "pmid": "14681579",
+    "title": "Aptamer redesigned tRNA is nonfunctional and degraded in cells.",
+    "authors": "Lee, D., & McClain, W. H.",
+    "journal": "RNA (New York, N.Y.), 10(1), 7–11. (2004)",
+    "source_file": "_posts/GlnRs-aptamer.md"
+  },
+  {
+    "pmid": "25101481",
+    "title": "RNA mango aptamer-fluorophore: a bright, high-affinity complex for RNA labeling and tracking.",
+    "authors": "Dolgosheina, E. V., Jeng, S. C., Panchapakesan, S. S., Cojocaru, R., Chen, P. S., Wilson, P. D., Hawkins, N., Wiggins, P. A., & Unrau, P. J.",
+    "journal": "ACS chemical biology, 9(10), 2412–2420. (2014)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "28553947",
+    "title": "Structural basis for high-affinity fluorophore binding and activation by RNA Mango.",
+    "authors": "Trachman, R. J., 3rd, Demeshkina, N. A., Lau, M. W. L., Panchapakesan, S. S. S., Jeng, S. C. Y., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature chemical biology, 13(7), 807–813. (2017)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "29440634",
+    "title": "Fluorogenic RNA Mango aptamers for imaging small non-coding RNAs in mammalian cells.",
+    "authors": "Autour, A., C Y Jeng, S., D Cawte, A., Abdolahzadeh, A., Galli, A., Panchapakesan, S. S. S., Rueda, D., Ryckelynck, M., & Unrau, P. J.",
+    "journal": "Nature communications, 9(1), 656. (2018)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "29768001",
+    "title": "Crystal structures of the Mango-II RNA aptamer reveal heterogeneous fluorophore binding and guide engineering of variants with improved selectivity and brightness.",
+    "authors": "Trachman, R. J., 3rd, Abdolahzadeh, A., Andreoni, A., Cojocaru, R., Knutson, J. R., Ryckelynck, M., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Biochemistry, 57(26), 3544–3548. (2018)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "30992561",
+    "title": "Structure and functional reselection of the Mango-III fluorogenic RNA aptamer.",
+    "authors": "Trachman, R. J., 3rd, Autour, A., Jeng, S. C. Y., Abdolahzadeh, A., Andreoni, A., Cojocaru, R., Garipov, R., Dolgosheina, E. V., Knutson, J. R., Ryckelynck, M., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature chemical biology, 15(5), 472–479. (2019)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "32152311",
+    "title": "Live cell imaging of single RNA molecules with fluorogenic Mango II arrays.",
+    "authors": "Cawte, A. D., Unrau, P. J., & Rueda, D. S.",
+    "journal": "Nature communications, 11(1), 1283. (2020)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "32386573",
+    "title": "Structure-guided engineering of the homodimeric Mango-IV fluorescence turn-on aptamer yields an RNA FRET pair.",
+    "authors": "Trachman, R. J., 3rd, Cojocaru, R., Wu, D., Piszczek, G., Ryckelynck, M., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Structure (London, England : 1993), 28(7), 776–785.e3. (2020)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "33674421",
+    "title": "RNA Peach and Mango: Orthogonal two-color fluorogenic aptamers distinguish nearly identical ligands.",
+    "authors": "Kong, K. Y. S., Jeng, S. C. Y., Rayyan, B., & Unrau, P. J.",
+    "journal": "RNA (New York, N.Y.), 27(5), 604–615. (2021)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "34971617",
+    "title": "Hidden intermediates in Mango III RNA aptamer folding revealed by pressure perturbation.",
+    "authors": "Harish, B., Wang, J., Hayden, E. J., Grabe, B., Hiller, W., Winter, R., & Royer, C. A.",
+    "journal": "Biophysical journal, 121(3), 421–429. (2022)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "36120549",
+    "title": "Computational study on the binding of Mango-II RNA aptamer and fluorogen using the polarizable force field AMOEBA.",
+    "authors": "Yang, X., Liu, C., Kuo, Y. A., Yeh, H. C., & Ren, P.",
+    "journal": "Frontiers in molecular biosciences, 9, 946708. (2022)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "36840712",
+    "title": "Red light-emitting short Mango-based system enables tracking a mycobacterial small noncoding RNA in infected macrophages.",
+    "authors": "Bychenko, O. S., Khrulev, A. A., Svetlova, J. I., Tsvetkov, V. B., Kamzeeva, P. N., Skvortsova, Y. V., Tupertsev, B. S., Ivanov, I. A., Aseev, L. V., Khodarovich, Y. M., Belyaev, E. S., Kozlovskaya, L. I., Zatsepin, T. S., Azhikina, T. L., Varizhuk, A. M., & Aralov, A. V.",
+    "journal": "Nucleic acids research, 51(6), 2586–2601. (2023)",
+    "source_file": "_posts/Mango-aptamer(TO1-biotin).md"
+  },
+  {
+    "pmid": "17030508",
+    "title": "An RNA aptamer that discriminates bovine factor IX from human factor IX.",
+    "authors": "Gopinath, S. C., Balasundaresan, D., Akitomi, J., & Mizuno, H.",
+    "journal": "Journal of biochemistry, 140(5), 667–676. (2006)",
+    "source_file": "_posts/Bovine-factor-IX-aptamer.md"
+  },
+  {
+    "pmid": "37723244",
+    "title": "Large Stokes shift fluorescent RNAs for dual-emission fluorescence and bioluminescence imaging in live cells.",
+    "authors": "Jiang, L., Xie, X., Su, N., Zhang, D., Chen, X., Xu, X., Zhang, B., Huang, K., Yu, J., Fang, M., Bao, B., Zuo, F., Yang, L., Zhang, R., Li, H., Huang, X., Chen, Z., Zeng, Q., Liu, R., Lin, Q., … Yang, Y.",
+    "journal": "Nature methods, 20(10), 1563–1572. (2023)",
+    "source_file": "_posts/Clivias-aptamer.md"
+  },
+  {
+    "pmid": "38816645",
+    "title": "Structural basis of a small monomeric Clivia fluorogenic RNA with a large Stokes shift.",
+    "authors": "Huang, K., Song, Q., Fang, M., Yao, D., Shen, X., Xu, X., Chen, X., Zhu, L., Yang, Y., & Ren, A.",
+    "journal": "Nature chemical biology, 10.1038/s41589-024-01633-1. (2024)",
+    "source_file": "_posts/Clivias-aptamer.md"
+  },
+  {
+    "pmid": "17079480",
+    "title": "Modulation of oncogenic transcription and alternative splicing by beta-catenin and an RNA aptamer in colon cancer cells.",
+    "authors": "Lee, H. K., & Jeong, S.",
+    "journal": "Cancer research, 66(21), 10560–10566. (2006)",
+    "source_file": "_posts/pUC19-aptamer.md"
+  },
+  {
+    "pmid": "7510417",
+    "title": "High-resolution molecular discrimination by RNA.",
+    "authors": "Jenison, R. D., Gill, S. C., Pardi, A., & Polisky, B.",
+    "journal": "Science (New York, N.Y.), 263(5152), 1425–1429. (1994)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "9224568",
+    "title": "Rational design of allosteric ribozymes.",
+    "authors": "Tang, J., & Breaker, R. R.",
+    "journal": "Chemistry & biology, 4(6), 453–459. (1997)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "9253414",
+    "title": "Interlocking structural motifs mediate molecular discrimination by a theophylline-binding RNA.",
+    "authors": "Zimmermann, G. R., Jenison, R. D., Wick, C. L., Simorre, J. P., & Pardi, A.",
+    "journal": "Nature structural biology, 4(8), 644–649. (1997)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "9636066",
+    "title": "A semiconserved residue inhibits complex formation by stabilizing interactions in the free state of a theophylline-binding RNA.",
+    "authors": "Zimmermann, G. R., Shields, T. P., Jenison, R. D., Wick, C. L., & Pardi, A.",
+    "journal": "Biochemistry, 37(25), 9186–919. (1998)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "10097080",
+    "title": "Engineering precision RNA molecular switches.",
+    "authors": "Soukup, G. A., & Breaker, R. R.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 96(7), 3584–3589. (1999)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "10425680",
+    "title": "Design of allosteric hammerhead ribozymes activated by ligand-induced structure stabilization.",
+    "authors": "Soukup, G. A., & Breaker, R. R.",
+    "journal": "Structure (London, England : 1993), 7(7), 783–791. (1999)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "10836787",
+    "title": "Molecular interactions and metal binding in the theophylline-binding core of an RNA aptamer.",
+    "authors": "Zimmermann, G. R., Wick, C. L., Shields, T. P., Jenison, R. D., & Pardi, A.",
+    "journal": "RNA (New York, N.Y.), 6(5), 659–667. (2000)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "11266567",
+    "title": "Cooperative binding of effectors by an allosteric ribozyme.",
+    "authors": "Jose, A. M., Soukup, G. A., & Breaker, R. R.",
+    "journal": "Nucleic acids research, 29(7), 1631–1637. (2001)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "15109659",
+    "title": "Unnatural base pairs mediate the site-specific incorporation of an unnatural hydrophobic component into RNA transcripts.",
+    "authors": "Endo, M., Mitsui, T., Okuni, T., Kimoto, M., Hirao, I., & Yokoyama, S.",
+    "journal": "Bioorganic & medicinal chemistry letters, 14(10), 2593–2596. (2004)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "15004248",
+    "title": "A theophylline responsive riboswitch based on helix slipping controls gene expression in vivo.",
+    "authors": "Suess, B., Fink, B., Berens, C., Stentz, R., & Hillen, W.",
+    "journal": "Nucleic acids research, 32(4), 1610–1614. (2004)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "15723047",
+    "title": "Programmable ligand-controlled riboregulators of eukaryotic gene expression.",
+    "authors": "Bayer, T. S., & Smolke, C. D.",
+    "journal": "Nature biotechnology, 23(3), 337–343. (2005)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "16513347",
+    "title": "Photochemical hammerhead ribozyme activation.",
+    "authors": "Young, D. D., & Deiters, A.",
+    "journal": "Bioorganic & medicinal chemistry letters, 16(10), 2658–2661. (2006)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "16996258",
+    "title": "Computational selection of nucleic acid biosensors via a slip structure model.",
+    "authors": "Hall, B., Hesselberth, J. R., & Ellington, A. D.",
+    "journal": "Biosensors & bioelectronics, 22(9-10), 1939–1947. (2007)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "17317571",
+    "title": "A high-throughput screen for synthetic riboswitches reveals mechanistic insights into their function.",
+    "authors": "Lynch, S. A., Desai, S. K., Sajja, H. K., & Gallivan, J. P.",
+    "journal": "Chemistry & biology, 14(2), 173–184. (2007)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "19033367",
+    "title": "A flow cytometry-based screen for synthetic riboswitches.",
+    "authors": "Lynch, S. A., & Gallivan, J. P.",
+    "journal": "Nucleic acids research, 37(1), 184–192.  (2009)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "20041206",
+    "title": "Design principles for ligand-sensing, conformation-switching ribozymes.",
+    "authors": "Chen, X., & Ellington, A. D.",
+    "journal": "PLoS computational biology, 5(12), e1000620. (2009)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "22733807",
+    "title": "Kinetic analysis of aptazyme-regulated gene expression in a cell-free translation system: modeling of ligand-dependent and -independent expression.",
+    "authors": "Kobori, S., Ichihashi, N., Kazuta, Y., Matsuura, T., & Yomo, T.",
+    "journal": "RNA (New York, N.Y.), 18(8), 1458–1465. (2012)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "23452219",
+    "title": "Computational design and biosensor applications of small molecule-sensing allosteric ribozymes.",
+    "authors": "Penchovsky R.",
+    "journal": "Biomacromolecules, 14(4), 1240–1249. (2013)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "23969558",
+    "title": "Theophylline-dependent riboswitch as a novel genetic tool for strict regulation of protein expression in Cyanobacterium Synechococcus elongatus PCC 7942.",
+    "authors": "Nakahira, Y., Ogawa, A., Asano, H., Oyama, T., & Tozawa, Y.",
+    "journal": "Plant & cell physiology, 54(10), 1724–1735. (2013)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "23654267",
+    "title": "Modularity of select riboswitch expression platforms enables facile engineering of novel genetic regulatory devices.",
+    "authors": "Ceres, P., Garst, A. D., Marcano-Velázquez, J. G., & Batey, R. T.",
+    "journal": "ACS synthetic biology, 2(8), 463–472. (2013)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "25726466",
+    "title": "Thermodynamic and kinetic folding of riboswitches.",
+    "authors": "Badelt, S., Hammer, S., Flamm, C., & Hofacker, I. L.",
+    "journal": "Methods in enzymology, 553, 193–213. (2015)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "26594238",
+    "title": "Engineering dynamic cell cycle control with synthetic small molecule-responsive RNA devices.",
+    "authors": "Wei, K. Y., & Smolke, C. D",
+    "journal": "Journal of biological engineering,  9, 21. (2015)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "26642994",
+    "title": "Searching the Sequence Space for Potent Aptamers Using SELEX in Silico.",
+    "authors": "Zhou, Q., Xia, X., Luo, Z., Liang, H., & Shakhnovich, E.",
+    "journal": "Journal of chemical theory and computation, 11(12), 5939–5946. (2015)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "30119599",
+    "title": "Engineering Riboswitches in Vivo Using Dual Genetic Selection and Fluorescence-Activated Cell Sorting.",
+    "authors": "Page, K., Shaffer, J., Lin, S., Zhang, M., & Liu, J. M.",
+    "journal": "ACS synthetic biology, 7(9), 2000–2006. (2018)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "30773480",
+    "title": "Detection of Low-Abundance Metabolites in Live Cells Using an RNA Integrator.",
+    "authors": "You, M., Litke, J. L., Wu, R., & Jaffrey, S. R.",
+    "journal": "Cell chemical biology, 26(4), 471–481.e3. (2019)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "31490060",
+    "title": "Controlling Heterogeneity and Increasing Titer from Riboswitch-Regulated Bacillus subtilis Spores for Time-Delayed Protein Expression Applications.",
+    "authors": "Tamiev, D., Lantz, A., Vezeau, G., Salis, H., & Reuel, N. F.",
+    "journal": "ACS synthetic biology, 8(10), 2336–2346. (2019)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "32142605",
+    "title": "The Theophylline Aptamer: 25 Years as an Important Tool in Cellular Engineering Research.",
+    "authors": "Wrist, A., Sun, W., & Summers, R. M.",
+    "journal": "ACS synthetic biology, 9(4), 682–697. (2020)",
+    "source_file": "_posts/Theophylline-aptamer_back2.md"
+  },
+  {
+    "pmid": "10339553",
+    "title": "Laser-mediated, site-specific inactivation of RNA transcripts.",
+    "authors": "Grate, D., & Wilson, C.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 96(11), 6131–6136. (1999)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "10926496",
+    "title": "2.8 A crystal structure of the malachite green aptamer.",
+    "authors": "Baugh, C., Grate, D., & Wilson, C.",
+    "journal": "Journal of molecular biology, 301(1), 117–128. (2000)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "12475353",
+    "title": "Binding to an RNA aptamer changes the charge distribution and conformation of malachite green.",
+    "authors": "Nguyen, D. H., DeFina, S. C., Fink, W. H., & Dieckmann, T.",
+    "journal": "Journal of the American Chemical Society, 124(50), 15081–15084. (2002)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "14695514",
+    "title": "Recognition of planar and nonplanar Ligands in the malachite green±RNA aptamer complex.",
+    "authors": "Flinders, J., DeFina, S. C., Brackett, D. M., Baugh, C., Wilson, C., & Dieckmann, T.",
+    "journal": "Chembiochem : a European journal of chemical biology, 5(1), 62–72. (2004)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "16144363",
+    "title": "Binary malachite green aptamer for fluorescent detection of nucleic acids.",
+    "authors": "Kolpashchikov D. M.",
+    "journal": "Journal of the American Chemical Society, 127(36), 12442–12443.  (2005)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "18667307",
+    "title": "Fluorescence generation from tandem repeats of a malachite green RNA aptamer using rolling circle transcription.",
+    "authors": "Furukawa, K., Abe, H., Abe, N., Harada, M., Tsuneda, S., & Ito, Y.",
+    "journal": "Bioorganic & medicinal chemistry letters, 18(16), 4562–4565. (2008)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "19195013",
+    "title": "Engineered 5S ribosomal RNAs displaying aptamers recognizing vascular endothelial growth factor and malachite green.",
+    "authors": "Zhang, X., Potty, A. S., Jackson, G. W., Stepanov, V., Tang, A., Liu, Y., Kourentzi, K., Strych, U., Fox, G. E., & Willson, R. C.",
+    "journal": "Journal of molecular recognition: JMR, 22(2), 154–161. (2009)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "21523267",
+    "title": "Entropy and Mg2+ control ligand affinity and specificity in the malachite green binding RNA aptamer.",
+    "authors": "Bernard Da Costa, J., & Dieckmann, T.",
+    "journal": "Molecular bioSystems, 7(7), 2156–2163. (2011)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "22192051",
+    "title": "Thermodynamics of ligand binding to a heterogeneous RNA population in the malachite green aptamer.",
+    "authors": "Sokoloski, J. E., Dombrowski, S. E., & Bevilacqua, P. C.",
+    "journal": "Biochemistry, 51(1), 565–572. (2012)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "23984874",
+    "title": "Thermodynamics and kinetics of adaptive binding in the malachite green RNA aptamer.",
+    "authors": "Da Costa, J. B., Andreiev, A. I., & Dieckmann, T.",
+    "journal": "Biochemistry, 52(38), 6575–6583. (2013)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "27591602",
+    "title": "Organic additives stabilize RNA aptamer binding of malachite green.",
+    "authors": "Zhou, Y., Chi, H., Wu, Y., Marks, R. S., & Steele, T. W. J.",
+    "journal": "Talanta, 160, 172–182. (2016)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "29513000",
+    "title": "Labeling RNAs in live cells using malachite green aptamer scaffolds as fluorescent probes.",
+    "authors": "Yerramilli, V. S., & Kim, K. H.",
+    "journal": "ACS synthetic biology, 7(3), 758–766. (2018)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "31187804",
+    "title": "Exploiting the application of l-aptamer with excellent stability: an efficient sensing platform for malachite green in fish samples.",
+    "authors": "Luo, X., Chen, Z., Li, H., Li, W., Cui, L., & Huang, J.",
+    "journal": "The Analyst, 144(14), 4204–4209. (2019)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "35529731",
+    "title": "A label-free aptamer-based biosensor for microRNA detection by the RNA-regulated fluorescence of malachite green.",
+    "authors": "Wang, H., Wang, H., Zhang, M., Jia, Y., & Li, Z.",
+    "journal": "RSC advances, 9(56), 32906–32910. (2019)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "36373144",
+    "title": "A self-assembling split aptamer multiplex assay for SARS-COVID19 and miniaturization of a malachite green DNA-based aptamer.",
+    "authors": "R O'Steen, M., & M Kolpashchikov, D.",
+    "journal": "Sensors and actuators reports, 4, 100125. (2022)",
+    "source_file": "_posts/MG-aptamer.md"
+  },
+  {
+    "pmid": "24374323",
+    "title": "An aptamer that binds efficiently to the hemagglutinins of highly pathogenic avian influenza viruses (H5N1 and H7N7) and inhibits hemagglutinin-glycan interactions.",
+    "authors": "Suenaga, E., & Kumar, PK.",
+    "journal": "Acta Biomaterialia,10(3):1314-23. (2014)",
+    "source_file": "_posts/HPAI-H5N1-aptamer.md"
+  },
+  {
+    "pmid": "10101203",
+    "title": "RNA binding specificity of Unr, a protein with five cold shock domains.",
+    "authors": "Triqueneaux, G., Velten, M., Franzon, P., Dautry, F., & Jacquemin-Sablon, H.",
+    "journal": "Nucleic acids research, 27(8), 1926–1934. (1999)",
+    "source_file": "_posts/Upstream-of-N-Ras-aptamer.md"
+  },
+  {
+    "pmid": "8642604",
+    "title": "Molecular recognition in the FMN-RNA aptamer complex.",
+    "authors": "Fan P, Suri AK, Fiala R, Live D, Patel DJ.",
+    "journal": "J Mol Biol. 1996 May 10;258(3):480-500. (1996)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "10397790",
+    "title": "A molecular dynamics simulation of the flavin mononucleotide-RNA aptamer complex.",
+    "authors": "Schneider C, Sühnel J.",
+    "journal": "Biopolymers. 1999 Sep;50(3):287-302. (1999)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "12903340",
+    "title": "Specific labeling approaches to guanine and adenine imino and amino proton assignments in the AMP-RNA aptamer complex.",
+    "authors": "Jiang, F., Patel, D. J., Zhang, X., Zhao, H., & Jones, R. A",
+    "journal": "Journal of biomolecular NMR, 9(1), 55–62. (2000)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "11377174",
+    "title": "Expression mechanism of the allosteric interactions in a ribozyme catalysis.",
+    "authors": "Araki M, Okuno Y, Sugiura Y.",
+    "journal": "Nucleic Acids Symp Ser. 2000;(44):205-6. (2001)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "14588007",
+    "title": "Electrochromatographic retention studies on a flavin-binding RNA aptamer sorbent.",
+    "authors": "Clark SL, Remcho VT.",
+    "journal": "Anal Chem. 2003 Nov 1;75(21):5692-6. (2003)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "16377778",
+    "title": "Identification of a 14mer RNA that recognizes and binds flavin mononucleotide with high affinity.",
+    "authors": "Anderson PC, Mecozzi S",
+    "journal": "Nucleic Acids Res. 2005 Dec 23;33(22):6992-9 (2005)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "16199761",
+    "title": "Competitive regulation of modular allosteric aptazymes by a small molecule and oligonucleotide effector.",
+    "authors": "Najafi-Shoushtari SH, Famulok M.",
+    "journal": "RNA. 2005 Oct;11(10):1514-20. (2005)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "16996258",
+    "title": "Computational selection of nucleic acid biosensors via a slip structure model.",
+    "authors": "Hall B, Hesselberth JR, Ellington AD.",
+    "journal": "Biosens Bioelectron. 2007 Apr 15;22(9-10):1939-47. (2007)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "25173759",
+    "title": "Role of Mg²⁺ ions in flavin recognition by RNA aptamer.",
+    "authors": "Sengupta A, Gavvala K, Koninti RK, Hazra P.",
+    "journal": "J Photochem Photobiol B. 2014 Nov;140:240-8. (2014)",
+    "source_file": "_posts/FMN-aptamer.md"
+  },
+  {
+    "pmid": "9889155",
+    "title": "Isolation and characterization of fluorophore-binding RNA aptamers.",
+    "authors": "Holeman, L. A., Robinson, S. L., Szostak, J. W., & Wilson, C.",
+    "journal": "Folding & design, 3(6), 423–431. (1998)",
+    "source_file": "_posts/SRB-2-aptamer.md"
+  },
+  {
+    "pmid": "19303859",
+    "title": "Characterization of a fluorophore binding RNA aptamer by fluorescence correlation spectroscopy and small angle X-ray scattering.",
+    "authors": "Werner, A., Konarev, P. V., Svergun, D. I., & Hahn, U.",
+    "journal": "Analytical biochemistry, 389(1), 52–62. (2009)",
+    "source_file": "_posts/SRB-2-aptamer.md"
+  },
+  {
+    "pmid": "24133044",
+    "title": "Contact-Mediated Quenching for RNA Imaging in Bacteria with  a Fluorophore-Binding Aptamer.",
+    "authors": "Sunbul, M., & Jäschke, A.",
+    "journal": "Angewandte Chemie, 52(50), 13401–13404. (2013)",
+    "source_file": "_posts/SRB-2-aptamer.md"
+  },
+  {
+    "pmid": "26175046",
+    "title": "Dual-colour imaging of RNAs using quencher- and fluorophore-binding aptamers.",
+    "authors": "Arora, A., Sunbul, M., & Jäschke, A.",
+    "journal": "Nucleic acids research, 43(21), e144. (2015)",
+    "source_file": "_posts/SRB-2-aptamer.md"
+  },
+  {
+    "pmid": "29931157",
+    "title": "SRB-2: a promiscuous rainbow aptamer for live-cell RNA imaging.",
+    "authors": "Sunbul, M., & Jäschke, A.",
+    "journal": "Nucleic acids research, 46(18), e110. (2018)",
+    "source_file": "_posts/SRB-2-aptamer.md"
+  },
+  {
+    "pmid": "31636432",
+    "title": "A dimerization-based fluorogenic dye-aptamer module for RNA imaging in live cells.",
+    "authors": "Bouhedda, F., Fam, K. T., Collot, M., Autour, A., Marzi, S., Klymchenko, A., & Ryckelynck, M.",
+    "journal": "Nature chemical biology, 16(1), 69–76.  (2020)",
+    "source_file": "_posts/SRB-2-aptamer.md"
+  },
+  {
+    "pmid": "28945233",
+    "title": "Imaging RNA polymerase III transcription using a photostable RNA-fluorophore complex.",
+    "authors": "Song, W., Filonov, G. S., Kim, H., Hirsch, M., Li, X., Moon, J. D., & Jaffrey, S. R.",
+    "journal": "Nature chemical biology, 13(11), 1187–1194. (2017)",
+    "source_file": "_posts/Beetroot-aptamer(ThT).md"
+  },
+  {
+    "pmid": "31178406",
+    "title": "Binding between G quadruplexes at the homodimer interface of the corn RNA aptamer strongly activates thioflavin T fluorescence.",
+    "authors": "Sjekloća, L., & Ferré-D'Amaré, A. R.",
+    "journal": "Cell chemical biology, 26(8), 1159–1168.e4. (2019)",
+    "source_file": "_posts/Beetroot-aptamer(ThT).md"
+  },
+  {
+    "pmid": "37221204",
+    "title": "Co-crystal structures of the fluorogenic aptamer Beetroot show that close homology may not predict similar RNA architecture.",
+    "authors": "Passalacqua, L. F. M., Starich, M. R., Link, K. A., Wu, J., Knutson, J. R., Tjandra, N., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature communications, 14(1), 2969. (2023)",
+    "source_file": "_posts/Beetroot-aptamer(ThT).md"
+  },
+  {
+    "pmid": "21798953",
+    "title": "RNA mimics of green fluorescent protein.",
+    "authors": "Paige, J. S., Wu, K. Y., & Jaffrey, S. R.",
+    "journal": "Science (New York, N.Y.), 333(6042), 642–646. (2011)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "23746618",
+    "title": "New approaches for sensing metabolites and proteins in live cells using RNA.",
+    "authors": "Strack, R. L., & Jaffrey, S. R.",
+    "journal": "Current opinion in chemical biology, 17(4), 651–655. (2013)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "23991672",
+    "title": "Universal aptamer-based real-time monitoring of enzymatic RNA synthesis.",
+    "authors": "Höfer, K., Langejürgen, L. V., & Jäschke, A.",
+    "journal": "Journal of the American Chemical Society, 135(37), 13692–13694. (2013)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "24286188",
+    "title": "Understanding the photophysics of the spinach-DFHBI RNA aptamer-fluorogen complex to improve live-cell RNA imaging.",
+    "authors": "Han, K. Y., Leslie, B. J., Fei, J., Zhang, J., & Ha, T.",
+    "journal": "Journal of the American Chemical Society, 135(50), 19033–19038. (2013)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "24393009",
+    "title": "Plug-and-play fluorophores extend the spectral properties of Spinach.",
+    "authors": "Song, W., Strack, R. L., Svensen, N., & Jaffrey, S. R.",
+    "journal": "Journal of the American Chemical Society, 136(4), 1198–1201. (2014)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "23991760",
+    "title": "The spinach RNA aptamer as a characterization tool for synthetic biology.",
+    "authors": "Pothoulakis, G., Ceroni, F., Reeve, B., & Ellis, T.",
+    "journal": "ACS synthetic biology, 3(3), 182–187. (2014)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "25026079",
+    "title": "Structural basis for activity of highly efficient RNA mimics of green fluorescent protein.",
+    "authors": "Warner, K. D., Chen, M. C., Song, W., Strack, R. L., Thorn, A., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature structural & molecular biology, 21(8), 658–663. (2014)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "24942625",
+    "title": "A Spinach molecular beacon triggered by strand displacement.",
+    "authors": "Bhadra, S., & Ellington, A. D.",
+    "journal": "RNA (New York, N.Y.), 20(8), 1183–1194. (2014)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "25337688",
+    "title": "Broccoli: rapid selection of an RNA mimic of green fluorescent protein by fluorescence-based selection and directed evolution.",
+    "authors": "Filonov, G. S., Moon, J. D., Svensen, N., & Jaffrey, S. R.",
+    "journal": "Journal of the American Chemical Society, 136(46), 16299–16308. (2014)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "24932527",
+    "title": "Fluorescent monitoring of RNA assembly and processing using the split-Spinach aptamer.",
+    "authors": "Rogers, T. A., Andrews, G. E., Jaeger, L., & Grabow, W. W.",
+    "journal": "ACS synthetic biology, 4(2), 162–166. (2015)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "26000751",
+    "title": "In-gel imaging of RNA processing using Broccoli reveals optimal aptamer expression strategies.",
+    "authors": "Filonov, G. S., Kam, C. W., Song, W., & Jaffrey, S. R.",
+    "journal": "Chemistry & biology, 22(5), 649–660. (2015)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "25964329",
+    "title": "Imaging metabolite dynamics in living cells using a Spinach-based riboswitch.",
+    "authors": "You, M., Litke, J. L., & Jaffrey, S. R.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 112(21), E2756–E2765. (2015)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "26612428",
+    "title": "Tandem spinach array for mRNA imaging in living bacterial cells.",
+    "authors": "Zhang, J., Fei, J., Leslie, B. J., Han, K. Y., Kuhlman, T. E., & Ha, T.",
+    "journal": "Scientific reports, 5, 17295.  (2015)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "26932363",
+    "title": "iSpinach: a fluorogenic RNA aptamer optimized for in vitro applications.",
+    "authors": "Autour, A., Westhof, E., & Ryckelynck, M.",
+    "journal": "Nucleic acids research, 44(6), 2491–2500.  (2016)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "27305425",
+    "title": "Split spinach aptamer for highly selective recognition of DNA and RNA at ambient temperatures.",
+    "authors": "Kikuchi, N., & Kolpashchikov, D. M.",
+    "journal": "Chembiochem : a European journal of chemical biology, 17(17), 1589–1592. (2016)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "28180326",
+    "title": "Use of Baby Spinach and broccoli for imaging of structured cellular RNAs.",
+    "authors": "Okuda, M., Fourmy, D., & Yoshizawa, S.",
+    "journal": "Nucleic acids research, 45(3), 1404–1415. (2017)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "29295996",
+    "title": "Development of a genetically encodable FRET system using fluorescent RNA aptamers.",
+    "authors": "Jepsen, M. D. E., Sparvath, S. M., Nielsen, T. B., Langvad, A. H., Grossi, G., Gothelf, K. V., & Andersen, E. S.",
+    "journal": "Nature communications, 9(1), 18. (2018)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "30016869",
+    "title": "Amplified tandem Spinach-based aptamer transcription enables low background miRNA detection.",
+    "authors": "Tang, X., Deng, R., Sun, Y., Ren, X., Zhou, M., & Li, J. (2018).",
+    "journal": "Analytical chemistry, 90(16), 10001–10008. (2018)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "30807171",
+    "title": "Characterization of the photophysical behavior of DFHBI derivatives: Fluorogenic molecules that illuminate the Spinach RNA aptamer.",
+    "authors": "Santra, K., Geraskin, I., Nilsen-Hamilton, M., Kraus, G. A., & Petrich, J. W.",
+    "journal": "The journal of physical chemistry. B, 123(11), 2536–2545. (2019)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "33795733",
+    "title": "Photophysics of DFHBI bound to RNA aptamer Baby Spinach.",
+    "authors": "Dao, N. T., Haselsberger, R., Khuc, M. T., Phan, A. T., Voityuk, A. A., & Michel-Beyerle, M. E.",
+    "journal": "Scientific reports, 11(1), 7356. (2021)",
+    "source_file": "_posts/Spinach-aptamer.md"
+  },
+  {
+    "pmid": "9310370",
+    "title": "Selection of RNA aptamers that bind specifically to the NS3 protease of hepatitis C virus.",
+    "authors": "Urvil, P. T., Kakiuchi, N., Zhou, D. M., Shimotohno, K., Kumar, P. K., & Nishikawa, S.",
+    "journal": "European journal of biochemistry, 248(1), 130–138.  (1997)",
+    "source_file": "_posts/G9-II-aptamer.md"
+  },
+  {
+    "pmid": "9356339",
+    "title": "Isolation of RNA aptamers specific to the NS3 protein of hepatitis C virus from a pool of completely random RNA.",
+    "authors": "Kumar, P. K., Machida, K., Urvil, P. T., Kakiuchi, N., Vishnuvardhan, D., Shimotohno, K., Taira, K., & Nishikawa, S.",
+    "journal": "Virology, 237(2), 270–282. (1997)",
+    "source_file": "_posts/G9-II-aptamer.md"
+  },
+  {
+    "pmid": "10848986",
+    "title": "Isolation and characterization of RNA aptamers specific for the hepatitis C virus nonstructural protein 3 protease.",
+    "authors": "Fukuda, K., Vishnuvardhan, D., Sekiya, S., Hwang, J., Kakiuchi, N., Taira, K., Shimotohno, K., Kumar, P. K., & Nishikawa, S.",
+    "journal": "European journal of biochemistry, 267(12), 3685–3694. (2000)",
+    "source_file": "_posts/G9-II-aptamer.md"
+  },
+  {
+    "pmid": "11118325",
+    "title": "The RNA aptamer-binding site of hepatitis C virus NS3 protease.",
+    "authors": "Hwang, J., Fauzi, H., Fukuda, K., Sekiya, S., Kakiuchi, N., Shimotohno, K., Taira, K., Kusakabe, I., & Nishikawa, S.",
+    "journal": "Biochemical and biophysical research communications, 279(2), 557–562. (2000)",
+    "source_file": "_posts/G9-II-aptamer.md"
+  },
+  {
+    "pmid": "12655010",
+    "title": "Inhibition of HCV NS3 protease by RNA aptamers in cells.",
+    "authors": "Nishikawa, F., Kakiuchi, N., Funaji, K., Fukuda, K., Sekiya, S., & Nishikawa, S.",
+    "journal": "Nucleic acids research, 31(7), 1935–1943. (2003)",
+    "source_file": "_posts/G9-II-aptamer.md"
+  },
+  {
+    "pmid": "15541341",
+    "title": "An RNA ligand inhibits hepatitis C virus NS3 protease and helicase activities.",
+    "authors": "Fukuda, K., Umehara, T., Sekiya, S., Kunio, K., Hasegawa, T., & Nishikawa, S.",
+    "journal": "Biochemical and biophysical research communications, 325(3), 670–675. (2004)",
+    "source_file": "_posts/G9-II-aptamer.md"
+  },
+  {
+    "pmid": "22814430",
+    "title": "RNA binding by the NS3 protease of the hepatitis C virus.",
+    "authors": "Vaughan, R., Li, Y., Fan, B., Ranjith-Kumar, C. T., & Kao, C. C.",
+    "journal": "Virus research, 169(1), 80–90. (2012)",
+    "source_file": "_posts/G9-II-aptamer.md"
+  },
+  {
+    "pmid": "9310370",
+    "title": "Selection of RNA aptamers that bind specifically to the NS3 protease of hepatitis C virus.",
+    "authors": "Urvil, P. T., Kakiuchi, N., Zhou, D. M., Shimotohno, K., Kumar, P. K., & Nishikawa, S.",
+    "journal": "European journal of biochemistry, 248(1), 130–138.  (1997)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "9356339",
+    "title": "Isolation of RNA aptamers specific to the NS3 protein of hepatitis C virus from a pool of completely random RNA.",
+    "authors": "Kumar, P. K., Machida, K., Urvil, P. T., Kakiuchi, N., Vishnuvardhan, D., Shimotohno, K., Taira, K., & Nishikawa, S.",
+    "journal": "Virology, 237(2), 270–282. (1997)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "10848986",
+    "title": "Isolation and characterization of RNA aptamers specific for the hepatitis C virus nonstructural protein 3 protease.",
+    "authors": "Fukuda, K., Vishnuvardhan, D., Sekiya, S., Hwang, J., Kakiuchi, N., Taira, K., Shimotohno, K., Kumar, P. K., & Nishikawa, S.",
+    "journal": "European journal of biochemistry, 267(12), 3685–3694. (2000)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "11118325",
+    "title": "The RNA aptamer-binding site of hepatitis C virus NS3 protease.",
+    "authors": "Hwang, J., Fauzi, H., Fukuda, K., Sekiya, S., Kakiuchi, N., Shimotohno, K., Taira, K., Kusakabe, I., & Nishikawa, S.",
+    "journal": "Biochemical and biophysical research communications, 279(2), 557–562. (2000)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "12655010",
+    "title": "Inhibition of HCV NS3 protease by RNA aptamers in cells.",
+    "authors": "Nishikawa, F., Kakiuchi, N., Funaji, K., Fukuda, K., Sekiya, S., & Nishikawa, S.",
+    "journal": "Nucleic acids research, 31(7), 1935–1943. (2003)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "15247433",
+    "title": "Isolation of specific and high-affinity RNA aptamers against NS3 helicase domain of hepatitis C virus.",
+    "authors": "Hwang, B., Cho, J. S., Yeo, H. J., Kim, J. H., Chung, K. M., Han, K., Jang, S. K., & Lee, S. W.",
+    "journal": "RNA (New York, N.Y.), 10(8), 1277–1290. (2004)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "15541341",
+    "title": "An RNA ligand inhibits hepatitis C virus NS3 protease and helicase activities.",
+    "authors": "Fukuda, K., Umehara, T., Sekiya, S., Kunio, K., Hasegawa, T., & Nishikawa, S.",
+    "journal": "Biochemical and biophysical research communications, 325(3), 670–675. (2004)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "22814430",
+    "title": "RNA binding by the NS3 protease of the hepatitis C virus.",
+    "authors": "Vaughan, R., Li, Y., Fan, B., Ranjith-Kumar, C. T., & Kao, C. C.",
+    "journal": "Virus research, 169(1), 80–90. (2012)",
+    "source_file": "_posts/G6-16-aptamer.md"
+  },
+  {
+    "pmid": "12490703",
+    "title": "Interaction of C5 protein with RNA aptamers selected by SELEX.",
+    "authors": "Lee, J. H., Kim, H., Ko, J., & Lee, Y.",
+    "journal": "Nucleic acids research, 30(24), 5360–5368. (2002)",
+    "source_file": "_posts/Complement-component-5-aptamer.md"
+  },
+  {
+    "pmid": "30303958",
+    "title": "Novel RNA aptamers targeting gastrointestinal cancer biomarkers CEA, CA50 and CA72-4 with superior affinity and specificity.",
+    "authors": "Pan, Q., Law, C. O., Yung, M. M., Han, K. C., Pon, Y. L., & Lau, T. C. K.",
+    "journal": "PLoS One, 13(10), e0198980. (2015)",
+    "source_file": "_posts/Gastrointestinal-carcinoembryonic-antigen-(CEA)-aptamer.md"
+  },
+  {
+    "pmid": "25101481",
+    "title": "RNA mango aptamer-fluorophore: a bright, high-affinity complex for RNA labeling and tracking.",
+    "authors": "Dolgosheina, E. V., Jeng, S. C., Panchapakesan, S. S., Cojocaru, R., Chen, P. S., Wilson, P. D., Hawkins, N., Wiggins, P. A., & Unrau, P. J.",
+    "journal": "ACS chemical biology, 9(10), 2412–2420. (2014)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "28553947",
+    "title": "Structural basis for high-affinity fluorophore binding and activation by RNA Mango.",
+    "authors": "Trachman, R. J., 3rd, Demeshkina, N. A., Lau, M. W. L., Panchapakesan, S. S. S., Jeng, S. C. Y., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature chemical biology, 13(7), 807–813. (2017)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "29440634",
+    "title": "Fluorogenic RNA Mango aptamers for imaging small non-coding RNAs in mammalian cells.",
+    "authors": "Autour, A., C Y Jeng, S., D Cawte, A., Abdolahzadeh, A., Galli, A., Panchapakesan, S. S. S., Rueda, D., Ryckelynck, M., & Unrau, P. J.",
+    "journal": "Nature communications, 9(1), 656. (2018)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "29768001",
+    "title": "Crystal structures of the Mango-II RNA aptamer reveal heterogeneous fluorophore binding and guide engineering of variants with improved selectivity and brightness.",
+    "authors": "Trachman, R. J., 3rd, Abdolahzadeh, A., Andreoni, A., Cojocaru, R., Knutson, J. R., Ryckelynck, M., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Biochemistry, 57(26), 3544–3548. (2018)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "30992561",
+    "title": "Structure and functional reselection of the Mango-III fluorogenic RNA aptamer.",
+    "authors": "Trachman, R. J., 3rd, Autour, A., Jeng, S. C. Y., Abdolahzadeh, A., Andreoni, A., Cojocaru, R., Garipov, R., Dolgosheina, E. V., Knutson, J. R., Ryckelynck, M., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature chemical biology, 15(5), 472–479. (2019)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "32152311",
+    "title": "Live cell imaging of single RNA molecules with fluorogenic Mango II arrays.",
+    "authors": "Cawte, A. D., Unrau, P. J., & Rueda, D. S.",
+    "journal": "Nature communications, 11(1), 1283. (2020)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "32386573",
+    "title": "Structure-guided engineering of the homodimeric Mango-IV fluorescence turn-on aptamer yields an RNA FRET pair.",
+    "authors": "Trachman, R. J., 3rd, Cojocaru, R., Wu, D., Piszczek, G., Ryckelynck, M., Unrau, P. J., & Ferré-D'Amaré, A. R.",
+    "journal": "Structure (London, England : 1993), 28(7), 776–785.e3. (2020)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "33674421",
+    "title": "RNA Peach and Mango: Orthogonal two-color fluorogenic aptamers distinguish nearly identical ligands.",
+    "authors": "Kong, K. Y. S., Jeng, S. C. Y., Rayyan, B., & Unrau, P. J.",
+    "journal": "RNA (New York, N.Y.), 27(5), 604–615. (2021)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "34971617",
+    "title": "Hidden intermediates in Mango III RNA aptamer folding revealed by pressure perturbation.",
+    "authors": "Harish, B., Wang, J., Hayden, E. J., Grabe, B., Hiller, W., Winter, R., & Royer, C. A.",
+    "journal": "Biophysical journal, 121(3), 421–429. (2022)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "36120549",
+    "title": "Computational study on the binding of Mango-II RNA aptamer and fluorogen using the polarizable force field AMOEBA.",
+    "authors": "Yang, X., Liu, C., Kuo, Y. A., Yeh, H. C., & Ren, P.",
+    "journal": "Frontiers in molecular biosciences, 9, 946708. (2022)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "36840712",
+    "title": "Red light-emitting short Mango-based system enables tracking a mycobacterial small noncoding RNA in infected macrophages.",
+    "authors": "Bychenko, O. S., Khrulev, A. A., Svetlova, J. I., Tsvetkov, V. B., Kamzeeva, P. N., Skvortsova, Y. V., Tupertsev, B. S., Ivanov, I. A., Aseev, L. V., Khodarovich, Y. M., Belyaev, E. S., Kozlovskaya, L. I., Zatsepin, T. S., Azhikina, T. L., Varizhuk, A. M., & Aralov, A. V.",
+    "journal": "Nucleic acids research, 51(6), 2586–2601. (2023)",
+    "source_file": "_posts/Mango-aptamer.md"
+  },
+  {
+    "pmid": "12557236",
+    "title": "RNA aptamers specific for bovine thrombin.",
+    "authors": "Liu X, Zhang D, Cao G, Yang G, Ding H, Liu G, Fan M, Shen B, Shao N.",
+    "journal": "J Mol Recognit. 16(1):23-7. (2003)",
+    "source_file": "_posts/Bovine-thrombin-aptamer.md"
+  },
+  {
+    "pmid": "10786843",
+    "title": "Molecular recognition of amino acids by RNA aptamers: the evolution into an L-tyrosine binder of a dopamine-binding RNA motif.",
+    "authors": "Mannironi C, Scerch C, Fruscoloni P, Tocchini-Valentini GP",
+    "journal": "RNA. 2000 Apr;6(4):520-7. (2000)",
+    "source_file": "_posts/Tyr-1-aptamer.md"
+  },
+  {
+    "pmid": "28835641",
+    "title": "NA-aptamers-in-droplets (RAPID) high-throughput screening for secretory phenotypes.",
+    "authors": "Abatemarco J, Sarhan MF, Wagner JM, Lin JL, Liu L, Hassouneh W, Yuan SF, Alper HS, Abate AR",
+    "journal": "Nature communications. 2017 Aug 23;8(1):332. (2017)",
+    "source_file": "_posts/Tyr-1-aptamer.md"
+  },
+  {
+    "pmid": "30303958",
+    "title": "Novel RNA aptamers targeting gastrointestinal cancer biomarkers CEA, CA50 and CA72-4 with superior affinity and specificity.",
+    "authors": "Pan, Q., Law, C. O., Yung, M. M., Han, K. C., Pon, Y. L., & Lau, T. C. K.",
+    "journal": "PLoS One, 13(10), e0198980. (2018)",
+    "source_file": "_posts/Gastrointestinal-cancer-antigen-50-aptamer.md"
+  },
+  {
+    "pmid": "7505429",
+    "title": "Selective optimization of the Rev-binding element of HIV-1.",
+    "authors": "Giver, L., Bartel, D., Zapp, M., Pawul, A., Green, M., & Ellington, A. D.",
+    "journal": "Nucleic acids research, 21(23), 5509–5516. (1993)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "7506689",
+    "title": "Selection and design of high-affinity RNA ligands for HIV-1 Rev.",
+    "authors": "Giver, L., Bartel, D. P., Zapp, M. L., Green, M. R., & Ellington, A. D.",
+    "journal": "Gene, 137(1), 19–24. (1993)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "7664035",
+    "title": "A three-dimensional model of the Rev-binding element of HIV-1 derived from analyses of aptamers.",
+    "authors": "Leclerc, F., Cedergren, R., & Ellington, A. D.",
+    "journal": "Nature structural biology, 1(5), 293–300. (1994)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "8523524",
+    "title": "RNA aptamers selected to bind human immunodeficiency virus type 1 Rev in vitro are Rev responsive in vivo.",
+    "authors": "Symensma, T. L., Giver, L., Zapp, M., Takle, G. B., & Ellington, A. D.",
+    "journal": "Journal of virology, 70(1), 179–187. (1996)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "8946856",
+    "title": "Deep penetration of an alpha-helix into a widened RNA major groove in the HIV-1 rev peptide-RNA aptamer complex.",
+    "authors": "Ye, X., Gorin, A., Ellington, A. D., & Patel, D. J.",
+    "journal": "Nature structural biology, 3(12), 1026–1033. (1996)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "9713975",
+    "title": "Receptor ligand-facilitated cationic liposome delivery of anti-HIV-1 Rev-binding aptamer and ribozyme DNAs.",
+    "authors": "Konopka, K., Düzgüneş, N., Rossi, J., & Lee, N. S.",
+    "journal": "Journal of drug targeting, 5(4), 247–259. (1998)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "15610009",
+    "title": "Retention of conformational flexibility in HIV-1 Rev-RNA complexes.",
+    "authors": "Wilkinson, T. A., Zhu, L., Hu, W., & Chen, Y.",
+    "journal": "Biochemistry, 43(51), 16153–16160. (2004)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "30017564",
+    "title": "Structure of an RNA Aptamer that Can Inhibit HIV-1 by Blocking Rev-Cognate RNA (RRE) Binding and Rev-Rev Association.",
+    "authors": "Dearborn, A. D., Eren, E., Watts, N. R., Palmer, I. W., Kaufman, J. D., Steven, A. C., & Wingfield, P. T.",
+    "journal": "Structure (London, England : 1993), 26(9), 1187–1195.e4.  (2018)",
+    "source_file": "_posts/RBA-14-aptamer.md"
+  },
+  {
+    "pmid": "9111335",
+    "title": "A specific RNA hairpin loop structure binds the RNA recognition motifs of the Drosophila SR protein B52.",
+    "authors": "Shi, H., Hoffman, B. E., & Lis, J. T.",
+    "journal": "Molecular and cellular biology, 17(5), 2649–2657. (1997)",
+    "source_file": "_posts/B52-aptamer.md"
+  },
+  {
+    "pmid": "10468557",
+    "title": "RNA aptamers as effective protein antagonists in a multicellular organism.",
+    "authors": "Shi, H., Hoffman, B. E., & Lis, J. T.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 96(18), 10033–10038. (1999)",
+    "source_file": "_posts/B52-aptamer.md"
+  },
+  {
+    "pmid": "12655012",
+    "title": "Specific SR protein-dependent splicing substrates identified through genomic SELEX.",
+    "authors": "Kim, S., Shi, H., Lee, D. K., & Lis, J. T.",
+    "journal": "Nucleic acids research, 31(7), 1955–1961. (2003)",
+    "source_file": "_posts/B52-aptamer.md"
+  },
+  {
+    "pmid": "19380374",
+    "title": "Composite RNA aptamers as functional mimics of proteins.",
+    "authors": "Xu, D., & Shi, H.",
+    "journal": "Nucleic acids research, 37(9), e71. (2009)",
+    "source_file": "_posts/B52-aptamer.md"
+  },
+  {
+    "pmid": "24570482",
+    "title": "An RNA aptamer possessing a novel monovalent cation-mediated fold inhibits lysozyme catalysis by inhibiting the binding of long natural substrates.",
+    "authors": "Padlan, C. S., Malashkevich, V. N., Almo, S. C., Levy, M., Brenowitz, M., & Girvin, M. E.",
+    "journal": "RNA, 20(4), 447–461. (2013)",
+    "source_file": "_posts/Lysozyme-aptamer.md"
+  },
+  {
+    "pmid": "20159999",
+    "title": "Selecting RNA aptamers for synthetic biology: investigating magnesium dependence and predicting binding affinity.",
+    "authors": "Carothers, J. M., Goler, J. A., Kapoor, Y., Lara, L., & Keasling, J. D.",
+    "journal": "Nucleic acids research, 38(8), 2736–2747. (2010)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "27730489",
+    "title": "NMR resonance assignments for the tetramethylrhodamine binding RNA aptamer 3 in complex with the ligand 5-carboxy-tetramethylrhodamine.",
+    "authors": "Duchardt-Ferner, E., Juen, M., Kreutz, C., & Wöhnert, J.",
+    "journal": "Biomolecular NMR assignments, 11(1), 29–34. (2017)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "30986047",
+    "title": "SiRA: A Silicon Rhodamine-Binding Aptamer for Live-Cell Super-Resolution RNA Imaging.",
+    "authors": "Wirth, R., Gao, P., Nienhaus, G. U., Sunbul, M., & Jäschke, A.",
+    "journal": "Journal of the American Chemical Society, 141(18), 7562–7571. (2019)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "31754719",
+    "title": "Structure of an RNA aptamer in complex with the  fluorophore tetramethylrhodamine.",
+    "authors": "Duchardt-Ferner, E., Juen, M., Bourgeois, B., Madl, T., Kreutz, C., Ohlenschläger, O., & Wöhnert, J.",
+    "journal": "Nucleic acids research, 48(2), 949–961. (2020)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "33574610",
+    "title": "Super-resolution RNA imaging using a rhodamine-binding aptamer with fast exchange kinetics.",
+    "authors": "Sunbul, M., Lackner, J., Martin, A., Englert, D., Hacene, B., Grün, F., Nienhaus, K., Nienhaus, G. U., & Jäschke, A.",
+    "journal": "Nature biotechnology, 39(6), 686–690. (2021)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "35486532",
+    "title": "Rational Design of Self-Quenched Rhodamine Dimers as Fluorogenic Aptamer Probes for Live-Cell RNA Imaging.",
+    "authors": "Fam, K. T., Pelletier, R., Bouhedda, F., Ryckelynck, M., Collot, M., & Klymchenko, A. S.",
+    "journal": "Analytical chemistry, 94(18), 6657–6664. (2022)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "36658339",
+    "title": "Avidity-based bright and photostable light-up aptamers for single-molecule mRNA imaging.",
+    "authors": "Bühler, B., Schokolowski, J., Benderoth, A., Englert, D., Grün, F., Jäschke, A., & Sunbul, M.",
+    "journal": "Nature chemical biology, 19(4), 478–487. (2023)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "38760339",
+    "title": "Structural mechanisms for binding and activation of a contact-quenched fluorophore by RhoBAST.",
+    "authors": "Zhang, Y., Xu, Z., Xiao, Y., Jiang, H., Zuo, X., Li, X., & Fang, X.",
+    "journal": "Nature communications, 15(1), 4206. (2024)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "39803439",
+    "title": "Structural basis for ring-opening fluorescence by the RhoBAST RNA aptamer.",
+    "authors": "Siwik, S. H., Wierzba, A. J., Lennon, S. R., Olenginski, L. T., Palmer, A. E., & Batey, R. T.",
+    "journal": "bioRxiv : the preprint server for biology, 2024.12.30.630784. (2024)",
+    "source_file": "_posts/TMR-aptamer.md"
+  },
+  {
+    "pmid": "9346949",
+    "title": "Selective targeting and inhibition of yeast RNA polymerase II by RNA aptamers.",
+    "authors": "Thomas, M., Chédin, S., Carles, C., Riva, M., Famulok, M., & Sentenac, A.",
+    "journal": "The Journal of biological chemistry, 272(44), 27980–27986. (1997)",
+    "source_file": "_posts/FC-RNA-aptamer.md"
+  },
+  {
+    "pmid": "16341226",
+    "title": "Structure of an RNA polymerase II-RNA inhibitor complex elucidates transcription regulation by noncoding RNAs.",
+    "authors": "Kettenberger, H., Eisenführ, A., Brueckner, F., Theis, M., Famulok, M., & Cramer, P.",
+    "journal": "Nature structural & molecular biology, 13(1), 44–48. (2006)",
+    "source_file": "_posts/FC-RNA-aptamer.md"
+  },
+  {
+    "pmid": "29570714",
+    "title": "Nascent RNA signaling to yeast RNA Pol II during transcription elongation.",
+    "authors": "Klopf, E., Moes, M., Amman, F., Zimmermann, B., von Pelchrzim, F., Wagner, C., & Schroeder, R.",
+    "journal": "PloS one, 13(3), e0194438. (2018)",
+    "source_file": "_posts/FC-RNA-aptamer.md"
+  },
+  {
+    "pmid": "32663063",
+    "title": "RNA polymerase II-binding aptamers in human ACRO1 satellites disrupt transcription in cis.",
+    "authors": "Boots, J. L., von Pelchrzim, F., Weiss, A., Zimmermann, B., Friesacher, T., Radtke, M., Żywicki, M., Chen, D., Matylla-Kulińska, K., Zagrovic, B., & Schroeder, R.",
+    "journal": "Transcription, 11(5), 217–229. (2020)",
+    "source_file": "_posts/FC-RNA-aptamer.md"
+  },
+  {
+    "pmid": "12408978",
+    "title": "In vitro selection of specific RNA inhibitors of NFATc.",
+    "authors": "Bae, S. J., Oum, J. H., Sharma, S., Park, J., & Lee, S. W.",
+    "journal": "Biochemical and biophysical research communications, 298(4), 486–492. (2002)",
+    "source_file": "_posts/Activated-T-Cells-Nuclear-Factor-aptamer.md"
+  },
+  {
+    "pmid": "27930845",
+    "title": "Isolation and Characterization of RNA Aptamers against a Proteasome‐Associated Deubiquitylating Enzyme UCH37.",
+    "authors": "Lee, J. H., & Lee, M. J.",
+    "journal": "ChemBioChem, 18(2), 171-175. (2017)",
+    "source_file": "_posts/Ubiquitin-carboxyl-terminal-hydrolase37-(UCH37)-aptamer.md"
+  },
+  {
+    "pmid": "19246008",
+    "title": "An RNA aptamer that induces transcription.",
+    "authors": "Hunsicker, A., Steber, M., Mayer, G., Meitert, J., Klotzsche, M., Blind, M., Hillen, W., Berens, C., & Suess, B.",
+    "journal": "Chemistry & biology, 16(2), 173–180. (2009)",
+    "source_file": "_posts/TetR-aptamer.md"
+  },
+  {
+    "pmid": "22021209",
+    "title": "Mechanistic basis for RNA aptamer-based induction of TetR.",
+    "authors": "Steber, M., Arora, A., Hofmann, J., Brutschy, B., & Suess, B.",
+    "journal": "Chembiochem : a European journal of chemical biology, 12(17), 2608–2614. (2011)",
+    "source_file": "_posts/TetR-aptamer.md"
+  },
+  {
+    "pmid": "29036355",
+    "title": "Design and implementation of a synthetic pre-miR switch for controlling miRNA biogenesis in mammals.",
+    "authors": "Atanasov, J., Groher, F., Weigand, J. E., & Suess, B.",
+    "journal": "Nucleic acids research, 45(22), e181. (2017)",
+    "source_file": "_posts/TetR-aptamer.md"
+  },
+  {
+    "pmid": "31504742",
+    "title": "Robust gene expression control in human cells with a novel universal TetR aptamer splicing module.",
+    "authors": "Mol, A. A., Groher, F., Schreiber, B., Rühmkorff, C., & Suess, B.",
+    "journal": "Nucleic acids research, 47(20), e132. (2019)",
+    "source_file": "_posts/TetR-aptamer.md"
+  },
+  {
+    "pmid": "32052019",
+    "title": "The complex formed between a synthetic RNA aptamer and the transcription repressor TetR is a structural and functional twin of the operator DNA-TetR regulator complex.",
+    "authors": "Grau, F. C., Jaeger, J., Groher, F., Suess, B., & Muller, Y. A.",
+    "journal": "Nucleic acids research, 48(6), 3366–3378. (2020)",
+    "source_file": "_posts/TetR-aptamer.md"
+  },
+  {
+    "pmid": "33148600",
+    "title": "Inducible nuclear import by TetR aptamer-controlled 3' splice site selection.",
+    "authors": "Mol, A. A., Vogel, M., & Suess, B.",
+    "journal": "RNA (New York, N.Y.), 27(2), 234–241. (2021)",
+    "source_file": "_posts/TetR-aptamer.md"
+  },
+  {
+    "pmid": "7505429",
+    "title": "Selective optimization of the Rev-binding element of HIV-1.",
+    "authors": "Giver, L., Bartel, D., Zapp, M., Pawul, A., Green, M., & Ellington, A. D.",
+    "journal": "Nucleic acids research, 21(23), 5509–5516. (1993)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "8289245",
+    "title": "Characterization of an in vitro-selected RNA ligand to the HIV-1 Rev protein.",
+    "authors": "Jensen KB, Green L, MacDougal-Waugh S, Tuerk C.",
+    "journal": "J Mol Biol, 1994, 235(1), 237-247 (1994)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "8946856",
+    "title": "Deep penetration of an alpha-helix into a widened RNA major groove in the HIV-1 rev peptide-RNA aptamer complex.",
+    "authors": "Ye X, Gorin A, Ellington AD, Patel DJ",
+    "journal": "Nat Struct Biol, 1996, 3(12):1026-1033. (1996)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "10467126",
+    "title": "RNA architecture dictates the conformations of a bound peptide.",
+    "authors": "Ye, X., Gorin, A., Frederick, R., Hu, W., Majumdar, A., Xu, W., McLendon, G., Ellington, A., & Patel, D. J.",
+    "journal": "Chem Biol, 1999;6(9), 657-669 (1999)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "10647177",
+    "title": "Anchoring an extended HTLV-1 Rex peptide within an RNA major groove containing junctional base triples.",
+    "authors": "Jiang, F., Gorin, A., Hu, W., Majumdar, A., Baskerville, S., Xu, W., Ellington, A., & Patel, D. J.",
+    "journal": "Structure, 1999,7(12),1461-1472 (1999)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "18922466",
+    "title": "A solution to limited genomic capacity: using adaptable binding surfaces to assemble the functional HIV Rev oligomer on RNA.",
+    "authors": "Daugherty MD, D'Orso I, Frankel AD.",
+    "journal": "Mol Cell, 2008, 31(6), 824-834. (2008)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "23972852",
+    "title": "The arginine-rich RNA-binding motif of HIV-1 Rev is intrinsically disordered and folds upon RRE binding.",
+    "authors": "Casu F, Duggan BM, Hennig M.",
+    "journal": "Biophys J, 2013, 105(4), 1004-1017 (2013)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "25486594",
+    "title": "RNA-directed remodeling of the HIV-1 protein Rev orchestrates assembly of the Rev-Rev response element complex.",
+    "authors": "Jayaraman B, Crosby DC, Homer C, Ribeiro I, Mavor D, Frankel AD.",
+    "journal": "Elife, 2014,3:e04120. (2014)",
+    "source_file": "_posts/HIV-1-REV-peptide-aptamer.md"
+  },
+  {
+    "pmid": "30303958",
+    "title": "Novel RNA aptamers targeting gastrointestinal cancer biomarkers CEA, CA50 and CA72-4 with superior affinity and specificity.",
+    "authors": "Pan, Q., Law, C. O., Yung, M. M., Han, K. C., Pon, Y. L., & Lau, T. C. K.",
+    "journal": "PLoS One, 13(10), e0198980. (2018)",
+    "source_file": "_posts/Cancer-antigen-72–4(CA72-4)-aptamer.md"
+  },
+  {
+    "pmid": "28092358",
+    "title": "Recurrent RNA motifs as scaffolds for genetically encodable small-molecule biosensors.",
+    "authors": "Porter EB, Polaski JT, Morck MM, Batey RT",
+    "journal": "Nature chemical biology. 2017 Mar;13(3):295-301. (2017)",
+    "source_file": "_posts/5HTP-aptamer.md"
+  },
+  {
+    "pmid": "18441054",
+    "title": "Structural and molecular basis for hyperspecificity of RNA aptamer to human immunoglobulin G.",
+    "authors": "Miyakawa, S., Nomura, Y., Sakamoto, T., Yamaguchi, Y., Kato, K., Yamazaki, S., & Nakamura, Y.",
+    "journal": "RNA (New York, N.Y.), 14(6), 1154–1163. (2008)",
+    "source_file": "_posts/IgG-aptamer.md"
+  },
+  {
+    "pmid": "18931441",
+    "title": "Crystallization and preliminary X-ray diffraction studies of an RNA aptamer in complex with the human IgG Fc fragment.",
+    "authors": "Sugiyama, S., Nomura, Y., Sakamoto, T., Kitatani, T., Kobayashi, A., Miyakawa, S., Takahashi, Y., Adachi, H., Takano, K., Murakami, S., Inoue, T., Mori, Y., Nakamura, Y., & Matsumura, H.",
+    "journal": "Acta crystallographica. Section F, Structural biology and crystallization communications, 64(Pt 10), 942–944. (2008)",
+    "source_file": "_posts/IgG-aptamer.md"
+  },
+  {
+    "pmid": "20675355",
+    "title": "Conformational plasticity of RNA for target recognition as revealed by the 2.15 A crystal structure of a human IgG-aptamer complex.",
+    "authors": "Nomura, Y., Sugiyama, S., Sakamoto, T., Miyakawa, S., Adachi, H., Takano, K., Murakami, S., Inoue, T., Mori, Y., Nakamura, Y., & Matsumura, H.",
+    "journal": "Nucleic acids research, 38(21), 7822–7829. (2010)",
+    "source_file": "_posts/IgG-aptamer.md"
+  },
+  {
+    "pmid": "22924890",
+    "title": "Engineered synthetic polymer nanoparticles as IgG affinity ligands.",
+    "authors": "Lee, S. H., Hoshino, Y., Randall, A., Zeng, Z., Baldi, P., Doong, R. A., & Shea, K. J.",
+    "journal": "Journal of the American Chemical Society, 134(38), 15765–15772. (2012)",
+    "source_file": "_posts/IgG-aptamer.md"
+  },
+  {
+    "pmid": "23661463",
+    "title": "Target replacement strategy for selection of DNA aptamers against the Fc region of mouse IgG.",
+    "authors": "Ma, J., Wang, M. G., Mao, A. H., Zeng, J. Y., Liu, Y. Q., Wang, X. Q., Ma, J., Tian, Y. J., Ma, N., Yang, N., Wang, L., & Liao, S. Q.",
+    "journal": "Genetics and molecular research : GMR, 12(2), 1399–1410. (2013)",
+    "source_file": "_posts/IgG-aptamer.md"
+  },
+  {
+    "pmid": "20967861",
+    "title": "Therapeutic potential of anti-interleukin-17A aptamer: suppression of interleukin-17A signaling and attenuation of autoimmunity in two mouse models.",
+    "authors": "Ishiguro, A., Akiyama, T., Adachi, H., Inoue, J., & Nakamura, Y.",
+    "journal": "Arthritis Rheum, 63(2):455-66. (2011)",
+    "source_file": "_posts/IL-17A-aptamer.md"
+  },
+  {
+    "pmid": "7520755",
+    "title": "Inhibition of receptor binding by high-affinity RNA ligands to vascular endothelial growth factor.",
+    "authors": "Jellinek, D., Green, L. S., Bell, C., & Janjić, N.",
+    "journal": "Biochemistry, 33(34), 10450–10456. (1994)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "9383475",
+    "title": "Nuclease-resistant nucleic acid ligands to vascular permeability factor/vascular endothelial growth factor.",
+    "authors": "Green, L. S., Jellinek, D., Bell, C., Beebe, L. A., Feistner, B. D., Gill, S. C., Jucker, F. M., & Janjić, N.",
+    "journal": "Chemistry & biology, 2(10), 683–695. (1995)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "9685413",
+    "title": "2'-Fluoropyrimidine RNA-based aptamers to the 165-amino acid form of vascular endothelial growth factor (VEGF165). Inhibition of receptor binding and VEGF-induced vascular permeability through interactions requiring the exon 7-encoded domain.",
+    "authors": "Ruckman, J., Green, L. S., Beeson, J., Waugh, S., Gillette, W. L., Henninger, D. D., Claesson-Welsh, L., & Janjić, N.",
+    "journal": "The Journal of biological chemistry, 273(32), 20556–20567. (1998)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "10548435",
+    "title": "Oligonucleotide NX1838 inhibits VEGF165-mediated cellular responses in vitro.",
+    "authors": "Bell, C., Lynam, E., Landfair, D. J., Janjic, N., & Wiles, M. E.",
+    "journal": "In vitro cellular & developmental biology. Animal, 35(9), 533–542. (1999)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "10517237",
+    "title": "Detection and plasma pharmacokinetics of an anti-vascular endothelial growth factor oligonucleotide-aptamer (NX1838) in rhesus monkeys.",
+    "authors": "Tucker, C. E., Chen, L. S., Judkins, M. B., Farmer, J. A., Gill, S. C., & Drolet, D. W.",
+    "journal": "Journal of chromatography. B, Biomedical sciences and applications, 732(1), 203–212. (1999)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "15625332",
+    "title": "Pegaptanib for neovascular age-related macular degeneration.",
+    "authors": "Gragoudas, E. S., Adamis, A. P., Cunningham, E. T., Jr, Feinsod, M., Guyer, D. R., & VEGF Inhibition Study in Ocular Neovascularization Clinical Trial Group",
+    "journal": "The New England journal of medicine, 351(27), 2805–2816. (2004)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "16357200",
+    "title": "A therapeutic aptamer inhibits angiogenesis by specifically targeting the heparin binding domain of VEGF165.",
+    "authors": "Lee, J. H., Canny, M. D., De Erkenez, A., Krilleke, D., Ng, Y. S., Shima, D. T., Pardi, A., & Jucker, F.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 102(52), 18902–18907. (2005)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "16518379",
+    "title": "Pegaptanib, a targeted anti-VEGF aptamer for ocular vascular disease.",
+    "authors": "Ng, E. W., Shima, D. T., Calias, P., Cunningham, E. T., Jr, Guyer, D. R., & Adamis, A. P.",
+    "journal": "Nature reviews. Drug discovery, 5(2), 123–132. (2006)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "19668516",
+    "title": "Development of the anti-VEGF aptamer to a therapeutic agent for clinical ophthalmology.",
+    "authors": "Trujillo, C. A., Nery, A. A., Alves, J. M., Martins, A. H., & Ulrich, H.",
+    "journal": "Clinical ophthalmology (Auckland, N.Z.), 1(4), 393–402. (2007)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "18951306",
+    "title": "Wirkung von VEGF165 und dem VEGF-Aptamer Pegaptanib (Macugen) auf die Zusammensetzung der Tight Junctions mikrovaskulärer Endothelzellen aus der Retina [Effect of VEGF165 and the VEGF aptamer pegaptanib (Macugen) on the protein composition of tight junctions in microvascular endothelial cells of the retina].",
+    "authors": "Deissler, H. L., & Lang, G. E.",
+    "journal": "Klinische Monatsblatter fur Augenheilkunde, 225(10), 863–867. (2008)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "18154762",
+    "title": "Intraocular pressure effects of pegaptanib (macugen) injections in patients with and without glaucoma.",
+    "authors": "Lanzl, I. M., Maier, M., Feucht, N., Lohmann, C. P., & Kotliar, K. E.",
+    "journal": "American journal of ophthalmology, 145(1), 185–186. (2008)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "18156376",
+    "title": "Combined Pegaptanib sodium (Macugen) and photodynamic therapy in predominantly classic juxtafoveal choroidal neovascularisation in age related macular degeneration.",
+    "authors": "Calvo-González, C., Reche-Frutos, J., Donate-López, J., García-Feijoó, J., Leila, M., Fernández-Pérez, C., & Garcia-Sánchez, J.",
+    "journal": "The British journal of ophthalmology, 92(1), 74–75. (2008)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "28352569",
+    "title": "Development of an aptamer-based affinity purification method for vascular endothelial growth factor.",
+    "authors": "Lönne, M., Bolten, S., Lavrentieva, A., Stahl, F., Scheper, T., & Walter, J. G.",
+    "journal": "Biotechnology reports (Amsterdam, Netherlands), 8, 16–23. (2015)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "25733800",
+    "title": "Population pharmacokinetics of pegaptanib sodium (Macugen(®)) in patients with diabetic macular edema.",
+    "authors": "Basile, A. S., Hutmacher, M. M., Kowalski, K. G., Gandelman, K. Y., & Nickens, D. J.",
+    "journal": "Clinical ophthalmology (Auckland, N.Z.), 9, 323–335. (2015)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "27189805",
+    "title": "VEGF-B inhibits hyperglycemia- and Macugen-induced retinal apoptosis.",
+    "authors": "Huang, D., Zhao, C., Ju, R., Kumar, A., Tian, G., Huang, L., Zheng, L., Li, X., Liu, L., Wang, S., Ren, X., Ye, Z., Chen, W., Xing, L., Chen, Q., Gao, Z., Mi, J., Tang, Z., Wang, B., Zhang, S., … Li, X.",
+    "journal": "Scientific reports, 6, 26059. (2016)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "33363367",
+    "title": "Simultaneous Detection of VEGF and CEA by Time-Resolved Chemiluminescence Enzyme-Linked Aptamer Assay.",
+    "authors": "Man, J., Dong, J., Wang, Y., He, L., Yu, S., Yu, F., Wang, J., Tian, Y., Liu, L., Han, R., Guo, H., Wu, Y., & Qu, L.",
+    "journal": "International journal of nanomedicine, 15, 9975–9985. (2020)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "34562647",
+    "title": "VEGF aptamer/i-motif-based drug co-delivery system for combined chemotherapy and photodynamic therapy.",
+    "authors": "Zhao, P., Tang, Z. W., Lin, H. C., Djuanda, D., Zhu, Z., Niu, Q., Zhao, L. M., Qian, Y. N., Cao, G., Shen, J. L., & Fu, B.",
+    "journal": "Photodiagnosis and photodynamic therapy, 36, 102547. (2021)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "36625560",
+    "title": "Molecular mechanism of binding between a therapeutic RNA aptamer and its protein target VEGF: A molecular dynamics study.",
+    "authors": "Kalathingal, M., & Rhee, Y. M.",
+    "journal": "Journal of computational chemistry, 44(11), 1129–1137. (2023)",
+    "source_file": "_posts/VEGF-aptamer.md"
+  },
+  {
+    "pmid": "10198434",
+    "title": "Combinatorial selection of high affinity RNA ligands to live African trypanosomes.",
+    "authors": "Homann, M., & Göringer, H. U.",
+    "journal": "Nucleic acids research, 27(9), 2006–2014. (1999)",
+    "source_file": "_posts/Trypanosome-VSG-aptamer.md"
+  },
+  {
+    "pmid": "11557345",
+    "title": "Uptake and intracellular transport of RNA aptamers in African trypanosomes suggest therapeutic \"piggy-back\" approach.",
+    "authors": "Homann, M., & Göringer, H. U.",
+    "journal": "Bioorganic & medicinal chemistry, 9(10), 2571–2580. (2001)",
+    "source_file": "_posts/Trypanosome-VSG-aptamer.md"
+  },
+  {
+    "pmid": "12582125",
+    "title": "Targeting the variable surface of African trypanosomes with variant surface glycoprotein-specific, serum-stable RNA aptamers.",
+    "authors": "Lorger, M., Engstler, M., Homann, M., & Göringer, H. U.",
+    "journal": "Eukaryotic cell, 2(1), 84–94. (2003)",
+    "source_file": "_posts/Trypanosome-VSG-aptamer.md"
+  },
+  {
+    "pmid": "16925510",
+    "title": "Serum-stable RNA aptamers to an invariant surface domain of live African trypanosomes.",
+    "authors": "Homann, M., Lorger, M., Engstler, M., Zacharias, M., & Göringer, H. U.",
+    "journal": "Combinatorial chemistry & high throughput screening, 9(7), 491–499. (2006)",
+    "source_file": "_posts/Trypanosome-VSG-aptamer.md"
+  },
+  {
+    "pmid": "16594626",
+    "title": "RNA aptamers as potential pharmaceuticals against infections with African trypanosomes.",
+    "authors": "Göringer, H. U., Homann, M., Zacharias, M., & Adler, A.",
+    "journal": "Handbook of experimental pharmacology, (173), 375–393. (2006)",
+    "source_file": "_posts/Trypanosome-VSG-aptamer.md"
+  },
+  {
+    "pmid": "18220540",
+    "title": "Post-SELEX chemical optimization of a trypanosome-specific RNA aptamer.",
+    "authors": "Adler, A., Forster, N., Homann, M., & Göringer, H. U.",
+    "journal": "Combinatorial chemistry & high throughput screening, 11(1), 16–23. (2008)",
+    "source_file": "_posts/Trypanosome-VSG-aptamer.md"
+  },
+  {
+    "pmid": "23017685",
+    "title": "Ultrasensitive and real-time detection of proteins in blood using a potentiometric carbon-nanotube aptasensor.",
+    "authors": "Zelada-Guillén, G. A., Tweed-Kent, A., Niemann, M., Göringer, H. U., Riu, J., & Rius, F. X.",
+    "journal": "Biosensors & bioelectronics, 41, 366–371. (2013)",
+    "source_file": "_posts/Trypanosome-VSG-aptamer.md"
+  },
+  {
+    "pmid": "16799875",
+    "title": "Fast, reversible interaction of prion protein with RNA aptamers containing specific sequence patterns.",
+    "authors": "Mercey, R., Lantier, I., Maurel, M. C., Grosclaude, J., Lantier, F., & Marc, D.",
+    "journal": "Archives of virology, 151(11), 2197–2214. (2006)",
+    "source_file": "_posts/Prion-protein2-aptamer.md"
+  },
+  {
+    "pmid": "7505429",
+    "title": "Selective optimization of the Rev-binding element of HIV-1.",
+    "authors": "Giver, L., Bartel, D., Zapp, M., Pawul, A., Green, M., & Ellington, A. D.",
+    "journal": "Nucleic acids research, 21(23), 5509–5516. (1993)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "7506689",
+    "title": "Selection and design of high-affinity RNA ligands for HIV-1 Rev.",
+    "authors": "Giver, L., Bartel, D. P., Zapp, M. L., Green, M. R., & Ellington, A. D.",
+    "journal": "Gene, 137(1), 19–24. (1993)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "7664035",
+    "title": "A three-dimensional model of the Rev-binding element of HIV-1 derived from analyses of aptamers.",
+    "authors": "Leclerc, F., Cedergren, R., & Ellington, A. D.",
+    "journal": "Nature structural biology, 1(5), 293–300. (1994)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "8289245",
+    "title": "Characterization of an in vitro-selected RNA ligand to the HIV-1 Rev protein.",
+    "authors": "Jensen, K. B., Green, L., MacDougal-Waugh, S., & Tuerk, C.",
+    "journal": "Journal of molecular biology, 235(1), 237–247. (1994)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "8523524",
+    "title": "RNA aptamers selected to bind human immunodeficiency virus type 1 Rev in vitro are Rev responsive in vivo.",
+    "authors": "Symensma, T. L., Giver, L., Zapp, M., Takle, G. B., & Ellington, A. D.",
+    "journal": "Journal of virology, 70(1), 179–187. (1996)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "8946856",
+    "title": "Deep penetration of an alpha-helix into a widened RNA major groove in the HIV-1 rev peptide-RNA aptamer complex.",
+    "authors": "Ye, X., Gorin, A., Ellington, A. D., & Patel, D. J.",
+    "journal": "Nature structural biology, 3(12), 1026–1033. (1996)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "9713975",
+    "title": "Receptor ligand-facilitated cationic liposome delivery of anti-HIV-1 Rev-binding aptamer and ribozyme DNAs.",
+    "authors": "Konopka, K., Düzgüneş, N., Rossi, J., & Lee, N. S.",
+    "journal": "Journal of drug targeting, 5(4), 247–259. (1998)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "15610009",
+    "title": "Retention of conformational flexibility in HIV-1 Rev-RNA complexes.",
+    "authors": "Wilkinson, T. A., Zhu, L., Hu, W., & Chen, Y.",
+    "journal": "Biochemistry, 43(51), 16153–16160. (2004)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "18922466",
+    "title": "A solution to limited genomic capacity: using adaptable binding surfaces to assemble the functional HIV Rev oligomer on RNA.",
+    "authors": "Daugherty, M. D., D'Orso, I., & Frankel, A. D.",
+    "journal": "Molecular cell, 31(6), 824–834. (2008)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "23972852",
+    "title": "The arginine-rich RNA-binding motif of HIV-1 Rev is intrinsically disordered and folds upon RRE binding.",
+    "authors": "Casu, F., Duggan, B. M., & Hennig, M.",
+    "journal": "Biophysical journal, 105(4), 1004–1017. (2013)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "25486594",
+    "title": "RNA-directed remodeling of the HIV-1 protein Rev orchestrates assembly of the Rev-Rev response element complex.",
+    "authors": "Jayaraman, B., Crosby, D. C., Homer, C., Ribeiro, I., Mavor, D., & Frankel, A. D.",
+    "journal": "eLife, 3, e04120. (2014)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "30017564",
+    "title": "Structure of an RNA Aptamer that Can Inhibit HIV-1 by Blocking Rev-Cognate RNA (RRE) Binding and Rev-Rev Association.",
+    "authors": "Dearborn, A. D., Eren, E., Watts, N. R., Palmer, I. W., Kaufman, J. D., Steven, A. C., & Wingfield, P. T.",
+    "journal": "Structure (London, England : 1993), 26(9), 1187–1195.e4. (2018)",
+    "source_file": "_posts/HIV-1-Rev-aptamer.md"
+  },
+  {
+    "pmid": "11800555",
+    "title": "An intramolecular quadruplex of (GGA)4 triplet repeat DNA with a G:G:G:G tetrad and a G(:A):G(:A):G(:A):G heptad, and its dimeric interaction.",
+    "authors": "Matsugami, A., Ouhashi, K., Kanagawa, M., Liu, H., Kanagawa, S., Uesugi, S., & Katahira, M.",
+    "journal": "Journal of Molecular Biology, 313(2):255-69. (2001)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "18029754",
+    "title": "Detection of structural changes of RNA aptamer containing GGA repeats under the ionic condition using the microchip electrophoresis.",
+    "authors": "Nishikawa, F., Murakami, K., Noda, K., Yokoyama, T., & Nishikawa, S.",
+    "journal": "Nucleic Acids Symposium Series,(51):397-8. (2007)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "19098441",
+    "title": "Anti-bovine Prion protein RNA aptamer containing tandem GGA repeat interacts both with recombinant bovine prion protein and its β isoform with high affinity.",
+    "authors": "Murakami, K., Nishikawa, F., Noda, K., Yokoyama, T., & Nishikawa S.",
+    "journal": "Prion, 2(2):73-80. (2008)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "18776312",
+    "title": "Structural analysis of r(GGA)4 found in RNA aptamer for bovine prion protein.",
+    "authors": "Matsugami, A., Mashima, T., Nishikawa, F., Murakami, K., & Nishikawa, S.",
+    "journal": "Nucleic Acids Symposium Series, (52):179-80. (2008)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "19666719",
+    "title": "Unique quadruplex structure and interaction of an RNA aptamer against bovine prion protein.",
+    "authors": "Mashima, T., Matsugami, A., Nishikawa, F., Nishikawa, S., & Katahira, M.",
+    "journal": "Nucleic Acids Research, 37(18):6249-58. (2009)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "23180780",
+    "title": "Anti-prion activity of an RNA aptamer and its structural basis.",
+    "authors": "Mashima, T., Nishikawa, F., Kamatari, YO., Fujiwara, H., Saimura, M., Nagata, T., Kodaki, T., Nishikawa, S., Kuwata, K., & Katahira, M.",
+    "journal": "Nucleic Acids Research, 41(2):1355-62. (2012)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "23104426",
+    "title": "Cross-talk between prion protein and quadruplex-forming nucleic acids: a dynamic complex formation.",
+    "authors": "Cavaliere, P., Pagano, B., Granata, V., Prigent, S., Rezaei, H., Giancola, C., & Zagari, A.",
+    "journal": "Nucleic Acids Research, 41(1):327-39. (2013)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "24803670",
+    "title": "Binding of an RNA aptamer and a partial peptide of a prion protein: crucial importance of water entropy in molecular recognition.",
+    "authors": "Hayashi, T., Oshima, H., Mashima, T., Nagata, T., Katahira, M., & Kinoshita, M.",
+    "journal": "Nucleic Acids Research, 42(11):6861-75. (2014)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "30916478",
+    "title": "The anti-prion RNA aptamer R12 disrupts the Alzheimer's disease-related complex between prion and amyloid β.",
+    "authors": "Iida, M., Mashima, T., Yamaoki, Y., So, M., Nagata, T., & Katahira, M.",
+    "journal": "FEBS Journal, 286(12):2355-2365. (2019)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "32188933",
+    "title": "Development and structural determination of an anti-PrPC aptamer that blocks pathological conformational conversion of prion protein.",
+    "authors": "Mashima, T., Lee, JH., Kamatari, YO., Hayashi, T., Nagata, T., Nishikawa, F., Nishikawa, S., Kinoshita, M., Kuwata, K., & Katahira, M.",
+    "journal": "Scientific Reports, 10(1):4934. (2020)",
+    "source_file": "_posts/Bovine-prion-protein-aptamer.md"
+  },
+  {
+    "pmid": "20022942",
+    "title": "An Anticoagulant RNA Aptamer That Inhibits Proteinase-Cofactor Interactions within Prothrombinase.",
+    "authors": "Buddai, S. K., Layzer, J. M., Lu, G., Rusconi, C. P., Sullenger, B. A., Monroe, D. M., & Krishnaswamy, S.",
+    "journal": "The Journal of biological chemistry, 285(8), 5212–5223. (2009)",
+    "source_file": "_posts/Factor-Xa-aptamer.md"
+  },
+  {
+    "pmid": "26584417",
+    "title": "Targeting Two Coagulation Cascade Proteases with a Bivalent Aptamer Yields a Potent and Antidote-Controllable Anticoagulant.",
+    "authors": "Soule, E. E., Bompiani, K. M., Woodruff, R. S., & Sullenger, B. A.",
+    "journal": "Nucleic acid therapeutics, 26(1), 1–9. (2016)",
+    "source_file": "_posts/Factor-Xa-aptamer.md"
+  },
+  {
+    "pmid": "29863725",
+    "title": "Combination of aptamer and drug for reversible anticoagulation in cardiopulmonary bypass.",
+    "authors": "Gunaratne, R., Kumar, S., Frederiksen, J. W., Stayrook, S., Lohrmann, J. L., Perry, K., Bompiani, K. M., Chabata, C. V., Thalji, N. K., Ho, M. D., Arepally, G., Camire, R. M., Krishnaswamy, S., & Sullenger, B. A.",
+    "journal": "Nature biotechnology, 36(7), 606–613. (2018)",
+    "source_file": "_posts/Factor-Xa-aptamer.md"
+  },
+  {
+    "pmid": "35021888",
+    "title": "Combining Heparin and a FX/Xa Aptamer to Reduce Thrombin Generation in Cardiopulmonary Bypass and COVID-19.",
+    "authors": "Chabata, C. V., Frederiksen, J. W., Olson, L. B., Naqvi, I. A., Hall, S. E., Gunaratne, R., Kraft, B. D., Que, L. G., Chen, L., & Sullenger, B. A.",
+    "journal": "Nucleic acid therapeutics, 32(3), 139–150. (2022)",
+    "source_file": "_posts/Factor-Xa-aptamer.md"
+  },
+  {
+    "pmid": "23196060",
+    "title": "RNA aptamers targeting cancer stem cell marker CD133.",
+    "authors": "Shigdar, S., Qiao, L., Zhou, S. F., Xiang, D., Wang, T., Li, Y., Lim, L. Y., Kong, L., Li, L., & Duan, W.",
+    "journal": "Cancer letters, 330(1), 84–95. (2013)",
+    "source_file": "_posts/CD133-aptamer.md"
+  },
+  {
+    "pmid": "1379730",
+    "title": "RNA pseudoknots that inhibit human immunodeficiency virus type 1 reverse transcriptase.",
+    "authors": "Tuerk, C., MacDougal, S., & Gold, L.",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America, 89(15), 6988–6992. (1992)",
+    "source_file": "_posts/ligand-1.1-aptamer.md"
+  },
+  {
+    "pmid": "10751399",
+    "title": "HIV-1 reverse transcriptase-pseudoknot RNA aptamer interaction has a binding affinity in the low picomolar range coupled with high specificity.",
+    "authors": "Kensch, O., Connolly, B. A., Steinhoff, H. J., McGregor, A., Goody, R. S., & Restle, T.",
+    "journal": "The Journal of biological chemistry, 275(24), 18271–18278. (2000)",
+    "source_file": "_posts/ligand-1.1-aptamer.md"
+  },
+  {
+    "pmid": "12050367",
+    "title": "Potent inhibition of human immunodeficiency virus type 1 replication by template analog reverse transcriptase inhibitors derived by SELEX (systematic evolution of ligands by exponential enrichment).",
+    "authors": "Joshi, P., & Prasad, V. R.",
+    "journal": "Journal of virology, 76(13), 6545–6557. (2002)",
+    "source_file": "_posts/ligand-1.1-aptamer.md"
+  },
+  {
+    "pmid": "25073457",
+    "title": "Insight into HIV-1 reverse transcriptase-aptamer interaction from molecular dynamics simulations.",
+    "authors": "Aeksiri, N., Songtawee, N., Gleeson, M. P., Hannongbua, S., & Choowongkomon, K.",
+    "journal": "Journal of molecular modeling, 20(8), 2380. (2014)",
+    "source_file": "_posts/ligand-1.1-aptamer.md"
+  },
+  {
+    "pmid": "31943114",
+    "title": "Binding interface and impact on protease cleavage for an RNA aptamer to HIV-1 reverse transcriptase.",
+    "authors": "Nguyen, P. D. M., Zheng, J., Gremminger, T. J., Qiu, L., Zhang, D., Tuske, S., Lange, M. J., Griffin, P. R., Arnold, E., Chen, S. J., Zou, X., Heng, X., & Burke, D. H.",
+    "journal": "Nucleic acids research, 48(5), 2709–2722. (2020)",
+    "source_file": "_posts/ligand-1.1-aptamer.md"
+  },
+  {
+    "pmid": "32732393",
+    "title": "2'-fluoro-modified pyrimidines enhance affinity of RNA oligonucleotides to HIV-1 reverse transcriptase.",
+    "authors": "Gruenke, P. R., Alam, K. K., Singh, K., & Burke, D. H.",
+    "journal": "RNA (New York, N.Y.), 26(11), 1667–1679. (2020)",
+    "source_file": "_posts/ligand-1.1-aptamer.md"
+  },
+  {
+    "pmid": "16476969",
+    "title": "Identification of RNA ligands that bind hepatitis C virus polymerase selectively and inhibit its RNA synthesis from the natural viral RNA templates.",
+    "authors": "Vo, N. V., Oh, J. W., & Lai, M. M.",
+    "journal": "Virology, 307(2), 301–316. (2003)",
+    "source_file": "_posts/HCV-NS5B-protein-aptamer.md"
+  },
+  {
+    "pmid": "25689224",
+    "title": "High-affinity RNA Aptamers Against the HIV-1 Protease Inhibit Both In Vitro Protease Activity and Late Events of Viral Replication.",
+    "authors": "Duclair, S., Gautam, A., Ellington, A., & Prasad, V. R.",
+    "journal": "Molecular therapy. Nucleic acids, 4(2), e228. (2015)",
+    "source_file": "_posts/HIV-1-PR-aptamer.md"
+  },
+  {
+    "pmid": "15055546",
+    "title": "In vitro selection and characterization of TCF-1 binding RNA aptamers.",
+    "authors": "Lee SY, Jeong S.",
+    "journal": "Mol Cells. 17(1):174-9. (2004)",
+    "source_file": "_posts/TCF-1-aptamer.md"
+  },
+  {
+    "pmid": "15629461",
+    "title": "An RNA aptamer that binds to the beta-catenin interaction domain of TCF-1 protein.",
+    "authors": "Lee SK, Park MW, Yang EG, Yu J, Jeong S.",
+    "journal": "Biochem Biophys Res Commun. 327(1):294-9. (2005)",
+    "source_file": "_posts/TCF-1-aptamer.md"
+  },
+  {
+    "pmid": "15781225",
+    "title": "Inhibition of the DNA binding by the TCF-1 binding RNA aptamer.",
+    "authors": "Park MW, Choi KH, Jeong S.",
+    "journal": "Biochem Biophys Res Commun. 330(1):11-7. (2005)",
+    "source_file": "_posts/TCF-1-aptamer.md"
+  },
+  {
+    "pmid": "16985077",
+    "title": "Intracellular expression of the T-cell factor-1 RNA aptamer as an intramer.",
+    "authors": "Choi KH, Park MW, Lee SY, Jeon MY, Kim MY, Lee HK, Yu J, Kim HJ, Han K, Lee H, Park K, Park WJ, Jeong S.",
+    "journal": "Mol Cancer Ther. 2006 Sep;5(9):2428-34. (2006)",
+    "source_file": "_posts/TCF-1-aptamer.md"
+  },
+  {
+    "pmid": "19271740",
+    "title": "Technical and biological issues relevant to cell typing with aptamers.",
+    "authors": "Li, N., Ebright, J. N., Stovall, G. M., Chen, X., Nguyen, H. H., Singh, A., Syrett, A., & Ellington, A. D.",
+    "journal": "Journal of proteome research, 8(5), 2438–2448. (2009)",
+    "source_file": "_posts/J18-aptamer.md"
+  },
+  {
+    "pmid": "11259376",
+    "title": "Pro-apoptotic function of calsenilin/DREAM/KChIP3.",
+    "authors": "Jo, D. G., Kim, M. J., Choi, Y. H., Kim, I. K., Song, Y. H., Woo, H. N., Chung, C. W., & Jung, Y. K.",
+    "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology, 15(3), 589–591. (2001)",
+    "source_file": "_posts/The-protein-calsenilin-aptamer.md"
+  },
+  {
+    "pmid": "11535596",
+    "title": "Calcium-regulated DNA binding and oligomerization of the neuronal calcium-sensing protein, calsenilin/DREAM/KChIP3.",
+    "authors": "Osawa, M., Tong, K. I., Lilliehook, C., Wasco, W., Buxbaum, J. D., Cheng, H. Y., Penninger, J. M., Ikura, M., & Ames, J. B.",
+    "journal": "The Journal of biological chemistry, 276(44), 41005–41013. (2001)",
+    "source_file": "_posts/The-protein-calsenilin-aptamer.md"
+  },
+  {
+    "pmid": "11788589",
+    "title": "The metal-binding properties of DREAM: evidence for calcium-mediated changes in DREAM structure.",
+    "authors": "Craig, T. A., Benson, L. M., Venyaminov, S. Y., Klimtchuk, E. S., Bajzer, Z., Prendergast, F. G., Naylor, S., & Kumar, R.",
+    "journal": "The Journal of biological chemistry, 277(13), 10955–10966. (2002)",
+    "source_file": "_posts/The-protein-calsenilin-aptamer.md"
+  },
+  {
+    "pmid": "12732196",
+    "title": "Contribution of presenilin/gamma-secretase to calsenilin-mediated apoptosis.",
+    "authors": "Jo, D. G., Chang, J. W., Hong, H. S., Mook-Jung, I., & Jung, Y. K.",
+    "journal": "Biochemical and biophysical research communications, 305(1), 62–66. (2003)",
+    "source_file": "_posts/The-protein-calsenilin-aptamer.md"
+  },
+  {
+    "pmid": "15590057",
+    "title": "Target selectivity in EF-hand calcium binding proteins.",
+    "authors": "Bhattacharya, S., Bunick, C. G., & Chazin, W. J.",
+    "journal": "Biochimica et biophysica acta, 1742(1-3), 69–79. (2004)",
+    "source_file": "_posts/The-protein-calsenilin-aptamer.md"
+  },
+  {
+    "pmid": "17904852",
+    "title": "An RNA aptamer that recognizes a specific conformation of the protein calsenilin.",
+    "authors": "Lee, K. H., Jeong, S., Yang, E. G., Park, Y. K., & Yu, J.",
+    "journal": "Bioorganic & medicinal chemistry, 15(24), 7545–7552. (2007)",
+    "source_file": "_posts/The-protein-calsenilin-aptamer.md"
+  },
+  {
+    "pmid": "7518917",
+    "title": "High-affinity RNA ligands to human alpha-thrombin.",
+    "authors": "Kubik, M. F., Stephens, A. W., Schneider, D., Marlar, R. A., & Tasset, D.",
+    "journal": "Nucleic acids research, 22(13), 2619–2626. (1994)",
+    "source_file": "_posts/Thrombin-aptamer.md"
+  },
+  {
+    "pmid": "11735341",
+    "title": "Generation of species cross-reactive aptamers using \"toggle\" SELEX.",
+    "authors": "White, R., Rusconi, C., Scardino, E., Wolberg, A., Lawson, J., Hoffman, M., & Sullenger, B.",
+    "journal": "Molecular therapy : the journal of the American Society of Gene Therapy, 4(6), 567–573. (2001)",
+    "source_file": "_posts/Thrombin-aptamer.md"
+  },
+  {
+    "pmid": "12214238",
+    "title": "RNA aptamers as reversible antagonists of coagulation factor IXa.",
+    "authors": "Rusconi, C. P., Scardino, E., Layzer, J., Pitoc, G. A., Ortel, T. L., Monroe, D., & Sullenger, B. A.",
+    "journal": "Nature, 419(6902), 90–94. (2002)",
+    "source_file": "_posts/Thrombin-aptamer.md"
+  },
+  {
+    "pmid": "12557236",
+    "title": "RNA aptamers specific for bovine thrombin.",
+    "authors": "Liu, X., Zhang, D., Cao, G., Yang, G., Ding, H., Liu, G., Fan, M., Shen, B., & Shao, N.",
+    "journal": "Journal of molecular recognition : JMR, 16(1), 23–27. (2003)",
+    "source_file": "_posts/Thrombin-aptamer.md"
+  },
+  {
+    "pmid": "15196911",
+    "title": "RNA aptamer to thrombin binds anion-binding exosite-2 and alters protease inhibition by heparin-binding serpins.",
+    "authors": "Jeter, M. L., Ly, L. V., Fortenberry, Y. M., Whinna, H. C., White, R. R., Rusconi, C. P., Sullenger, B. A., & Church, F. C.",
+    "journal": "JFEBS letters, 568(1-3), 10–14. (2004)",
+    "source_file": "_posts/Thrombin-aptamer.md"
+  },
+  {
+    "pmid": "18971322",
+    "title": "Crystal structure of an RNA aptamer bound to thrombin.",
+    "authors": "Long, S. B., Long, M. B., White, R. R., & Sullenger, B. A.",
+    "journal": "RNA (New York, N.Y.), 14(12), 2504–2512. (2008)",
+    "source_file": "_posts/Thrombin-aptamer.md"
+  },
+  {
+    "pmid": "27566147",
+    "title": "Evoking picomolar binding in RNA by a single phosphorodithioate linkage.",
+    "authors": "Abeydeera, N. D., Egli, M., Cox, N., Mercier, K., Conde, J. N., Pallan, P. S., Mizurini, D. M., Sierant, M., Hibti, F. E., Hassell, T., Wang, T., Liu, F. W., Liu, H. M., Martinez, C., Sood, A. K., Lybrand, T. P., Frydman, C., Monteiro, R. Q., Gomer, R. H., Nawrot, B., … Yang, X",
+    "journal": "Nucleic acids research, 44(17), 8052–8064. (2016)",
+    "source_file": "_posts/Thrombin-aptamer.md"
+  },
+  {
+    "pmid": "9383475",
+    "title": "Nuclease-resistant nucleic acid ligands to vascular permeability factor/vascular endothelial growth factor.",
+    "authors": "Green, L. S., Jellinek, D., Bell, C., Beebe, L. A., Feistner, B. D., Gill, S. C., Jucker, F. M., & Janjić, N.",
+    "journal": "Chemistry & biology, 2(10), 683–695. (1995)",
+    "source_file": "_posts/Vascular-endothelial-growth-factor-aptamer.md"
+  },
+  {
+    "pmid": "7505429",
+    "title": "Selective optimization of the Rev-binding element of HIV-1.",
+    "authors": "Giver, L., Bartel, D., Zapp, M., Pawul, A., Green, M., & Ellington, A. D.",
+    "journal": "Nucleic acids research, 21(23), 5509–5516. (1993)",
+    "source_file": "_posts/59-aptamer.md"
+  },
+  {
+    "pmid": "7506689",
+    "title": "Selection and design of high-affinity RNA ligands for HIV-1 Rev.",
+    "authors": "Giver, L., Bartel, D. P., Zapp, M. L., Green, M. R., & Ellington, A. D.",
+    "journal": "Gene, 137(1), 19–24. (1993)",
+    "source_file": "_posts/59-aptamer.md"
+  },
+  {
+    "pmid": "7664035",
+    "title": "A three-dimensional model of the Rev-binding element of HIV-1 derived from analyses of aptamers.",
+    "authors": "Leclerc, F., Cedergren, R., & Ellington, A. D.",
+    "journal": "Nature structural biology, 1(5), 293–300. (1994)",
+    "source_file": "_posts/59-aptamer.md"
+  },
+  {
+    "pmid": "8523524",
+    "title": "RNA aptamers selected to bind human immunodeficiency virus type 1 Rev in vitro are Rev responsive in vivo.",
+    "authors": "Symensma, T. L., Giver, L., Zapp, M., Takle, G. B., & Ellington, A. D.",
+    "journal": "Journal of virology, 70(1), 179–187. (1996)",
+    "source_file": "_posts/59-aptamer.md"
+  },
+  {
+    "pmid": "9713975",
+    "title": "Receptor ligand-facilitated cationic liposome delivery of anti-HIV-1 Rev-binding aptamer and ribozyme DNAs.",
+    "authors": "Konopka, K., Düzgüneş, N., Rossi, J., & Lee, N. S.",
+    "journal": "Journal of drug targeting, 5(4), 247–259. (1998)",
+    "source_file": "_posts/59-aptamer.md"
+  },
+  {
+    "pmid": "15610009",
+    "title": "Retention of conformational flexibility in HIV-1 Rev-RNA complexes.",
+    "authors": "Wilkinson, T. A., Zhu, L., Hu, W., & Chen, Y.",
+    "journal": "Biochemistry, 43(51), 16153–16160. (2004)",
+    "source_file": "_posts/59-aptamer.md"
+  },
+  {
+    "pmid": "30017564",
+    "title": "Structure of an RNA Aptamer that Can Inhibit HIV-1 by Blocking Rev-Cognate RNA (RRE) Binding and Rev-Rev Association.",
+    "authors": "Dearborn, A. D., Eren, E., Watts, N. R., Palmer, I. W., Kaufman, J. D., Steven, A. C., & Wingfield, P. T.",
+    "journal": "Structure (London, England : 1993), 26(9), 1187–1195.e4. (2018)",
+    "source_file": "_posts/59-aptamer.md"
+  },
+  {
+    "pmid": "35294188",
+    "title": "Self-assembly of intracellular multivalent RNA complexes using dimeric Corn and Beetroot Aptamers.",
+    "authors": "Wu, J., Svensen, N., Song, W., Kim, H., Zhang, S., Li, X., & Jaffrey, S. R.",
+    "journal": "Journal of the American Chemical Society, 144(12), 5471–5477. (2022)",
+    "source_file": "_posts/Beetroot-aptamer(DFAME).md"
+  },
+  {
+    "pmid": "37221204",
+    "title": "Co-crystal structures of the fluorogenic aptamer Beetroot show that close homology may not predict similar RNA architecture.",
+    "authors": "Passalacqua, L. F. M., Starich, M. R., Link, K. A., Wu, J., Knutson, J. R., Tjandra, N., Jaffrey, S. R., & Ferré-D'Amaré, A. R.",
+    "journal": "Nature communications, 14(1), 2969. (2023)",
+    "source_file": "_posts/Beetroot-aptamer(DFAME).md"
+  },
+  {
+    "pmid": "12885412",
+    "title": "Prevention of passively transferred experimental autoimmune myasthenia gravis by an in vitro selected RNA aptamer.",
+    "authors": "Hwang B, Han K, Lee SW.",
+    "journal": "FEBS Lett. 548(1-3):85-9. (2003)",
+    "source_file": "_posts/tMG-RNA-aptamer.md"
+  },
+  {
+    "pmid": "11785949",
+    "title": "Improvement of RNA aptamer activity against myasthenic autoantibodies by extended sequence selection.",
+    "authors": "Hwang B, Lee SW.",
+    "journal": "Biochem Biophys Res Commun. 290(2):656-62. (2002)",
+    "source_file": "_posts/tMG-RNA-aptamer.md"
+  },
+  {
+    "pmid": "15562003",
+    "title": "RNA aptamers selected against the receptor activator of NF-kappaB acquire general affinity to proteins of the tumor necrosis factor receptor family.",
+    "authors": "Mori T, Oguro A, Ohtsu T, Nakamura Y.",
+    "journal": "Nucleic Acids Res. 32(20):6120-8. (2004)",
+    "source_file": "_posts/RANK-aptamer.md"
+  }
+]

--- a/publicationRef.json
+++ b/publicationRef.json
@@ -1,0 +1,4146 @@
+[
+  {
+    "pmid": "9310370",
+    "year": "1997",
+    "authors": "Urvil, P. T., Kakiuchi, N., Zhou, D. M., Shimotohno, K.",
+    "title": "Selection of RNA aptamers that bind specifically to the NS3 protease of hepatitis C virus",
+    "journal": "European journal of biochemistry"
+  },
+  {
+    "pmid": "9356339",
+    "year": "1997",
+    "authors": "Kumar, P. K., Machida, K., Urvil, P. T., Kakiuchi, N., Vishnuvardhan, D.",
+    "title": "Isolation of RNA aptamers specific to the NS3 protein of hepatitis C virus from a pool of completely random RNA",
+    "journal": "Virology"
+  },
+  {
+    "pmid": "10848986",
+    "year": "2000",
+    "authors": "Fukuda, K., Vishnuvardhan, D., Sekiya, S., Hwang, J., Kakiuchi, N.",
+    "title": "Isolation and characterization of RNA aptamers specific for the hepatitis C virus nonstructural protein 3 protease",
+    "journal": "European journal of biochemistry"
+  },
+  {
+    "pmid": "11118325",
+    "year": "2000",
+    "authors": "Hwang, J., Fauzi, H., Fukuda, K., Sekiya, S., Kakiuchi, N., Shimotohno, K., Taira, K., Kusakabe, I., & Nishikawa, S.",
+    "title": "The RNA aptamer-binding site of hepatitis C virus NS3 protease",
+    "journal": "Biochemical and biophysical research communications"
+  },
+  {
+    "pmid": "12655010",
+    "year": "2003",
+    "authors": "Nishikawa, F., Kakiuchi, N., Funaji, K., Fukuda, K., Sekiya, S., & Nishikawa, S.",
+    "title": "Inhibition of HCV NS3 protease by RNA aptamers in cells",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "15541341",
+    "year": "2004",
+    "authors": "Fukuda, K., Umehara, T., Sekiya, S., Kunio, K., Hasegawa, T., & Nishikawa, S.",
+    "title": "An RNA ligand inhibits hepatitis C virus NS3 protease and helicase activities",
+    "journal": "Biochemical and biophysical research communications"
+  },
+  {
+    "pmid": "22814430",
+    "year": "2012",
+    "authors": "Vaughan, R., Li, Y., Fan, B., Ranjith-Kumar, C. T., & Kao, C. C.",
+    "title": "RNA binding by the NS3 protease of the hepatitis C virus",
+    "journal": "Virus research"
+  },
+  {
+    "pmid": "7505429",
+    "year": "1993",
+    "authors": "Giver, L., Bartel, D., Zapp, M., Pawul, A., Green, M., & Ellington, A. D.",
+    "title": "Selective optimization of the Rev-binding element of HIV-1",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "7506689",
+    "year": "1993",
+    "authors": "Giver, L., Bartel, D. P., Zapp, M. L., Green, M. R., & Ellington, A. D.",
+    "title": "Selection and design of high-affinity RNA ligands for HIV-1 Rev",
+    "journal": "Gene"
+  },
+  {
+    "pmid": "7664035",
+    "year": "1994",
+    "authors": "Leclerc, F., Cedergren, R., & Ellington, A. D.",
+    "title": "A three-dimensional model of the Rev-binding element of HIV-1 derived from analyses of aptamers",
+    "journal": "Nature structural biology"
+  },
+  {
+    "pmid": "8523524",
+    "year": "1996",
+    "authors": "Symensma, T. L., Giver, L., Zapp, M., Takle, G. B., & Ellington, A. D.",
+    "title": "RNA aptamers selected to bind human immunodeficiency virus type 1 Rev in vitro are Rev responsive in vivo",
+    "journal": "Journal of virology"
+  },
+  {
+    "pmid": "9713975",
+    "year": "1998",
+    "authors": "Konopka, K., Düzgüneş, N., Rossi, J., & Lee, N. S.",
+    "title": "Receptor ligand-facilitated cationic liposome delivery of anti-HIV-1 Rev-binding aptamer and ribozyme DNAs",
+    "journal": "Journal of drug targeting"
+  },
+  {
+    "pmid": "15610009",
+    "year": "2004",
+    "authors": "Wilkinson, T. A., Zhu, L., Hu, W., & Chen, Y.",
+    "title": "Retention of conformational flexibility in HIV-1 Rev-RNA complexes",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "30017564",
+    "year": "2018",
+    "authors": "Dearborn, A. D., Eren, E., Watts, N. R., Palmer, I. W.",
+    "title": "Structure of an RNA Aptamer that Can Inhibit HIV-1 by Blocking Rev-Cognate RNA (RRE) Binding and Rev-Rev Association",
+    "journal": "Structure"
+  },
+  {
+    "pmid": "11907208",
+    "year": "2002",
+    "authors": "Biroccio, A., Hamm, J., Incitti, I., De Francesco, R., & Tomei, L.",
+    "title": "Selection of RNA aptamers that are specific and high-affinity ligands of the hepatitis C virus RNA-dependent RNA polymerase",
+    "journal": "Journal of virology"
+  },
+  {
+    "pmid": "12667800",
+    "year": "2003",
+    "authors": "Vo, N. V., Oh, J. W., & Lai, M. M.",
+    "title": "Identification of RNA ligands that bind hepatitis C virus polymerase selectively and inhibit its RNA synthesis from the natural viral RNA templates",
+    "journal": "Virology"
+  },
+  {
+    "pmid": "22163979",
+    "year": "2011",
+    "authors": "Roh, C., Kim, S. E., & Jo, S. K.",
+    "title": "Label free inhibitor screening of hepatitis C virus (HCV) NS5B viral protein using RNA oligonucleotide",
+    "journal": "Sensors"
+  },
+  {
+    "pmid": "23596299",
+    "year": "2013",
+    "authors": "Lee, C. H., Lee, Y. J., Kim, J. H., Lim, J. H.",
+    "title": "Inhibition of hepatitis C virus (HCV) replication by specific RNA aptamers against HCV NS5B RNA replicase",
+    "journal": "Journal of virology"
+  },
+  {
+    "pmid": "26440598",
+    "year": "2015",
+    "authors": "Lee, C. H., Lee, S. H., Kim, J. H., Noh, Y. H.",
+    "title": "Pharmacokinetics of a Cholesterol-conjugated Aptamer Against the Hepatitis C Virus (HCV) NS5B Protein",
+    "journal": "Molecular therapy. Nucleic acids"
+  },
+  {
+    "pmid": "38027068",
+    "year": "2023",
+    "authors": "Kim, T. H., & Lee, S. W.",
+    "title": "Generation of hepatitis C virus-resistant liver cells by genome editing-mediated stable expression of RNA aptamer",
+    "journal": "Molecular therapy. Methods & clinical development"
+  },
+  {
+    "pmid": "8755498",
+    "year": "1996",
+    "authors": "Xu, W., & Ellington, A. D.",
+    "title": "Anti-peptide aptamers recognize amino acid sequence and bind a protein epitope",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "8946856",
+    "year": "1996",
+    "authors": "Ye, X., Gorin, A., Ellington, A. D., & Patel, D. J.",
+    "title": "Deep penetration of an alpha-helix into a widened RNA major groove in the HIV-1 rev peptide-RNA aptamer complex",
+    "journal": "Nature structural biology"
+  },
+  {
+    "pmid": "8841594",
+    "year": "1995",
+    "authors": "Yamamoto, R., Toyoda, S., Viljanen, P., Machida, K.",
+    "title": "In vitro selection of RNA aptamers that can bind specifically to Tat protein of HIV-1",
+    "journal": "Nucleic acids symposium series"
+  },
+  {
+    "pmid": "10886365",
+    "year": "2000",
+    "authors": "Yamamoto, R., Katahira, M., Nishikawa, S., Baba, T.",
+    "title": "A novel RNA motif that binds efficiently and specifically to the Ttat protein of HIV and inhibits the trans-activation by Tat of transcription in vitro and in vivo",
+    "journal": "Genes to cells : devoted to molecular & cellular mechanisms"
+  },
+  {
+    "pmid": "11132628",
+    "year": "2000",
+    "authors": "Kawakami, J., Imanaka, H., Yokota, Y., & Sugimoto, N.",
+    "title": "In vitro selection of aptamers that act with Zn2+",
+    "journal": "Journal of inorganic biochemistry"
+  },
+  {
+    "pmid": "12737819",
+    "year": "2003",
+    "authors": "Matsugami, A., Kobayashi, S., Ouhashi, K., Uesugi, S., Yamamoto, R., Taira, K., Nishikawa, S., Kumar, P. K., & Katahira, M.",
+    "title": "Structural basis of the highly efficient trapping of the HIV Tat protein by an RNA aptamer",
+    "journal": "Structure (London"
+  },
+  {
+    "pmid": "28620664",
+    "year": "2017",
+    "authors": "Yamaoki, Y., Nagata, T., Mashima, T., & Katahira, M.",
+    "title": "Development of an RNA aptamer that acquires binding capacity against HIV-1 Tat protein via G-quadruplex formation in response to potassium ions",
+    "journal": "Chemical communications"
+  },
+  {
+    "pmid": "31707021",
+    "year": "2020",
+    "authors": "Caglayan, M. O., & Üstündağ, Z.",
+    "title": "Spectrophotometric ellipsometry based Tat-protein RNA-aptasensor for HIV-1 diagnosis",
+    "journal": "Spectrochimica acta. Part A"
+  },
+  {
+    "pmid": "37240414",
+    "year": "2023",
+    "authors": "Eladl, O., Yamaoki, Y., Kondo, K., Nagata, T., & Katahira, M.",
+    "title": "Complex Formation of an RNA Aptamer with a Part of HIV-1 Tat through Induction of Base Triples in Living Human Cells Proven by In-Cell NMR",
+    "journal": "International journal of molecular sciences"
+  },
+  {
+    "pmid": "15247433",
+    "year": "2004",
+    "authors": "Hwang, B., Cho, J. S., Yeo, H. J., Kim, J. H., Chung, K. M.",
+    "title": "Isolation of specific and high-affinity RNA aptamers against NS3 helicase domain of hepatitis C virus",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "1379730",
+    "year": "1992",
+    "authors": "Tuerk, C., MacDougal, S., & Gold, L.",
+    "title": "RNA pseudoknots that inhibit human immunodeficiency virus type 1 reverse transcriptase",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "10751399",
+    "year": "2000",
+    "authors": "Kensch, O., Connolly, B. A., Steinhoff, H. J., McGregor, A., Goody, R. S., & Restle, T.",
+    "title": "HIV-1 reverse transcriptase-pseudoknot RNA aptamer interaction has a binding affinity in the low picomolar range coupled with high specificity",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "12050367",
+    "year": "2002",
+    "authors": "Joshi, P., & Prasad, V. R.",
+    "title": "Potent inhibition of human immunodeficiency virus type 1 replication by template analog reverse transcriptase inhibitors derived by SELEX (systematic evolution of ligands by exponential enrichment)",
+    "journal": "Journal of virology"
+  },
+  {
+    "pmid": "25073457",
+    "year": "2014",
+    "authors": "Aeksiri, N., Songtawee, N., Gleeson, M. P., Hannongbua, S., & Choowongkomon, K.",
+    "title": "Insight into HIV-1 reverse transcriptase-aptamer interaction from molecular dynamics simulations",
+    "journal": "Journal of molecular modeling"
+  },
+  {
+    "pmid": "31943114",
+    "year": "2020",
+    "authors": "Nguyen, P. D. M., Zheng, J., Gremminger, T. J., Qiu, L.",
+    "title": "Binding interface and impact on protease cleavage for an RNA aptamer to HIV-1 reverse transcriptase",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "32732393",
+    "year": "2020",
+    "authors": "Gruenke, P. R., Alam, K. K., Singh, K., & Burke, D. H.",
+    "title": "2'-fluoro-modified pyrimidines enhance affinity of RNA oligonucleotides to HIV-1 reverse transcriptase",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "7778267",
+    "year": "1995",
+    "authors": "Allen, P., Worland, S., & Gold, L.",
+    "title": "Isolation of high-affinity RNA ligands to HIV-1 integrase from a random pool",
+    "journal": "Virology"
+  },
+  {
+    "pmid": "7489503",
+    "year": "1995",
+    "authors": "Tian, Y., Adya, N., Wagner, S., Giam, C. Z., Green, M. R., & Ellington, A. D.",
+    "title": "Dissecting protein:protein interactions between transcription factors with an RNA aptamer",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "16246910",
+    "year": "2005",
+    "authors": "Bryant, K. F., Cox, J. C., Wang, H., Hogle, J. M., Ellington, A. D., & Coen, D. M.",
+    "title": "Binding of herpes simplex virus-1 US11 to specific RNA sequences",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "19684916",
+    "year": "2009",
+    "authors": "Ahn, D. G., Jeon, I. J., Kim, J. D., Song, M. S.",
+    "title": "RNA aptamer-based sensitive detection of SARS coronavirus nucleocapsid protein",
+    "journal": "The Analyst"
+  },
+  {
+    "pmid": "35018437",
+    "year": "2022",
+    "authors": "Gruenke, P. R., Aneja, R., Welbourn, S., Ukah, O. B.",
+    "title": "Selection and identification of an RNA aptamer that specifically binds the HIV-1 capsid lattice and inhibits viral replication",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "15913532",
+    "year": "2005",
+    "authors": "Misono, T. S., & Kumar, P. K.",
+    "title": "Selection of RNA aptamers against human influenza virus hemagglutinin using surface plasmon resonance",
+    "journal": "Analytical biochemistry"
+  },
+  {
+    "pmid": "21565620",
+    "year": "2011",
+    "authors": "Toscano-Garibay, J. D., Benítez-Hess, M. L., & Alvarez-Salas, L. M.",
+    "title": "Isolation and characterization of an RNA aptamer for the HPV-16 E7 oncoprotein",
+    "journal": "Archives of medical research"
+  },
+  {
+    "pmid": "22943666",
+    "year": "2012",
+    "authors": "Hwang, S. D., Midorikawa, N., Punnarak, P., Kikuchi, Y., Kondo, H.",
+    "title": "Inhibition of Hirame rhabdovirus growth by RNA aptamers",
+    "journal": "Journal of fish diseases"
+  },
+  {
+    "pmid": "16476969",
+    "year": "2006",
+    "authors": "Gopinath, S. C. B., Misono, T. S., Kawasaki, K., Mizuno, T., Imai, M.",
+    "title": "An RNA aptamer that distinguishes between closely related human influenza viruses and inhibits haemagglutinin-mediated membrane fusion",
+    "journal": "The Journal of general virology"
+  },
+  {
+    "pmid": "25689224",
+    "year": "2015",
+    "authors": "Duclair, S., Gautam, A., Ellington, A., & Prasad, V. R.",
+    "title": "High-affinity RNA Aptamers Against the HIV-1 Protease Inhibit Both In Vitro Protease Activity and Late Events of Viral Replication",
+    "journal": "Molecular therapy. Nucleic acids"
+  },
+  {
+    "pmid": "22125633",
+    "year": "2011",
+    "authors": "Feng, H., Beck, J., Nassal, M., & Hu, K. H.",
+    "title": "A SELEX-screened aptamer of human hepatitis B virus RNA encapsidation signal suppresses viral replication",
+    "journal": "PloS one"
+  },
+  {
+    "pmid": "30303958",
+    "year": "2018",
+    "authors": "Pan, Q., Law, C. O., Yung, M. M., Han, K. C.",
+    "title": "Novel RNA aptamers targeting gastrointestinal cancer biomarkers CEA, CA50 and CA72-4 with superior affinity and specificity",
+    "journal": "PLoS One"
+  },
+  {
+    "pmid": "29103909",
+    "year": "2018",
+    "authors": "Fülle, L., Steiner, N., Funke, M., Gondorf, F., Pfeiffer, F.",
+    "title": "RNA aptamers recognizing murine CCL17 inhibit T cell chemotaxis and reduce contact hypersensitivity in vivo",
+    "journal": "Molecular Therapy"
+  },
+  {
+    "pmid": "24334484",
+    "year": "2014",
+    "authors": "Hanazato, M., Nakato, G., Nishikawa, F., Hase, K., Nishikawa, S., & Ohno, H",
+    "title": "Selection of an aptamer against mouse GP2 by SELEX",
+    "journal": "Cell structure and function"
+  },
+  {
+    "pmid": "24835440",
+    "year": "2014",
+    "authors": "Kwon, H. M., Lee, K. H., Han, B. W., Han, M. R.",
+    "title": "An RNA aptamer that specifically binds to the glycosylated hemagglutinin of avian influenza virus and suppresses viral infection in cells",
+    "journal": "PloS one"
+  },
+  {
+    "pmid": "26383776",
+    "year": "2015",
+    "authors": "Mittelberger, F., Meyer, C., Waetzig, G. H., Zacharias, M.",
+    "title": "RAID3-An interleukin-6 receptor-binding aptamer with post-selective modification-resistant affinity",
+    "journal": "RNA biology"
+  },
+  {
+    "pmid": "26184872",
+    "year": "2015",
+    "authors": "Mondragón, E., & Maher III, L. J.",
+    "title": "RNA aptamer inhibitors of a restriction endonuclease",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "27930845",
+    "year": "2017",
+    "authors": "Lee, J. H., & Lee, M. J.",
+    "title": "Isolation and Characterization of RNA Aptamers against a Proteasome‐Associated Deubiquitylating Enzyme UCH37",
+    "journal": "ChemBioChem"
+  },
+  {
+    "pmid": "22484812",
+    "year": "2012",
+    "authors": "Ray, P., Rialon-Guevara, KL., Veras, E., Sullenger, BA., & White, RR.",
+    "title": "Comparing human pancreatic cell secretomes by in vitro aptamer selection identifies cyclophilin B as a candidate pancreatic cancer biomarker",
+    "journal": "Journal of Clinical Investgation"
+  },
+  {
+    "pmid": "24152208",
+    "year": "2013",
+    "authors": "Ray, P., Sullenger, BA., & White, RR.",
+    "title": "Further characterization of the target of a potential aptamer biomarker for pancreatic cancer: cyclophilin B and its posttranslational modifications",
+    "journal": "Nucleic Acid Therapeutics"
+  },
+  {
+    "pmid": "24588102",
+    "year": "2014",
+    "authors": "Xu, D., Chatakonda, VK., Kourtidis, A., Conklin, DS., & Shi, H.",
+    "title": "In search of novel drug target sites on estrogen receptors using RNA aptamers",
+    "journal": "Nucleic Acid Therapeutics"
+  },
+  {
+    "pmid": "22166202",
+    "year": "2012",
+    "authors": "Lee, YJ., Han, SR., Maeng, JS., Cho, YJ., & Lee, SW.",
+    "title": "In vitro selection of Escherichia coli O157:H7-specific RNA aptamer",
+    "journal": "Biochemical and Biophysical Research Communications"
+  },
+  {
+    "pmid": "24374323",
+    "year": "2014",
+    "authors": "Suenaga, E., & Kumar, PK.",
+    "title": "An aptamer that binds efficiently to the hemagglutinins of highly pathogenic avian influenza viruses (H5N1 and H7N7) and inhibits hemagglutinin-glycan interactions",
+    "journal": "Acta Biomaterialia"
+  },
+  {
+    "pmid": "20967861",
+    "year": "2011",
+    "authors": "Ishiguro, A., Akiyama, T., Adachi, H., Inoue, J., & Nakamura, Y.",
+    "title": "Therapeutic potential of anti-interleukin-17A aptamer: suppression of interleukin-17A signaling and attenuation of autoimmunity in two mouse models",
+    "journal": "Arthritis Rheum"
+  },
+  {
+    "pmid": "23113766",
+    "year": "2013",
+    "authors": "Pratico, ED., Sullenger, BA., & Nair, SK.",
+    "title": "Identification and characterization of an agonistic aptamer against the T cell costimulatory receptor, OX40",
+    "journal": "Nucleic Acid Therapeutics"
+  },
+  {
+    "pmid": "21203916",
+    "year": "2010",
+    "authors": "Huang, Z., Wang, X., & Gao, G.",
+    "title": "Analyses of SELEX-derived ZAP-binding RNA aptamers suggest that the binding specificity is determined by both structure and sequence of the RNA",
+    "journal": "Protein Cell"
+  },
+  {
+    "pmid": "10908352",
+    "year": "2000",
+    "authors": "Tok, J. B., Cho, J., & Rando, R. R.",
+    "title": "RNA aptamers that specifically bind to a 16S ribosomal RNA decoding region construct",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "10449422",
+    "year": "1999",
+    "authors": "Scarabino, D., Crisari, A., Lorenzini, S., Williams, K., & Tocchini-Valentini, G. P.",
+    "title": "tRNA prefers to kiss",
+    "journal": "The EMBO journal"
+  },
+  {
+    "pmid": "7504300",
+    "year": "1993",
+    "authors": "Jellinek, D., Lynott, C. K., Rifkin, D. B., & Janjić, N.",
+    "title": "High-affinity RNA ligands to basic fibroblast growth factor inhibit receptor binding",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "9222504",
+    "year": "1997",
+    "authors": "Cho, B., Taylor, D. C., Nicholas, H. B., Jr, & Schmidt, F. J.",
+    "title": "Interacting RNA species identified by combinatorial selection",
+    "journal": "Bioorganic & medicinal chemistry"
+  },
+  {
+    "pmid": "20729797",
+    "year": "2010",
+    "authors": "Horii, K., Omi, K., Yoshida, Y., Imai, Y., Sakai, N.",
+    "title": "Development of a sphingosylphosphorylcholine detection system using RNA aptamers",
+    "journal": "Molecules"
+  },
+  {
+    "pmid": "9343239",
+    "year": "1997",
+    "authors": "Weiss, S., Proske, D., Neumann, M., Groschup, M. H.",
+    "title": "RNA aptamers specifically interact with the prion protein PrP",
+    "journal": "Journal of virology"
+  },
+  {
+    "pmid": "28513534",
+    "year": "2017",
+    "authors": "Macedo, B., & Cordeiro, Y.",
+    "title": "Unraveling Prion Protein Interactions with Aptamers and Other PrP-Binding Nucleic Acids",
+    "journal": "International journal of molecular sciences"
+  },
+  {
+    "pmid": "35970037",
+    "year": "2004",
+    "authors": "Hirao, I., Harada, Y., Nojima, T., Osawa, Y., Masaki, H., & Yokoyama, S.",
+    "title": "In vitro selection of RNA aptamers that bind to colicin E3 and structurally resemble the decoding site of 16S ribosomal RNA",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "16799875",
+    "year": "2006",
+    "authors": "Mercey, R., Lantier, I., Maurel, M. C., Grosclaude, J., Lantier, F., & Marc, D.",
+    "title": "Fast, reversible interaction of prion protein with RNA aptamers containing specific sequence patterns",
+    "journal": "Archives of virology"
+  },
+  {
+    "pmid": "16189080",
+    "year": "2005",
+    "authors": "Pan, Q., Zhang, X. L., Wu, H. Y., He, P. W., Wang, F.",
+    "title": "Aptamers that preferentially bind type IVB pili and inhibit human monocytic-cell invasion by Salmonella enterica serovar typhi",
+    "journal": "Antimicrobial agents and chemotherapy"
+  },
+  {
+    "pmid": "10348914",
+    "year": "1999",
+    "authors": "Takeno, H., Yamamoto, S., Tanaka, T., Sakano, Y., & Kikuchi, Y.",
+    "title": "Selection of an RNA molecule that specifically inhibits the protease activity of subtilisin",
+    "journal": "Journal of biochemistry"
+  },
+  {
+    "pmid": "9192624",
+    "year": "1997",
+    "authors": "Klug, S. J., Hüttenhofer, A., Kromayer, M., & Famulok, M.",
+    "title": "In vitro and in vivo characterization of novel mRNA motifs that bind special elongation factor SelB",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "10496219",
+    "year": "1999",
+    "authors": "Klug, S. J., Hüttenhofer, A., & Famulok, M.",
+    "title": "In vitro selection of RNA aptamers that bind special elongation factor SelB, a protein with multiple RNA-binding sites, reveals one major interaction domain at the carboxyl terminus",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "9603938",
+    "year": "1998",
+    "authors": "Bell, S. D., Denu, J. M., Dixon, J. E., & Ellington, A. D.",
+    "title": "RNA molecules that bind to and inhibit the active site of a tyrosine phosphatase",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "16131593",
+    "year": "2005",
+    "authors": "Dubey, A. K., Baker, C. S., Romeo, T., & Babitzke, P.",
+    "title": "RNA sequence and secondary structure participate in high-affinity CsrA-RNA interaction",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "11904188",
+    "year": "2002",
+    "authors": "Szkaradkiewicz, K., Nanninga, M., Nesper-Brock, M.",
+    "title": "RNA aptamers directed against release factor 1 from Thermus thermophilus",
+    "journal": "FEBS letters"
+  },
+  {
+    "pmid": "15294895",
+    "year": "2004",
+    "authors": "Ferrer-Orta,& Verdaguer, N.",
+    "title": "Structure of foot-and-mouth disease virus RNA-dependent RNA polymerase and its complex with a template-primer RNA",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "17588619",
+    "year": "2007",
+    "authors": "Du, M., Ulrich, H., Zhao, X., Aronowski, J., & Jayaraman, V.",
+    "title": "Water soluble RNA based antagonist of AMPA receptors",
+    "journal": "Neuropharmacology"
+  },
+  {
+    "pmid": "16888322",
+    "year": "2006",
+    "authors": "Rentmeister, & Famulok, M.",
+    "title": "RNA aptamers selectively modulate protein recruitment to the cytoplasmic domain of beta-secretase BACE1 in vitro",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "17030508",
+    "year": "2006",
+    "authors": "Gopinath, S. C., Balasundaresan, D., Akitomi, J., & Mizuno, H.",
+    "title": "An RNA aptamer that discriminates bovine factor IX from human factor IX",
+    "journal": "Journal of biochemistry"
+  },
+  {
+    "pmid": "16707660",
+    "year": "2006",
+    "authors": "Gening, L. V., & Miller, H.",
+    "title": "RNA aptamers selected against DNA polymerase beta inhibit the polymerase activities of DNA polymerases beta and kappa",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "16540230",
+    "year": "2006",
+    "authors": "Ohuchi, S. P., Ohtsu, T., & Nakamura, Y.",
+    "title": "Selection of RNA aptamers against recombinant transforming growth factor-beta type III receptor displayed on cell surface",
+    "journal": "Biochimie"
+  },
+  {
+    "pmid": "17079480",
+    "year": "2006",
+    "authors": "Lee, H. K., & Jeong, S.",
+    "title": "Modulation of oncogenic transcription and alternative splicing by beta-catenin and an RNA aptamer in colon cancer cells",
+    "journal": "Cancer research"
+  },
+  {
+    "pmid": "3097327",
+    "year": "1986",
+    "authors": "Satow Y, Cohen GH, Padlan EA, Davies DR",
+    "title": "Phosphocholine binding immunoglobulin Fab McPC603. An X-ray diffraction study at 2.7 A",
+    "journal": "Journal of molecular biology"
+  },
+  {
+    "pmid": "12163074",
+    "year": "2002",
+    "authors": "Carola Hunte 1, Hartmut Michel.",
+    "title": "Crystallisation of membrane proteins mediated by antibody fragments",
+    "journal": "Current opinion in structural biology"
+  },
+  {
+    "pmid": "17952087",
+    "year": "2007",
+    "authors": "Day PW, Rasmussen SG, Parnot C, Fung JJ, Masood A",
+    "title": "A monoclonal antibody for G protein-coupled receptor crystallography",
+    "journal": "Nature methods"
+  },
+  {
+    "pmid": "19477632",
+    "year": "2009",
+    "authors": "Koide S.",
+    "title": "Engineering of recombinant crystallization chaperones",
+    "journal": "Current opinion in structural biology"
+  },
+  {
+    "pmid": "21798953",
+    "year": "2011",
+    "authors": "Paige, J. S., Wu, K. Y., & Jaffrey, S. R.",
+    "title": "RNA mimics of green fluorescent protein",
+    "journal": "Science"
+  },
+  {
+    "pmid": "21151117",
+    "year": "2011",
+    "authors": "Koldobskaya Y, Duguid EM, Shechner DM, Suslov NB, Ye J",
+    "title": "A portable RNA sequence whose recognition by a synthetic antibody facilitates structural determination",
+    "journal": "Nature structural & molecular biology"
+  },
+  {
+    "pmid": "24952597",
+    "year": "2014",
+    "authors": "Huang H, Suslov NB, Li NS, Shelke SA, Evans ME",
+    "title": "A G-quadruplex-containing RNA activates fluorescence in a GFP-like fluorophore",
+    "journal": "Nat Chem Biol"
+  },
+  {
+    "pmid": "25940073",
+    "year": "2015",
+    "authors": "DasGupta, S., Shelke, S. A., Li, N. S., & Piccirilli, J. A.",
+    "title": "Spinach RNA aptamer detects lead(II) with high selectivity",
+    "journal": "Chemical communications"
+  },
+  {
+    "pmid": "27305425",
+    "year": "2016",
+    "authors": "Kikuchi, N., & Kolpashchikov, D. M.",
+    "title": "Split Spinach Aptamer for Highly Selective Recognition of DNA and RNA at Ambient Temperatures",
+    "journal": "Chembiochem : a European journal of chemical biology"
+  },
+  {
+    "pmid": "29309709",
+    "year": "2018",
+    "authors": "Koirala D, Shelke SA, Dupont M, Ruiz S, DasGupta S",
+    "title": "Affinity maturation of a portable Fab-RNA module for chaperone-assisted RNA crystallography",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "33795733",
+    "year": "2021",
+    "authors": "Dao, N. T., Haselsberger, R., Khuc, M. T., Phan, A. T.",
+    "title": "Photophysics of DFHBI bound to RNA aptamer Baby Spinach",
+    "journal": "Scientific reports"
+  },
+  {
+    "pmid": "32763306",
+    "year": "2022",
+    "authors": "Zon G",
+    "title": "Recent advances in aptamer applications for analytical biochemistry",
+    "journal": "Anal Biochem"
+  },
+  {
+    "pmid": "35351813",
+    "year": "2022",
+    "authors": "Anisuzzaman, S., Geraskin, I. M., Ilgu, M., Bendickson, L.",
+    "title": "Ligands with polyfluorophenyl moieties promote a local structural rearrangement in the Spinach2 and Broccoli aptamers that increases ligand affinities",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "35267109",
+    "year": "2022",
+    "authors": "Yu, Z., Wang, Y., Mei, F., Yan, H., Jin, Z., Zhang, P.",
+    "title": "Spinach-based RNA mimicking GFP in plant cells",
+    "journal": "Functional & integrative genomics"
+  },
+  {
+    "pmid": "15055546",
+    "year": "2004",
+    "authors": "Lee SY, Jeong S.",
+    "title": "In vitro selection and characterization of TCF-1 binding RNA aptamers",
+    "journal": "Mol Cells"
+  },
+  {
+    "pmid": "15629461",
+    "year": "2005",
+    "authors": "Lee SK, Park MW, Yang EG, Yu J, Jeong S.",
+    "title": "An RNA aptamer that binds to the beta-catenin interaction domain of TCF-1 protein",
+    "journal": "Biochem Biophys Res Commun"
+  },
+  {
+    "pmid": "15781225",
+    "year": "2005",
+    "authors": "Park MW, Choi KH, Jeong S.",
+    "title": "Inhibition of the DNA binding by the TCF-1 binding RNA aptamer",
+    "journal": "Biochem Biophys Res Commun"
+  },
+  {
+    "pmid": "16985077",
+    "year": "2006",
+    "authors": "Choi KH, Park MW, Lee SY, Jeon MY, Kim MY, Lee HK",
+    "title": "Intracellular expression of the T-cell factor-1 RNA aptamer as an intramer",
+    "journal": "Mol Cancer Ther"
+  },
+  {
+    "pmid": "12874383",
+    "year": "2003",
+    "authors": "Chen CH, Chernis GA, Hoang VQ, Landgraf R.",
+    "title": "Inhibition of heregulin signaling by an aptamer that preferentially binds to the oligomeric form of human epidermal growth factor receptor-3",
+    "journal": "Proc Natl Acad Sci U S A"
+  },
+  {
+    "pmid": "29499944",
+    "year": "2017",
+    "authors": "Yu X, Ghamande S, Liu H, Xue L, Zhao S, Tan W",
+    "title": "Targeting EGFR/HER2/HER3 with a Three-in-One Aptamer-siRNA Chimera Confers Superior Activity against HER2+ Breast Cancer",
+    "journal": "Mol Ther Nucleic Acids"
+  },
+  {
+    "pmid": "15562003",
+    "year": "2004",
+    "authors": "Mori T, Oguro A, Ohtsu T, Nakamura Y.",
+    "title": "RNA aptamers selected against the receptor activator of NF-kappaB acquire general affinity to proteins of the tumor necrosis factor receptor family",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "15277685",
+    "year": "2004",
+    "authors": "Theis MG, Knorre A, Kellersch B, Moelleken J, Wieland F, Kolanus W, Famulok M.",
+    "title": "Discriminatory aptamer reveals serum response element transcription regulated by cytohesin-2",
+    "journal": "Proc Natl Acad Sci U S A"
+  },
+  {
+    "pmid": "19854646",
+    "year": "2009",
+    "authors": "Mayer G, Lohberger A, Butzen S, Pofahl M, Blind M, Heckel A.",
+    "title": "From selection to caged aptamers: identification of light-dependent ssDNA aptamers targeting cytohesin",
+    "journal": "Bioorg Med Chem Lett"
+  },
+  {
+    "pmid": "23757206",
+    "year": "2013",
+    "authors": "Niebel B, Wosnitza CI, Famulok M.",
+    "title": "RNA-aptamers that modulate the RhoGEF activity of Tiam1",
+    "journal": "Bioorg Med Chem"
+  },
+  {
+    "pmid": "12649492",
+    "year": "2003",
+    "authors": "Oguro A, Ohtsu T, Svitkin YV, Sonenberg N, Nakamura Y.",
+    "title": "RNA aptamers to initiation factor 4A helicase hinder cap-dependent translation by blocking ATP hydrolysis",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "16940549",
+    "year": "2006",
+    "authors": "Miyakawa S, Oguro A, Ohtsu T, Imataka H, Sonenberg N, Nakamura Y.",
+    "title": "RNA aptamers to mammalian initiation factor 4G inhibit cap-dependent translation by blocking the formation of initiation factor complexes",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "15359119",
+    "year": "2004",
+    "authors": "Cho JS, Lee YJ, Shin KS, Jeong S, Park J, Lee SW.",
+    "title": "In vitro selection of specific RNA aptamers for the NFAT DNA binding domain",
+    "journal": "Mol Cells"
+  },
+  {
+    "pmid": "12408978",
+    "year": "2002",
+    "authors": "Bae SJ, Oum JH, Sharma S, Park J, Lee SW.",
+    "title": "In vitro selection of specific RNA inhibitors of NFATc",
+    "journal": "Biochem Biophys Res Commun"
+  },
+  {
+    "pmid": "26350736",
+    "year": "2015",
+    "authors": "Malsagova KA, Ivanov YD, Pleshakova TO, Kozlov AF, Krohin NV",
+    "title": "[SOI-nanowire biosensor for the detection of D-NFAT 1 protein]",
+    "journal": "Biomed Khim"
+  },
+  {
+    "pmid": "31451750",
+    "year": "2021",
+    "authors": "Yun Y, Zhang Y, Zhang C, Huang L, Tan S, Wang P, Vilariño-Gúell C",
+    "title": "Regulator of calcineurin 1 is a novel RNA-binding protein to regulate neuronal apoptosis",
+    "journal": "Mol Psychiatry"
+  },
+  {
+    "pmid": "16199752",
+    "year": "2005",
+    "authors": "Plummer KA, Carothers JM, Yoshimura M, Szostak JW, Verdine GL.",
+    "title": "In vitro selection of RNA aptamers against a composite small molecule-protein surface",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "15629041",
+    "year": "2004",
+    "authors": "Yan X, Gao X, Zhang Z.",
+    "title": "Isolation and characterization of 2'-amino-modified RNA aptamers for human TNFalpha",
+    "journal": "Genomics Proteomics Bioinformatics"
+  },
+  {
+    "pmid": "15971588",
+    "year": "2003",
+    "authors": "Guo KT, Yan XR, Huang GJ, Xu CX, Chai YS, Zhang ZQ.",
+    "title": "[Screening and characterization of DNA aptamers with hTNF-alpha binding and neutralizing activity]",
+    "journal": "Sheng Wu Gong Cheng Xue Bao"
+  },
+  {
+    "pmid": "31989789",
+    "year": "2020",
+    "authors": "Mashayekhi K, Ganji A, Sankian M.",
+    "title": "Designing a new dimerized anti human TNF-α aptamer with blocking activity",
+    "journal": "Biotechnol Prog"
+  },
+  {
+    "pmid": "12557236",
+    "year": "2003",
+    "authors": "Liu X, Zhang D, Cao G, Yang G, Ding H",
+    "title": "RNA aptamers specific for bovine thrombin",
+    "journal": "J Mol Recognit"
+  },
+  {
+    "pmid": "12885412",
+    "year": "2003",
+    "authors": "Hwang B, Han K, Lee SW.",
+    "title": "Prevention of passively transferred experimental autoimmune myasthenia gravis by an in vitro selected RNA aptamer",
+    "journal": "FEBS Lett"
+  },
+  {
+    "pmid": "11785949",
+    "year": "2002",
+    "authors": "Hwang B, Lee SW.",
+    "title": "Improvement of RNA aptamer activity against myasthenic autoantibodies by extended sequence selection",
+    "journal": "Biochem Biophys Res Commun"
+  },
+  {
+    "pmid": "23196060",
+    "year": "2013",
+    "authors": "Shigdar, S., Qiao, L., Zhou, S. F., Xiang, D., Wang, T., Li, Y.",
+    "title": "RNA aptamers targeting cancer stem cell marker CD133",
+    "journal": "Cancer letters"
+  },
+  {
+    "pmid": "16467303",
+    "year": "2006",
+    "authors": "Yang, C., Yan, N., Parish, J., Wang, X., Shi, Y., & Xue, D.",
+    "title": "RNA aptamers targeting the cell death inhibitor CED-9 induce cell killing in Caenorhabditis elegans",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "7528207",
+    "year": "1994",
+    "authors": "Conrad, R., Keranen, L. M., Ellington, A. D., & Newton, A. C.",
+    "title": "Isozyme-specific inhibition of protein kinase C by RNA aptamers",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "8937571",
+    "year": "1996",
+    "authors": "Conrad, R., & Ellington, A. D.",
+    "title": "Detecting immobilized protein kinase C isozymes with RNA aptamers",
+    "journal": "Analytical biochemistry"
+  },
+  {
+    "pmid": "29666232",
+    "year": "2018",
+    "authors": "Powell Gray, B., Kelly, L., Ahrens, D. P., Barry, A. P., Kratschmer, C.",
+    "title": "Tunable cytotoxic aptamer-drug conjugates for the treatment of prostate cancer",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "26221481",
+    "year": "2015",
+    "authors": "Moosavian, S. A., Jaafari, M. R., Taghdisi, S. M., Mosaffa, F.",
+    "title": "Development of RNA aptamers as molecular probes for HER2(+) breast cancer study using cell-SELEX",
+    "journal": "Iranian journal of basic medical sciences"
+  },
+  {
+    "pmid": "27648925",
+    "year": "2016",
+    "authors": "Iaboni, M., Fontanella, R., Rienzo, A., Capuozzo, M., Nuzzo, S.",
+    "title": "Targeting Insulin Receptor with a Novel Internalizing Aptamer",
+    "journal": "Molecular therapy. Nucleic acids"
+  },
+  {
+    "pmid": "18557632",
+    "year": "2008",
+    "authors": "Goers, E. S., Voelker, R. B., Gates, D. P., & Berglund, J. A.",
+    "title": "RNA binding specificity of Drosophila muscleblind",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "12024047",
+    "year": "2002",
+    "authors": "Bhattacharyya, S. N., Chatterjee, S., & Adhya, S.",
+    "title": "Mitochondrial RNA import in Leishmania tropica: aptamers homologous to multiple tRNA domains that interact cooperatively or antagonistically at the inner membrane",
+    "journal": "Molecular and cellular biology"
+  },
+  {
+    "pmid": "20348443",
+    "year": "2010",
+    "authors": "Kolesnikova, O., Kazakova, H., Comte, C., Steinberg, S., Kamenski, P.",
+    "title": "Selection of RNA aptamers imported into yeast and human mitochondria",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "25087963",
+    "year": "2014",
+    "authors": "Tawaraya, Y., Hyodo, M., Ara, M. N., Yamada, Y., & Harashima, H.",
+    "title": "RNA aptamers for targeting mitochondria using a mitochondria-based SELEX method",
+    "journal": "Biological & pharmaceutical bulletin"
+  },
+  {
+    "pmid": "27056631",
+    "year": "2016",
+    "authors": "Yamada, Y., Furukawa, R., & Harashima, H.",
+    "title": "A Dual-Ligand Liposomal System Composed of a Cell-Penetrating Peptide and a Mitochondrial RNA Aptamer Synergistically Facilitates Cellular Uptake and Mitochondrial Targeting",
+    "journal": "Journal of pharmaceutical sciences"
+  },
+  {
+    "pmid": "9586110",
+    "year": "1997",
+    "authors": "Hirao, I., Yoshinari, S., Yokoyama, S., Endo, Y., & Ellington, A. D.",
+    "title": "In vitro selection of aptamers that bind to ribosome-inactivating toxins",
+    "journal": "Nucleic acids symposium series"
+  },
+  {
+    "pmid": "10671532",
+    "year": "2000",
+    "authors": "Hirao, I., Madin, K., Endo, Y., Yokoyama, S., & Ellington, A. D.",
+    "title": "RNA aptamers that bind to and inhibit the ribosome-inactivating protein, pepocin",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "12903331",
+    "year": "2000",
+    "authors": "Fukusho, S., Furusawa, H., & Okahata, Y.",
+    "title": "In vitro selection and analysis of RNA aptamer recognize arginine-rich motif (ARM) model peptide on a QCM",
+    "journal": "Nucleic acids symposium series"
+  },
+  {
+    "pmid": "12120324",
+    "year": "2002",
+    "authors": "Fukusho, S., Furusawa, H., & Okahata, Y.",
+    "title": "In vitro selection and evaluation of RNA aptamers that recognize arginine-rich-motif model peptide on a quartz-crystal microbalance",
+    "journal": "Chemical communications"
+  },
+  {
+    "pmid": "24623705",
+    "year": "2014",
+    "authors": "Furusawa, H., Fukusho, S., & Okahata, Y.",
+    "title": "Arginine arrangement of bacteriophage λ N-peptide plays a role as a core motif in GNRA tetraloop RNA binding",
+    "journal": "Chembiochem : a European journal of chemical biology"
+  },
+  {
+    "pmid": "9111335",
+    "year": "1997",
+    "authors": "Shi, H., Hoffman, B. E., & Lis, J. T.",
+    "title": "A specific RNA hairpin loop structure binds the RNA recognition motifs of the Drosophila SR protein B52",
+    "journal": "Molecular and cellular biology"
+  },
+  {
+    "pmid": "10468557",
+    "year": "1999",
+    "authors": "Shi, H., Hoffman, B. E., & Lis, J. T.",
+    "title": "RNA aptamers as effective protein antagonists in a multicellular organism",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "12655012",
+    "year": "2003",
+    "authors": "Kim, S., Shi, H., Lee, D. K., & Lis, J. T.",
+    "title": "Specific SR protein-dependent splicing substrates identified through genomic SELEX",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "19380374",
+    "year": "2009",
+    "authors": "Xu, D., & Shi, H.",
+    "title": "Composite RNA aptamers as functional mimics of proteins",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "2200121",
+    "year": "1990",
+    "authors": "Tuerk, C., & Gold, L.",
+    "title": "Systematic evolution of ligands by exponential enrichment: RNA ligands to bacteriophage T4 DNA polymerase",
+    "journal": "Science"
+  },
+  {
+    "pmid": "32222697",
+    "year": "2020",
+    "authors": "Camorani, S., Granata, I., Collina, F., Leonetti, F., Cantile, M., Botti, G.",
+    "title": "Novel Aptamers Selected on Living Cells for Specific Recognition of Triple-Negative Breast Cancer",
+    "journal": "iScience"
+  },
+  {
+    "pmid": "10198434",
+    "year": "1999",
+    "authors": "Homann, M., & Göringer, H. U.",
+    "title": "Combinatorial selection of high affinity RNA ligands to live African trypanosomes",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "11557345",
+    "year": "2001",
+    "authors": "Homann, M., & Göringer, H. U.",
+    "title": "Uptake and intracellular transport of RNA aptamers in African trypanosomes suggest therapeutic \"piggy-back\" approach",
+    "journal": "Bioorganic & medicinal chemistry"
+  },
+  {
+    "pmid": "12582125",
+    "year": "2003",
+    "authors": "Lorger, M., Engstler, M., Homann, M., & Göringer, H. U.",
+    "title": "Targeting the variable surface of African trypanosomes with variant surface glycoprotein-specific, serum-stable RNA aptamers",
+    "journal": "Eukaryotic cell"
+  },
+  {
+    "pmid": "16925510",
+    "year": "2006",
+    "authors": "Homann, M., Lorger, M., Engstler, M., Zacharias, M., & Göringer, H. U.",
+    "title": "Serum-stable RNA aptamers to an invariant surface domain of live African trypanosomes",
+    "journal": "Combinatorial chemistry & high throughput screening"
+  },
+  {
+    "pmid": "16594626",
+    "year": "2006",
+    "authors": "Göringer, H. U., Homann, M., Zacharias, M., & Adler, A.",
+    "title": "RNA aptamers as potential pharmaceuticals against infections with African trypanosomes",
+    "journal": "Handbook of experimental pharmacology"
+  },
+  {
+    "pmid": "18220540",
+    "year": "2008",
+    "authors": "Adler, A., Forster, N., Homann, M., & Göringer, H. U.",
+    "title": "Post-SELEX chemical optimization of a trypanosome-specific RNA aptamer",
+    "journal": "Combinatorial chemistry & high throughput screening"
+  },
+  {
+    "pmid": "23017685",
+    "year": "2013",
+    "authors": "Zelada-Guillén, G. A., Tweed-Kent, A., Niemann, M., Göringer, H. U",
+    "title": "Ultrasensitive and real-time detection of proteins in blood using a potentiometric carbon-nanotube aptasensor",
+    "journal": "Biosensors & bioelectronics"
+  },
+  {
+    "pmid": "7520755",
+    "year": "1994",
+    "authors": "Jellinek, D., Green, L. S., Bell, C., & Janjić, N.",
+    "title": "Inhibition of receptor binding by high-affinity RNA ligands to vascular endothelial growth factor",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "9383475",
+    "year": "1995",
+    "authors": "Green, L. S., Jellinek, D., Bell, C., Beebe, L. A., Feistner, B. D., Gill, S. C.",
+    "title": "Nuclease-resistant nucleic acid ligands to vascular permeability factor/vascular endothelial growth factor",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "9685413",
+    "year": "1998",
+    "authors": "Ruckman, J., Green, L. S., Beeson, J., Waugh, S., Gillette, W. L.",
+    "title": "2'-Fluoropyrimidine RNA-based aptamers to the 165-amino acid form of vascular endothelial growth factor (VEGF165). Inhibition of receptor binding and VEGF-induced vascular permeability through interactions requiring the exon 7-encoded domain",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "10548435",
+    "year": "1999",
+    "authors": "Bell, C., Lynam, E., Landfair, D. J., Janjic, N., & Wiles, M. E.",
+    "title": "Oligonucleotide NX1838 inhibits VEGF165-mediated cellular responses in vitro",
+    "journal": "In vitro cellular & developmental biology. Animal"
+  },
+  {
+    "pmid": "10517237",
+    "year": "1999",
+    "authors": "Tucker, C. E., Chen, L. S., Judkins, M. B., Farmer, J. A., Gill, S. C.",
+    "title": "Detection and plasma pharmacokinetics of an anti-vascular endothelial growth factor oligonucleotide-aptamer (NX1838) in rhesus monkeys",
+    "journal": "Journal of chromatography. B"
+  },
+  {
+    "pmid": "15625332",
+    "year": "2004",
+    "authors": "Gragoudas, E. S., Adamis, A. P., Cunningham, E. T., Jr, Feinsod, M.",
+    "title": "Pegaptanib for neovascular age-related macular degeneration",
+    "journal": "The New England journal of medicine"
+  },
+  {
+    "pmid": "16357200",
+    "year": "2005",
+    "authors": "Lee, J. H., Canny, M. D., De Erkenez, A., Krilleke, D., Ng, Y. S.",
+    "title": "A therapeutic aptamer inhibits angiogenesis by specifically targeting the heparin binding domain of VEGF165",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "16518379",
+    "year": "2006",
+    "authors": "Ng, E. W., Shima, D. T., Calias, P., Cunningham, E. T.",
+    "title": "Pegaptanib, a targeted anti-VEGF aptamer for ocular vascular disease",
+    "journal": "Nature reviews. Drug discovery"
+  },
+  {
+    "pmid": "19668516",
+    "year": "2007",
+    "authors": "Trujillo, C. A., Nery, A. A., Alves, J. M., Martins, A. H., & Ulrich, H.",
+    "title": "Development of the anti-VEGF aptamer to a therapeutic agent for clinical ophthalmology",
+    "journal": "Clinical ophthalmology"
+  },
+  {
+    "pmid": "18951306",
+    "year": "2008",
+    "authors": "Deissler, H. L., & Lang, G. E.",
+    "title": "Wirkung von VEGF165 und dem VEGF-Aptamer Pegaptanib (Macugen) auf die Zusammensetzung der Tight Junctions mikrovaskulärer Endothelzellen aus der Retina [Effect of VEGF165 and the VEGF aptamer pegaptanib (Macugen) on the protein composition of tight junctions in microvascular endothelial cells of the retina]",
+    "journal": "Klinische Monatsblatter fur Augenheilkunde"
+  },
+  {
+    "pmid": "18154762",
+    "year": "2008",
+    "authors": "Lanzl, I. M., Maier, M., Feucht, N., Lohmann, C. P., & Kotliar, K. E.",
+    "title": "Intraocular pressure effects of pegaptanib (macugen) injections in patients with and without glaucoma",
+    "journal": "American journal of ophthalmology"
+  },
+  {
+    "pmid": "18156376",
+    "year": "2008",
+    "authors": "Calvo-González, C., Reche-Frutos, J., Donate-López, J., García-Feijoó, J.",
+    "title": "Combined Pegaptanib sodium (Macugen) and photodynamic therapy in predominantly classic juxtafoveal choroidal neovascularisation in age related macular degeneration",
+    "journal": "The British journal of ophthalmology"
+  },
+  {
+    "pmid": "28352569",
+    "year": "2015",
+    "authors": "Lönne, M., Bolten, S., Lavrentieva, A., Stahl, F., Scheper, T., & Walter, J. G.",
+    "title": "Development of an aptamer-based affinity purification method for vascular endothelial growth factor",
+    "journal": "Biotechnology reports"
+  },
+  {
+    "pmid": "25733800",
+    "year": "2015",
+    "authors": "Basile, A. S., Hutmacher, M. M., Kowalski, K. G., Gandelman, K. Y.",
+    "title": "Population pharmacokinetics of pegaptanib sodium (Macugen(®)) in patients with diabetic macular edema",
+    "journal": "Clinical ophthalmology"
+  },
+  {
+    "pmid": "27189805",
+    "year": "2016",
+    "authors": "Huang, D., Zhao, C., Ju, R., Kumar, A., Tian, G., Huang, L.",
+    "title": "VEGF-B inhibits hyperglycemia- and Macugen-induced retinal apoptosis",
+    "journal": "Scientific reports"
+  },
+  {
+    "pmid": "33363367",
+    "year": "2020",
+    "authors": "Man, J., Dong, J., Wang, Y., He, L., Yu, S., Yu, F., Wang, J.",
+    "title": "Simultaneous Detection of VEGF and CEA by Time-Resolved Chemiluminescence Enzyme-Linked Aptamer Assay",
+    "journal": "International journal of nanomedicine"
+  },
+  {
+    "pmid": "34562647",
+    "year": "2021",
+    "authors": "Zhao, P., Tang, Z. W., Lin, H. C., Djuanda, D., Zhu, Z., Niu, Q.",
+    "title": "VEGF aptamer/i-motif-based drug co-delivery system for combined chemotherapy and photodynamic therapy",
+    "journal": "Photodiagnosis and photodynamic therapy"
+  },
+  {
+    "pmid": "36625560",
+    "year": "2023",
+    "authors": "Kalathingal, M., & Rhee, Y. M.",
+    "title": "Molecular mechanism of binding between a therapeutic RNA aptamer and its protein target VEGF: A molecular dynamics study",
+    "journal": "Journal of computational chemistry"
+  },
+  {
+    "pmid": "11259376",
+    "year": "2001",
+    "authors": "Jo, D. G., Kim, M. J., Choi, Y. H., Kim, I. K.",
+    "title": "Pro-apoptotic function of calsenilin/DREAM/KChIP3",
+    "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology"
+  },
+  {
+    "pmid": "11535596",
+    "year": "2001",
+    "authors": "Osawa, M., Tong, K. I., Lilliehook, C., Wasco, W.",
+    "title": "Calcium-regulated DNA binding and oligomerization of the neuronal calcium-sensing protein, calsenilin/DREAM/KChIP3",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "11788589",
+    "year": "2002",
+    "authors": "Craig, T. A., Benson, L. M., Venyaminov, S. Y., Klimtchuk, E. S.",
+    "title": "The metal-binding properties of DREAM: evidence for calcium-mediated changes in DREAM structure",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "12732196",
+    "year": "2003",
+    "authors": "Jo, D. G., Chang, J. W., Hong, H. S., Mook-Jung, I., & Jung, Y. K.",
+    "title": "Contribution of presenilin/gamma-secretase to calsenilin-mediated apoptosis",
+    "journal": "Biochemical and biophysical research communications"
+  },
+  {
+    "pmid": "15590057",
+    "year": "2004",
+    "authors": "Bhattacharya, S., Bunick, C. G., & Chazin, W. J.",
+    "title": "Target selectivity in EF-hand calcium binding proteins",
+    "journal": "Biochimica et biophysica acta"
+  },
+  {
+    "pmid": "17904852",
+    "year": "2007",
+    "authors": "Lee, K. H., Jeong, S., Yang, E. G., Park, Y. K., & Yu, J.",
+    "title": "An RNA aptamer that recognizes a specific conformation of the protein calsenilin",
+    "journal": "Bioorganic & medicinal chemistry"
+  },
+  {
+    "pmid": "3893430",
+    "year": "1985",
+    "authors": "Gejyo, F., Yamada, T., Odani, S., Nakagawa, Y. Shirahama, T.",
+    "title": "new form of amyloid protein associated with chronic hemodialysis was identified as beta 2-microglobulin",
+    "journal": "Biochemical and biophysical research communications"
+  },
+  {
+    "pmid": "2871446",
+    "year": "1986",
+    "authors": "Chanard, J., Lavaud, S., Toupance, O., Melin, J. P.",
+    "title": "Beta 2-microglobulin-associated amyloidosis in chronic haemodialysis patients",
+    "journal": "Lancet"
+  },
+  {
+    "pmid": "9356260",
+    "year": "1997",
+    "authors": "Sunde, M., Serpell, L. C., Bartlam, M., Fraser, P. E.",
+    "title": "Common core structure of amyloid fibrils by synchrotron X-ray diffraction",
+    "journal": "Journal of molecular biology"
+  },
+  {
+    "pmid": "11818542",
+    "year": "2002",
+    "authors": "O'Nuallain, B., & Wetzel, R.",
+    "title": "Conformational Abs recognizing a generic amyloid fibril epitope",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "11820803",
+    "year": "2002",
+    "authors": "Ylera, F., Lurz, R., Erdmann, V. A., & Fürste, J. P.",
+    "title": "Selection of RNA aptamers to the Alzheimer's disease amyloid peptide",
+    "journal": "Biochemical and biophysical research communications"
+  },
+  {
+    "pmid": "17878167",
+    "year": "2007",
+    "authors": "Bunka, D. H., Mantle, B. J., Morten, I. J., Tennent, G. A.",
+    "title": "Production and characterization of RNA aptamers specific for amyloid fibril epitopes",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "6320006",
+    "year": "1984",
+    "authors": "Nowak, L., Bregestovski, P., Ascher, P., Herbet, A., & Prochiantz, A.",
+    "title": "Magnesium gates glutamate-activated channels in mouse central neurones",
+    "journal": "Nature"
+  },
+  {
+    "pmid": "11848921",
+    "year": "1998",
+    "authors": "Oivanen, M., Kuusela, S., & Lönnberg, H.",
+    "title": "Kinetics and Mechanisms for the Cleavage and Isomerization of the Phosphodiester Bonds of RNA by Brønsted Acids and Bases",
+    "journal": "Chemical reviews"
+  },
+  {
+    "pmid": "14567697",
+    "year": "2003",
+    "authors": "Li, G., Pei, W., & Niu, L.",
+    "title": "Channel-opening kinetics of GluR2Q(flip) AMPA receptor: a laser-pulse photolysis study",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "16540562",
+    "year": "2006",
+    "authors": "Mayer, M. L., Ghosal, A., Dolman, N. P., & Jane, D. E.",
+    "title": "Crystal structures of the kainate receptor GluR5 ligand binding core dimer with novel GluR5-selective antagonists",
+    "journal": "The Journal of neuroscience : the official journal of the Society for Neuroscience"
+  },
+  {
+    "pmid": "17929944",
+    "year": "2007",
+    "authors": "Huang, Z., Pei, W., Jayaseelan, S., Shi, H., & Niu, L.",
+    "title": "RNA aptamers selected against the GluR2 glutamate receptor channel",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "28872832",
+    "year": "2017",
+    "authors": "Huang, Z., Wen, W., Wu, A., & Niu, L.",
+    "title": "Chemically Modified, α-Amino-3-hydroxy-5-methyl-4-isoxazole (AMPA) Receptor RNA Aptamers Designed for in Vivo Use",
+    "journal": "ACS chemical neuroscience"
+  },
+  {
+    "pmid": "7781920",
+    "year": "1995",
+    "authors": "Premont, R. T., Inglese, J., & Lefkowitz, R. J.",
+    "title": "Protein kinases that phosphorylate activated G protein-coupled receptors",
+    "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology"
+  },
+  {
+    "pmid": "8691724",
+    "year": "1996",
+    "authors": "Lohse, M. J., Krasel, C., Winstel, R., & Mayor, F. Jr",
+    "title": "G-protein-coupled receptor kinases",
+    "journal": "Kidney international"
+  },
+  {
+    "pmid": "9325250",
+    "year": "1997",
+    "authors": "Peppel, K., Boekhoff, I., McDonald, P., Breer, H.",
+    "title": "G protein-coupled receptor kinase 3 (GRK3) gene disruption leads to loss of odorant receptor desensitization",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "16339447",
+    "year": "2005",
+    "authors": "Tesmer, V. M., Kawano, T., Shankaranarayanan, A., Kozasa, T.",
+    "title": "Snapshot of activated G proteins at the membrane: the Galphaq-GRK2-Gbetagamma complex",
+    "journal": "Science"
+  },
+  {
+    "pmid": "18230760",
+    "year": "2008",
+    "authors": "Mayer, G., Wulffen, B., Huber, C., Brockmann, J., Flicke, B.",
+    "title": "An RNA molecule that specifically inhibits G-protein-coupled receptor kinase 2 in vitro",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "6300098",
+    "year": "1983",
+    "authors": "Klausner, R. D., Van Renswoude, J., Ashwell, G., Kempf, C.",
+    "title": "Receptor-mediated endocytosis of transferrin in K562 cells",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "6300903",
+    "year": "1983",
+    "authors": "Dautry-Varsat, A., Ciechanover, A., & Lodish, H. F.",
+    "title": "pH and the recycling of transferrin during receptor-mediated endocytosis",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "3681112",
+    "year": "1987",
+    "authors": "Bernstein S. E.",
+    "title": "Hereditary hypotransferrinemia with hemosiderosis, a murine disorder resembling human atransferrinemia",
+    "journal": "The Journal of laboratory and clinical medicine"
+  },
+  {
+    "pmid": "9546397",
+    "year": "1998",
+    "authors": "Lebrón, J. A., Bennett, M. J., Vaughn, D. E., Chirino, A. J.",
+    "title": "Crystal structure of the hemochromatosis protein HFE and characterization of its interaction with transferrin receptor",
+    "journal": "Cell"
+  },
+  {
+    "pmid": "14617356",
+    "year": "2003",
+    "authors": "Parton, R. G., & Richards, A. A.",
+    "title": "Lipid rafts and caveolae as portals for endocytosis: new insights and common mechanisms",
+    "journal": "Traffic"
+  },
+  {
+    "pmid": "18838694",
+    "year": "2008",
+    "authors": "Chen, C. H., Dellamaggiore, K. R., Ouellette, C. P., Sedano, C. D.",
+    "title": "Aptamer-based endocytosis of a lysosomal enzyme",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "10704308",
+    "year": "2000",
+    "authors": "Huang, T. H., Yang, D. S., Plaskos, N. P.",
+    "title": "Structural studies of soluble oligomers of the Alzheimer beta-amyloid peptide",
+    "journal": "ournal of molecular biology"
+  },
+  {
+    "pmid": "12176077",
+    "year": "2002",
+    "authors": "Klein W. L.",
+    "title": "Abeta toxicity in Alzheimer's disease: globular oligomers (ADDLs) as new vaccine and drug targets",
+    "journal": "Neurochemistry international"
+  },
+  {
+    "pmid": "15919759",
+    "year": "2005",
+    "authors": "Arimon, M., Díez-Pérez, I., Kogan, M. J., Durany, N.",
+    "title": "Fine structure study of Abeta1-42 fibrillogenesis with atomic force microscopy",
+    "journal": "FASEB journal : official publication of the Federation of American Societies for Experimental Biology"
+  },
+  {
+    "pmid": "17008022",
+    "year": "2006",
+    "authors": "Güntert, A., Döbeli, H., & Bohrmann, B.",
+    "title": "High sensitivity analysis of amyloid-beta peptide composition in amyloid deposits from human and PS2APP mouse brain",
+    "journal": "Neuroscience"
+  },
+  {
+    "pmid": "19668864",
+    "year": "2009",
+    "authors": "Takahashi, T., Tada, K., & Mihara, H.",
+    "title": "RNA aptamers selected against amyloid beta-peptide (Abeta) inhibit the aggregation of Abeta",
+    "journal": "Molecular bioSystems"
+  },
+  {
+    "pmid": "3930479",
+    "year": "1985",
+    "authors": "Hekman, C. M., & Loskutoff, D. J.",
+    "title": "Endothelial cells produce a latent inhibitor of plasminogen activators that can be activated by denaturants",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "2459123",
+    "year": "1988",
+    "authors": "Declerck, P. J., De Mol, M., Alessi, M. C., Baudner, S.",
+    "title": "Purification and characterization of a plasminogen activator inhibitor 1 binding protein from human plasma. Identification as a multimeric form of S protein (vitronectin)",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "8662688",
+    "year": "1996",
+    "authors": "Deng, G., Royle, G., Wang, S., Crain, K., & Loskutoff, D. J.",
+    "title": "Structural and functional analysis of the plasminogen activator inhibitor-1 binding motif in the somatomedin B domain of vitronectin",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "9168821",
+    "year": "1997",
+    "authors": "Kjøller, L., Kanse, S. M., Kirkegaard, T., Rodenburg, K. W.",
+    "title": "Plasminogen activator inhibitor-1 represses integrin- and vitronectin-mediated cell migration independently of its function as an inhibitor of plasminogen activation",
+    "journal": "Experimental cell research"
+  },
+  {
+    "pmid": "15138609",
+    "year": "2004",
+    "authors": "Chorostowska-Wynimko, J., Skrzypczak-Jankun, E., & Jankun, J.",
+    "title": "Plasminogen activator inhibitor type-1: its structure, biological activity and role in tumorigenesis (Review)",
+    "journal": "International journal of molecular medicine"
+  },
+  {
+    "pmid": "19284310",
+    "year": "2009",
+    "authors": "Blake, C. M., Sullenger, B. A., Lawrence, D. A., & Fortenberry, Y. M.",
+    "title": "Antimetastatic potential of PAI-1-specific RNA aptamers",
+    "journal": "Oligonucleotides"
+  },
+  {
+    "pmid": "19271740",
+    "year": "2009",
+    "authors": "Li, N., Ebright, J. N., Stovall, G. M., Chen, X., Nguyen, H. H.",
+    "title": "Technical and biological issues relevant to cell typing with aptamers",
+    "journal": "Journal of proteome research"
+  },
+  {
+    "pmid": "20572251",
+    "year": "2010",
+    "authors": "Townshend, B., Aubry, I., Marcellus, R. C., Gehring, K.",
+    "title": "An RNA aptamer that selectively inhibits the enzymatic activity of protein tyrosine phosphatase 1B in vitro",
+    "journal": "Chembiochem : a European journal of chemical biology"
+  },
+  {
+    "pmid": "29711918",
+    "year": "2000",
+    "authors": "Piganeau, N., Jenne, A., Thuillier, V., & Famulok, M.",
+    "title": "An Allosteric Ribozyme Regulated by Doxycyline",
+    "journal": "Angewandte Chemie (International ed. in English)"
+  },
+  {
+    "pmid": "11705996",
+    "year": "2002",
+    "authors": "Meli, M., Vergne, J., Décout, J. L., & Maurel, M. C.",
+    "title": "Adenine-aptamer complexes: a bipartite RNA site that binds the adenine nucleic base",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "9384530",
+    "year": "1997",
+    "authors": "Burke, D. H., Hoffman, D. C., Brown, A., Hansen, M.",
+    "title": "RNA aptamers to the peptidyl transferase inhibitor chloramphenicol",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "21839787",
+    "year": "2011",
+    "authors": "Mehta, J., Van Dorst, B., Rouah-Martin, E., Herrebout, W.",
+    "title": "In vitro selection and characterization of DNA aptamers recognizing chloramphenicol",
+    "journal": "Journal of biotechnology"
+  },
+  {
+    "pmid": "10913311",
+    "year": "2000",
+    "authors": "Koizumi, M., & Breaker, R. R.",
+    "title": "Molecular recognition of cAMP by an RNA aptamer",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "9425088",
+    "year": "1998",
+    "authors": "Hamasaki, K., Killian, J., Cho, J., & Rando, R. R.",
+    "title": "Minimal RNA constructs that specifically bind aminoglycoside antibiotics with high affinities",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "11101810",
+    "year": "2000",
+    "authors": "Jhaveri, S., Rajendran, M., & Ellington, A. D.",
+    "title": "In vitro selection of signaling aptamers",
+    "journal": "Nature biotechnology"
+  },
+  {
+    "pmid": "9238640",
+    "year": "1996",
+    "authors": "Lato, S. M., & Ellington, A. D.",
+    "title": "Screening chemical libraries for nucleic-acid-binding drugs by in vitro selection: a test case with lividomycin",
+    "journal": "Molecular diversity"
+  },
+  {
+    "pmid": "9512549",
+    "year": "1998",
+    "authors": "Kiga, D., Futamura, Y., Sakamoto, K., & Yokoyama, S.",
+    "title": "An RNA aptamer to the xanthine/guanine base with a distinctive mode of purine recognition",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "18726014",
+    "year": "2008",
+    "authors": "Sando, S., Narita, A., Hayami, M., & Aoyama, Y.",
+    "title": "Transcription monitoring using fused RNA with a dye-binding light-up aptamer as a tag: a blue fluorescent RNA",
+    "journal": "Chemical communications"
+  },
+  {
+    "pmid": "38783134",
+    "year": "2024",
+    "authors": "Zuo, F., Jiang, L., Su, N., Zhang, Y., Bao, B.",
+    "title": "Imaging the dynamics of messenger RNA with a bright and stable green fluorescent RNA",
+    "journal": "Nature chemical biology"
+  },
+  {
+    "pmid": "37723244",
+    "year": "2023",
+    "authors": "Jiang, L., Xie, X., Su, N., Zhang, D., Chen, X.",
+    "title": "Large Stokes shift fluorescent RNAs for dual-emission fluorescence and bioluminescence imaging in live cells",
+    "journal": "Nature methods"
+  },
+  {
+    "pmid": "38816645",
+    "year": "2024",
+    "authors": "Huang, K., Song, Q., Fang, M., Yao, D.",
+    "title": "Structural basis of a small monomeric Clivia fluorogenic RNA with a large Stokes shift",
+    "journal": "Nature chemical biology"
+  },
+  {
+    "pmid": "8650187",
+    "year": "1996",
+    "authors": "O'Connell, D., Koenig, A., Jennings, S., Hicke, B., Han, H. L.",
+    "title": "Calcium-dependent oligonucleotide antagonists specific for L-selectin",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "12692304",
+    "year": "2003",
+    "authors": "White, R. R., Shan, S., Rusconi, C. P., Shetty, G.",
+    "title": "Inhibition of rat corneal angiogenesis by a nuclease-resistant RNA aptamer specific for angiopoietin-2",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "9883908",
+    "year": "1998",
+    "authors": "Kimoto, M., Sakamoto, K., Shirouzu, M., Hirao, I.",
+    "title": "RNA aptamers that specifically bind to the Ras-binding domain of Raf-1",
+    "journal": "FEBS letters"
+  },
+  {
+    "pmid": "10101203",
+    "year": "1999",
+    "authors": "Triqueneaux, G., Velten, M., Franzon, P., Dautry, F.",
+    "title": "RNA binding specificity of Unr, a protein with five cold shock domains",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "9546673",
+    "year": "1998",
+    "authors": "Gal, S. W., Amontov, S., Urvil, P. T., Vishnuvardhan, D.",
+    "title": "Selection of a RNA aptamer that binds to human activated protein C and inhibits its protease function",
+    "journal": "European journal of biochemistry"
+  },
+  {
+    "pmid": "8946842",
+    "year": "1996",
+    "authors": "Ishizaki, J., Nevins, J. R., & Sullenger, B. A.",
+    "title": "Inhibition of cell proliferation by an RNA ligand that selectively blocks E2F function",
+    "journal": "Nature medicine"
+  },
+  {
+    "pmid": "12054450",
+    "year": "2002",
+    "authors": "Daniels, D. A., Sohal, A. K., Rees, S., & Grisshammer, R.",
+    "title": "Generation of RNA aptamers to the G-protein-coupled receptor for neurotensin, NTS-1",
+    "journal": "Analytical biochemistry"
+  },
+  {
+    "pmid": "9873529",
+    "year": "1998",
+    "authors": "Jhaveri, S., Olwin, B., & Ellington, A. D.",
+    "title": "In vitro selection of phosphorothiolated aptamers",
+    "journal": "Bioorganic & medicinal chemistry letters"
+  },
+  {
+    "pmid": "11329270",
+    "year": "2001",
+    "authors": "Zhai, G., Iskandar, M., Barilla, K., & Romaniuk, P. J.",
+    "title": "Characterization of RNA aptamer binding by the Wilms' tumor suppressor protein WT1",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "10097084",
+    "year": "1999",
+    "authors": "Blind, M., Kolanus, W., & Famulok, M.",
+    "title": "Cytoplasmic RNA modulators of an inside-out signal-transduction cascade",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "12490703",
+    "year": "2002",
+    "authors": "Lee, J. H., Kim, H., Ko, J., & Lee, Y.",
+    "title": "Interaction of C5 protein with RNA aptamers selected by SELEX",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "9889155",
+    "year": "1998",
+    "authors": "Holeman, L. A., Robinson, S. L., Szostak, J. W., & Wilson, C.",
+    "title": "Isolation and characterization of fluorophore-binding RNA aptamers",
+    "journal": "Folding & design"
+  },
+  {
+    "pmid": "19303859",
+    "year": "2009",
+    "authors": "Werner, A., Konarev, P. V., Svergun, D. I., & Hahn, U.",
+    "title": "Characterization of a fluorophore binding RNA aptamer by fluorescence correlation spectroscopy and small angle X-ray scattering",
+    "journal": "Analytical biochemistry"
+  },
+  {
+    "pmid": "24133044",
+    "year": "2013",
+    "authors": "Sunbul, M., & Jäschke, A.",
+    "title": "Contact-Mediated Quenching for RNA Imaging in Bacteria with  a Fluorophore-Binding Aptamer",
+    "journal": "Angewandte Chemie"
+  },
+  {
+    "pmid": "26175046",
+    "year": "2015",
+    "authors": "Arora, A., Sunbul, M., & Jäschke, A.",
+    "title": "Dual-colour imaging of RNAs using quencher- and fluorophore-binding aptamers",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "29931157",
+    "year": "2018",
+    "authors": "Sunbul, M., & Jäschke, A.",
+    "title": "SRB-2: a promiscuous rainbow aptamer for live-cell RNA imaging",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "31636432",
+    "year": "2020",
+    "authors": "Bouhedda, F., Fam, K. T., Collot, M., Autour, A.",
+    "title": "A dimerization-based fluorogenic dye-aptamer module for RNA imaging in live cells",
+    "journal": "Nature chemical biology"
+  },
+  {
+    "pmid": "25337688",
+    "year": "2014",
+    "authors": "Filonov, G. S., Moon, J. D., Svensen, N., & Jaffrey, S. R.",
+    "title": "Broccoli: rapid selection of an RNA mimic of green fluorescent protein by fluorescence-based selection and directed evolution",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "26000751",
+    "year": "2015",
+    "authors": "Filonov, G. S., Kam, C. W., Song, W., & Jaffrey, S. R.",
+    "title": "In-gel imaging of RNA processing using broccoli reveals optimal aptamer expression strategies",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "26995352",
+    "year": "2016",
+    "authors": "Filonov, G. S., & Jaffrey, S. R.",
+    "title": "RNA imaging with dimeric Broccoli in live bacterial and mammalian cells",
+    "journal": "Current protocols in chemical biology"
+  },
+  {
+    "pmid": "26877022",
+    "year": "2016",
+    "authors": "Svensen, N., & Jaffrey, S. R.",
+    "title": "Fluorescent RNA aptamers as a tool to study RNA-modifying enzymes",
+    "journal": "Cell chemical biology"
+  },
+  {
+    "pmid": "27467146",
+    "year": "2016",
+    "authors": "Ageely, E. A., Kartje, Z. J., Rohilla, K. J., Barkau, C. L., & Gagnon, K. T.",
+    "title": "Quadruplex-flanking stem structures modulate the stability and metal ion preferences of RNA mimics of GFP",
+    "journal": "ACS chemical biology"
+  },
+  {
+    "pmid": "28180326",
+    "year": "2017",
+    "authors": "Okuda, M., Fourmy, D., & Yoshizawa, S.",
+    "title": "Use of baby Spinach and Broccoli for imaging of structured cellular RNAs",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "28548488",
+    "year": "2017",
+    "authors": "Alam, K. K., Tawiah, K. D., Lichte, M. F., Porciani, D., & Burke, D. H.",
+    "title": "A fluorescent split aptamer for visualizing RNA-RNA assembly in vivo",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "28991414",
+    "year": "2018",
+    "authors": "Wang, Z., Luo, Y., Xie, X., Hu, X., Song, H., Zhao, Y., Shi, J.",
+    "title": "In situ spatial complementation of aptamer-mediated recognition enables live-cell imaging of native RNA transcripts in real time",
+    "journal": "Angewandte Chemie"
+  },
+  {
+    "pmid": "30513826",
+    "year": "2018",
+    "authors": "Chandler, M., Lyalina, T., Halman, J., Rackley, L., Lee, L.",
+    "title": "Broccoli fluorets: split aptamers as a user-friendly fluorescent toolkit for dynamic RNA nanotechnology",
+    "journal": "Molecules"
+  },
+  {
+    "pmid": "30962542",
+    "year": "2019",
+    "authors": "Litke, J. L., & Jaffrey, S. R.",
+    "title": "Highly efficient expression of circular RNA aptamers in cells using autocatalytic transcripts",
+    "journal": "Nature biotechnology"
+  },
+  {
+    "pmid": "31850609",
+    "year": "2020",
+    "authors": "Li, X., Kim, H., Litke, J. L., Wu, J., & Jaffrey, S. R.",
+    "title": "Fluorophore-promoted RNA folding and photostability enables imaging of single broccoli-tagged mRNAs in live mammalian cells",
+    "journal": "Angewandte Chemie"
+  },
+  {
+    "pmid": "32698574",
+    "year": "2020",
+    "authors": "Li, X., Mo, L., Litke, J. L., Dey, S. K., Suter, S. R., & Jaffrey, S. R.",
+    "title": "Imaging intracellular S-adenosyl methionine dynamics in live mammalian cells with a genetically encoded red fluorescent RNA-based sensor",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "33303627",
+    "year": "2021",
+    "authors": "Kartje, Z. J., Janis, H. I., Mukhopadhyay, S., & Gagnon, K. T.",
+    "title": "Revisiting T7 RNA polymerase transcription in vitro with the Broccoli RNA aptamer as a simplified real-time fluorescent reporter",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "33342694",
+    "year": "2021",
+    "authors": "Zhang, T., Zhou, W., Lin, X., Khan, M. R., Deng, S.",
+    "title": "Light-up RNA aptamer signaling-CRISPR-cas13a-based mix-and-read assays for profiling viable pathogenic bacteria",
+    "journal": "Biosensors & bioelectronics"
+  },
+  {
+    "pmid": "34490956",
+    "year": "2021",
+    "authors": "Li, X., Wu, J., & Jaffrey, S. R.",
+    "title": "Engineering fluorophore recycling in a fluorogenic RNA aptamer",
+    "journal": "Angewandte Chemie"
+  },
+  {
+    "pmid": "25101481",
+    "year": "2014",
+    "authors": "Dolgosheina, E. V., Jeng, S. C., Panchapakesan, S. S.",
+    "title": "RNA mango aptamer-fluorophore: a bright, high-affinity complex for RNA labeling and tracking",
+    "journal": "ACS chemical biology"
+  },
+  {
+    "pmid": "28553947",
+    "year": "2017",
+    "authors": "Trachman, R. J., 3rd, Demeshkina, N. A., Lau, M. W. L.",
+    "title": "Structural basis for high-affinity fluorophore binding and activation by RNA Mango",
+    "journal": "Nature chemical biology"
+  },
+  {
+    "pmid": "29440634",
+    "year": "2018",
+    "authors": "Autour, A., C Y Jeng, S., D Cawte, A., Abdolahzadeh, A., Galli, A.",
+    "title": "Fluorogenic RNA Mango aptamers for imaging small non-coding RNAs in mammalian cells",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "29768001",
+    "year": "2018",
+    "authors": "Trachman, R. J., 3rd, Abdolahzadeh, A., Andreoni, A., Cojocaru, R.",
+    "title": "Crystal structures of the Mango-II RNA aptamer reveal heterogeneous fluorophore binding and guide engineering of variants with improved selectivity and brightness",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "30992561",
+    "year": "2019",
+    "authors": "Trachman, R. J., 3rd, Autour, A., Jeng, S. C. Y., Abdolahzadeh, A.",
+    "title": "Structure and functional reselection of the Mango-III fluorogenic RNA aptamer",
+    "journal": "Nature chemical biology"
+  },
+  {
+    "pmid": "32152311",
+    "year": "2020",
+    "authors": "Cawte, A. D., Unrau, P. J., & Rueda, D. S.",
+    "title": "Live cell imaging of single RNA molecules with fluorogenic Mango II arrays",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "32386573",
+    "year": "2020",
+    "authors": "Trachman, R. J., 3rd, Cojocaru, R., Wu, D., Piszczek, G.",
+    "title": "Structure-guided engineering of the homodimeric Mango-IV fluorescence turn-on aptamer yields an RNA FRET pair",
+    "journal": "Structure"
+  },
+  {
+    "pmid": "33674421",
+    "year": "2021",
+    "authors": "Kong, K. Y. S., Jeng, S. C. Y., Rayyan, B., & Unrau, P. J.",
+    "title": "RNA Peach and Mango: Orthogonal two-color fluorogenic aptamers distinguish nearly identical ligands",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "34971617",
+    "year": "2022",
+    "authors": "Harish, B., Wang, J., Hayden, E. J., Grabe, B., Hiller, W.",
+    "title": "Hidden intermediates in Mango III RNA aptamer folding revealed by pressure perturbation",
+    "journal": "Biophysical journal"
+  },
+  {
+    "pmid": "36120549",
+    "year": "2022",
+    "authors": "Yang, X., Liu, C., Kuo, Y. A., Yeh, H. C., & Ren, P.",
+    "title": "Computational study on the binding of Mango-II RNA aptamer and fluorogen using the polarizable force field AMOEBA",
+    "journal": "Frontiers in molecular biosciences"
+  },
+  {
+    "pmid": "36840712",
+    "year": "2023",
+    "authors": "Bychenko, O. S., Khrulev, A. A., Svetlova, J. I., Tsvetkov, V. B.",
+    "title": "Red light-emitting short Mango-based system enables tracking a mycobacterial small noncoding RNA in infected macrophages",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "28644615",
+    "year": "2017",
+    "authors": "Tan, X., Constantin, T. P., Sloane, K. L., Waggoner, A. S.",
+    "title": "Fluoromodules consisting of a promiscuous RNA aptamer and red or blue fluorogenic cyanine dyes: Selection, characterization, and bioimaging",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "30382099",
+    "year": "2018",
+    "authors": "Shelke, S. A., Shao, Y., Laski, A., Koirala, D., Weissman, B. P.",
+    "title": "Structural basis for activation of fluorogenic dyes by an RNA aptamer lacking a G-quadruplex motif",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "28945233",
+    "year": "2017",
+    "authors": "Song, W., Filonov, G. S., Kim, H., Hirsch, M., Li, X.",
+    "title": "Imaging RNA polymerase III transcription using a photostable RNA-fluorophore complex",
+    "journal": "Nature chemical biology"
+  },
+  {
+    "pmid": "31178406",
+    "year": "2019",
+    "authors": "Sjekloća, L., & Ferré-D'Amaré, A. R.",
+    "title": "Binding between G quadruplexes at the homodimer interface of the corn RNA aptamer strongly activates thioflavin T fluorescence",
+    "journal": "Cell chemical biology"
+  },
+  {
+    "pmid": "37221204",
+    "year": "2023",
+    "authors": "Passalacqua, L. F. M., Starich, M. R., Link, K. A.",
+    "title": "Co-crystal structures of the fluorogenic aptamer Beetroot show that close homology may not predict similar RNA architecture",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "30485561",
+    "year": "2019",
+    "authors": "Steinmetzger, C., Palanisamy, N., Gore, K. R., & Höbartner, C.",
+    "title": "A multicolor large stokes shift fluorogen-activating RNA aptamer with cationic chromophores",
+    "journal": "Chemistry"
+  },
+  {
+    "pmid": "31740962",
+    "year": "2019",
+    "authors": "Steinmetzger, C., Bessi, I., Lenz, A. K., & Höbartner, C.",
+    "title": "Structure-fluorescence activation relationships of a large Stokes shift fluorogenic RNA aptamer",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "34112799",
+    "year": "2021",
+    "authors": "Mieczkowski, M., Steinmetzger, C., Bessi, I., Lenz, A. K.",
+    "title": "Large Stokes shift fluorescence activation in an RNA aptamer by intermolecular proton transfer to guanine",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "20159999",
+    "year": "2010",
+    "authors": "Carothers, J. M., Goler, J. A., Kapoor, Y., Lara, L., & Keasling, J. D.",
+    "title": "Selecting RNA aptamers for synthetic biology: investigating magnesium dependence and predicting binding affinity",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "27730489",
+    "year": "2017",
+    "authors": "Duchardt-Ferner, E., Juen, M., Kreutz, C., & Wöhnert, J.",
+    "title": "NMR resonance assignments for the tetramethylrhodamine binding RNA aptamer 3 in complex with the ligand 5-carboxy-tetramethylrhodamine",
+    "journal": "Biomolecular NMR assignments"
+  },
+  {
+    "pmid": "31754719",
+    "year": "2020",
+    "authors": "Duchardt-Ferner, E., Juen, M., Bourgeois, B., Madl, T.",
+    "title": "Structure of an RNA aptamer in complex with the  fluorophore tetramethylrhodamine",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "35294188",
+    "year": "2022",
+    "authors": "Wu, J., Svensen, N., Song, W., Kim, H., Zhang, S., Li, X., & Jaffrey, S. R.",
+    "title": "Self-assembly of intracellular multivalent RNA complexes using dimeric Corn and Beetroot Aptamers",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "29295996",
+    "year": "2018",
+    "authors": "Jepsen, M. D. E., Sparvath, S. M., Nielsen, T. B., Langvad, A. H.",
+    "title": "Development of a genetically encodable FRET system using fluorescent RNA aptamers",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "33376189",
+    "year": "2021",
+    "authors": "Jeng, S. C. Y., Trachman, R. J., 3rd, Weissenboeck, F., Truong, L.",
+    "title": "Fluorogenic aptamers resolve the flexibility of RNA junctions using orientation-dependent FRET",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "36227560",
+    "year": "2023",
+    "authors": "Trachman, R. J., 3rd, Link, K. A., Knutson, J. R., & Ferré-D'Amaré, A. R.",
+    "title": "Characterizing fluorescence properties of turn-on RNA aptamers",
+    "journal": "Methods in molecular biology"
+  },
+  {
+    "pmid": "23746618",
+    "year": "2013",
+    "authors": "Strack, R. L., & Jaffrey, S. R.",
+    "title": "New approaches for sensing metabolites and proteins in live cells using RNA",
+    "journal": "Current opinion in chemical biology"
+  },
+  {
+    "pmid": "23991672",
+    "year": "2013",
+    "authors": "Höfer, K., Langejürgen, L. V., & Jäschke, A.",
+    "title": "Universal aptamer-based real-time monitoring of enzymatic RNA synthesis",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "24286188",
+    "year": "2013",
+    "authors": "Han, K. Y., Leslie, B. J., Fei, J., Zhang, J., & Ha, T.",
+    "title": "Understanding the photophysics of the spinach-DFHBI RNA aptamer-fluorogen complex to improve live-cell RNA imaging",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "24393009",
+    "year": "2014",
+    "authors": "Song, W., Strack, R. L., Svensen, N., & Jaffrey, S. R.",
+    "title": "Plug-and-play fluorophores extend the spectral properties of Spinach",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "23991760",
+    "year": "2014",
+    "authors": "Pothoulakis, G., Ceroni, F., Reeve, B., & Ellis, T.",
+    "title": "The spinach RNA aptamer as a characterization tool for synthetic biology",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "25026079",
+    "year": "2014",
+    "authors": "Warner, K. D., Chen, M. C., Song, W., Strack, R. L.",
+    "title": "Structural basis for activity of highly efficient RNA mimics of green fluorescent protein",
+    "journal": "Nature structural & molecular biology"
+  },
+  {
+    "pmid": "24942625",
+    "year": "2014",
+    "authors": "Bhadra, S., & Ellington, A. D.",
+    "title": "A Spinach molecular beacon triggered by strand displacement",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "24932527",
+    "year": "2015",
+    "authors": "Rogers, T. A., Andrews, G. E., Jaeger, L., & Grabow, W. W.",
+    "title": "Fluorescent monitoring of RNA assembly and processing using the split-Spinach aptamer",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "25964329",
+    "year": "2015",
+    "authors": "You, M., Litke, J. L., & Jaffrey, S. R.",
+    "title": "Imaging metabolite dynamics in living cells using a Spinach-based riboswitch",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "26612428",
+    "year": "2015",
+    "authors": "Zhang, J., Fei, J., Leslie, B. J., Han, K. Y., Kuhlman, T. E., & Ha, T.",
+    "title": "Tandem spinach array for mRNA imaging in living bacterial cells",
+    "journal": "Scientific reports"
+  },
+  {
+    "pmid": "26932363",
+    "year": "2016",
+    "authors": "Autour, A., Westhof, E., & Ryckelynck, M.",
+    "title": "iSpinach: a fluorogenic RNA aptamer optimized for in vitro applications",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "30016869",
+    "year": "2018",
+    "authors": "Tang, X., Deng, R., Sun, Y., Ren, X., Zhou, M., & Li, J.",
+    "title": "Amplified tandem Spinach-based aptamer transcription enables low background miRNA detection",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "30807171",
+    "year": "2019",
+    "authors": "Santra, K., Geraskin, I., Nilsen-Hamilton, M., Kraus, G. A., & Petrich, J. W.",
+    "title": "Characterization of the photophysical behavior of DFHBI derivatives: Fluorogenic molecules that illuminate the Spinach RNA aptamer",
+    "journal": "The journal of physical chemistry"
+  },
+  {
+    "pmid": "10339553",
+    "year": "19990525",
+    "authors": "Grate, D., & Wilson, C.",
+    "title": "Laser-mediated, site-specific inactivation of RNA transcripts",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "10926496",
+    "year": "20000804",
+    "authors": "Baugh, C., Grate, D., & Wilson, C.",
+    "title": "2.8 A crystal structure of the malachite green aptamer",
+    "journal": "Journal of molecular biology"
+  },
+  {
+    "pmid": "12475353",
+    "year": "20021218",
+    "authors": "Nguyen, D. H., DeFina, S. C., Fink, W. H., & Dieckmann, T.",
+    "title": "Binding to an RNA aptamer changes the charge distribution and conformation of malachite green",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "14695514",
+    "year": "20040103",
+    "authors": "Flinders, J., DeFina, S. C., Brackett, D. M., Baugh, C., Wilson, C.",
+    "title": "Recognition of planar and nonplanar Ligands in the malachite green±RNA aptamer complex",
+    "journal": "Chembiochem : a European journal of chemical biology"
+  },
+  {
+    "pmid": "16144363",
+    "year": "20050914",
+    "authors": "Kolpashchikov D. M.",
+    "title": "Binary malachite green aptamer for fluorescent detection of nucleic acids",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "18667307",
+    "year": "20080815",
+    "authors": "Furukawa, K., Abe, H., Abe, N., Harada, M., Tsuneda, S., & Ito, Y.",
+    "title": "Fluorescence generation from tandem repeats of a malachite green RNA aptamer using rolling circle transcription",
+    "journal": "Bioorganic & medicinal chemistry letters"
+  },
+  {
+    "pmid": "19195013",
+    "year": "20090301",
+    "authors": "Zhang, X., Potty, A. S., Jackson, G. W., Stepanov, V., Tang, A.",
+    "title": "Engineered 5S ribosomal RNAs displaying aptamers recognizing vascular endothelial growth factor and malachite green",
+    "journal": "Journal of molecular recognition: JMR"
+  },
+  {
+    "pmid": "21523267",
+    "year": "20110701",
+    "authors": "Bernard Da Costa, J., & Dieckmann, T.",
+    "title": "Entropy and Mg2+ control ligand affinity and specificity in the malachite green binding RNA aptamer",
+    "journal": "Molecular bioSystems"
+  },
+  {
+    "pmid": "22192051",
+    "year": "20120110",
+    "authors": "Sokoloski, J. E., Dombrowski, S. E., & Bevilacqua, P. C.",
+    "title": "Thermodynamics of ligand binding to a heterogeneous RNA population in the malachite green aptamer",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "23984874",
+    "year": "20130924",
+    "authors": "Da Costa, J. B., Andreiev, A. I., & Dieckmann, T.",
+    "title": "Thermodynamics and kinetics of adaptive binding in the malachite green RNA aptamer",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "27591602",
+    "year": "20161101",
+    "authors": "Zhou, Y., Chi, H., Wu, Y., Marks, R. S., & Steele, T. W. J.",
+    "title": "Organic additives stabilize RNA aptamer binding of malachite green",
+    "journal": "Talanta"
+  },
+  {
+    "pmid": "29513000",
+    "year": "20180316",
+    "authors": "Yerramilli, V. S., & Kim, K. H.",
+    "title": "Labeling RNAs in live cells using malachite green aptamer scaffolds as fluorescent probes",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "31187804",
+    "year": "20190721",
+    "authors": "Luo, X., Chen, Z., Li, H., Li, W., Cui, L., & Huang, J.",
+    "title": "Exploiting the application of l-aptamer with excellent stability: an efficient sensing platform for malachite green in fish samples",
+    "journal": "The Analyst"
+  },
+  {
+    "pmid": "35529731",
+    "year": "20191015",
+    "authors": "Wang, H., Wang, H., Zhang, M., Jia, Y., & Li, Z.",
+    "title": "A label-free aptamer-based biosensor for microRNA detection by the RNA-regulated fluorescence of malachite green",
+    "journal": "RSC advances"
+  },
+  {
+    "pmid": "36373144",
+    "year": "20221101",
+    "authors": "R O'Steen, M., & M Kolpashchikov, D.",
+    "title": "A self-assembling split aptamer multiplex assay for SARS-COVID19 and miniaturization of a malachite green DNA-based aptamer",
+    "journal": "Sensors and actuators reports"
+  },
+  {
+    "pmid": "19901993",
+    "year": "2009",
+    "authors": "Rahimi F, Murakami K, Summers JL, Chen CH, Bitan G",
+    "title": "RNA aptamers generated against oligomeric Abeta40 recognize common amyloid aptatopes with low specificity but high sensitivity",
+    "journal": "PLoS One"
+  },
+  {
+    "pmid": "25618678",
+    "year": "2015",
+    "authors": "Babu E, Muthu Mareeswaran P, Sathish V, Singaravadivel S, Rajagopal S",
+    "title": "Sensing and inhibition of amyloid-β based on the simple luminescent aptamer-ruthenium complex system",
+    "journal": "Talanta"
+  },
+  {
+    "pmid": "30642129",
+    "year": "2019",
+    "authors": "Janas T, Sapoń K, Stowell MHB, Janas T",
+    "title": "Selection of Membrane RNA Aptamers to Amyloid Beta Peptide: Implications for Exosome-Based Antioxidant Strategies",
+    "journal": "International journal of molecular sciences"
+  },
+  {
+    "pmid": "32127399",
+    "year": "2020",
+    "authors": "Murakami K, Obata Y, Sekikawa A, Ueda H, Izuo N",
+    "title": "An RNA aptamer with potent affinity for a toxic dimer of amyloid β42 has potential utility for histochemical studies of Alzheimer's disease",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "11884639",
+    "year": "2002",
+    "authors": "Lato SM, Ozerova ND, He K, Sergueeva Z, Shaw BR, Burke DH",
+    "title": "Boron-containing aptamers to ATP",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "9245404",
+    "year": "1997",
+    "authors": "Mannironi C, Di Nardo A, Fruscoloni P, Tocchini-Valentini GP",
+    "title": "In vitro selection of dopamine RNA ligands",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "21168553",
+    "year": "2011",
+    "authors": "Park H, Paeng IR",
+    "title": "Development of direct competitive enzyme-linked aptamer assay for determination of dopamine in serum",
+    "journal": "Analytica chimica acta"
+  },
+  {
+    "pmid": "23069733",
+    "year": "2012",
+    "authors": "Annoni C, Nakata E, Tamura T, Liew FF, Nakano S, Gelmi ML, Morii T",
+    "title": "Construction of ratiometric fluorescent sensors by ribonucleopeptides",
+    "journal": "Organic & biomolecular chemistry"
+  },
+  {
+    "pmid": "23210972",
+    "year": "2013",
+    "authors": "Farjami E, Campos R, Nielsen JS, Gothelf KV, Kjems J, Ferapontova EE",
+    "title": "RNA aptamer-based electrochemical biosensor for selective and label-free analysis of dopamine",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "25882962",
+    "year": "2015",
+    "authors": "Álvarez-Martos I, Campos R, Ferapontova EE",
+    "title": "Surface state of the dopamine RNA aptamer affects specific recognition and binding of dopamine by the aptamer-modified electrodes",
+    "journal": "The Analyst"
+  },
+  {
+    "pmid": "26916821",
+    "year": "2016",
+    "authors": "Álvarez-Martos I, Ferapontova EE",
+    "title": "Electrochemical Label-Free Aptasensor for Specific Analysis of Dopamine in Serum in the Presence of Structurally Related Neurotransmitters",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "30605601",
+    "year": "2019",
+    "authors": "Álvarez-Martos I, Møller A, Ferapontova EE",
+    "title": "Dopamine Binding and Analysis in Undiluted Human Serum and Blood by the RNA-Aptamer Electrode",
+    "journal": "ACS chemical neuroscience"
+  },
+  {
+    "pmid": "35775197",
+    "year": "2022",
+    "authors": "Harbaugh SV, Silverman AD, Chushak YG, Zimlich K, Wolfe M",
+    "title": "Engineering a Synthetic Dopamine-Responsive Riboswitch for In Vitro Biosensing",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "9631062",
+    "year": "1996",
+    "authors": "Nolte A, Klussmann S, Bald R, Erdmann VA, Fürste JP",
+    "title": "Mirror-design of L-oligonucleotide ligands binding to L-arginine",
+    "journal": "Nature biotechnology"
+  },
+  {
+    "pmid": "8604334",
+    "year": "1996",
+    "authors": "Geiger A, Burgstaller P, von der Eltz H, Roeder A, Famulok M",
+    "title": "RNA aptamers that bind L-arginine with sub-micromolar dissociation constants and high enantioselectivity",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "10786843",
+    "year": "2000",
+    "authors": "Mannironi C, Scerch C, Fruscoloni P, Tocchini-Valentini GP",
+    "title": "Molecular recognition of amino acids by RNA aptamers: the evolution into an L-tyrosine binder of a dopamine-binding RNA motif",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "28835641",
+    "year": "2017",
+    "authors": "Abatemarco J, Sarhan MF, Wagner JM, Lin JL, Liu L",
+    "title": "NA-aptamers-in-droplets (RAPID) high-throughput screening for secretory phenotypes",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "11756401",
+    "year": "2002",
+    "authors": "Proske D, Höfliger M, Söll RM, Beck-Sickinger AG, Famulok M",
+    "title": "A Y2 receptor mimetic aptamer directed against neuropeptide Y",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "15984861",
+    "year": "2005",
+    "authors": "Mendonsa SD, Bowser MT",
+    "title": "In vitro selection of aptamers with affinity for neuropeptide Y using capillary electrophoresis",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "33297678",
+    "year": "2021",
+    "authors": "López L, Hernández N, Reyes Morales J, Cruz J, Flores K",
+    "title": "Measurement of Neuropeptide Y Using Aptamer-Modified Microelectrodes by Electrochemical Impedance Spectroscopy",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "38033269",
+    "year": "2023",
+    "authors": "Seibold JM, Abeykoon SW, Ross AE, White RJ",
+    "title": "Development of an Electrochemical, Aptamer-Based Sensor for Dynamic Detection of Neuropeptide Y",
+    "journal": "ACS sensors"
+  },
+  {
+    "pmid": "38709872",
+    "year": "2024",
+    "authors": "Fernández-Vega L, Meléndez-Rodríguez DE, Ospina-Alejandro M",
+    "title": "Development of a Neuropeptide Y-Sensitive Implantable Microelectrode for Continuous Measurements",
+    "journal": "ACS sensors"
+  },
+  {
+    "pmid": "11139634",
+    "year": "2001",
+    "authors": "Srisawat C, Goldstein IJ, Engelke DR",
+    "title": "Sephadex-binding RNA ligands: rapid affinity purification of RNA from complex RNA mixtures",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "26135474",
+    "year": "2015",
+    "authors": "Lee T, Yagati AK, Pi F, Sharma A, Choi JW, Guo P",
+    "title": "Construction of RNA-Quantum Dot Chimera for Nanoscale Resistive Biomemory Application",
+    "journal": "ACS nano"
+  },
+  {
+    "pmid": "32042566",
+    "year": "2019",
+    "authors": "Lee T, Mohammadniaei M, Zhang H, Yoon J, Choi HK, Guo S",
+    "title": "Single Functionalized pRNA/Gold Nanoparticle for Ultrasensitive MicroRNA Detection Using Electrochemical Surface-Enhanced Raman Spectroscopy",
+    "journal": "Advanced science"
+  },
+  {
+    "pmid": "11178986",
+    "year": "2001",
+    "authors": "Jeong S, Eom T, Kim S, Lee S, Yu J",
+    "title": "In vitro selection of the RNA aptamer against the Sialyl Lewis X and its inhibition of the cell adhesion",
+    "journal": "Biochemical and biophysical research communications"
+  },
+  {
+    "pmid": "15745995",
+    "year": "2005",
+    "authors": "Eulberg D, Buchner K, Maasch C, Klussmann S",
+    "title": "Development of an automated in vitro selection protocol to obtain RNA-based aptamers: identification of a biostable substance P antagonist",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "1370372",
+    "year": "1992",
+    "authors": "Burnashev, N., Monyer, H., Seeburg, P. H., & Sakmann, B.",
+    "title": "Divalent ion permeability of AMPA receptor channels is dominated by the edited form of a single subunit",
+    "journal": "Neuron 8"
+  },
+  {
+    "pmid": "8604042",
+    "year": "1996",
+    "authors": "Wenthold, R. J., Petralia, R. S., Blahos, J., II, & Niedzielski, A. S.",
+    "title": "Evidence for multiple AMPA receptor complexes in hippocampal CA1/CA2 neurons",
+    "journal": "J. Neurosci"
+  },
+  {
+    "pmid": "8522940",
+    "year": "1996",
+    "authors": "Seeburg, P. H.",
+    "title": "The role of RNA editing in controlling glutamate receptor channel properties",
+    "journal": "J. Neurochem"
+  },
+  {
+    "pmid": "8987736",
+    "year": "1997",
+    "authors": "Swanson, G. T., Kamboj, S. K., & Cull-Candy, S. G.",
+    "title": "Single-channel properties of recombinant AMPA receptors depend on RNA editing, splice variation, and subunit composition",
+    "journal": "J. Neurosci"
+  },
+  {
+    "pmid": "11124978",
+    "year": "2000",
+    "authors": "Schiffer, H. H., Swanson, G. T., Masliah, E., & Heinemann, S. F.",
+    "title": "Unequal expression of allelic kainate receptor GluR7 mRNAs in human brains",
+    "journal": "J. Neurosci"
+  },
+  {
+    "pmid": "14622580",
+    "year": "2003",
+    "authors": "Greger, I. H., Khatri, L., Kong, X., & Ziff, E. B.",
+    "title": "AMPA receptor tetramerization is mediated by Q/R editing",
+    "journal": "Neuron"
+  },
+  {
+    "pmid": "20518485",
+    "year": "2010",
+    "authors": "Huang, Z., Han, Y., Wang, C., & Niu, L.",
+    "title": "Potent and selective inhibition of the open-channel conformation of AMPA receptors by an RNA aptamer",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "21402710",
+    "year": "2011",
+    "authors": "Park, J. S., Wang, C., Han, Y., Huang, Z., & Niu, L.",
+    "title": "Potent and selective inhibition of a single alpha-amino-3-hydroxy-5-methyl-4-isoxazolepropionic acid (AMPA) receptor subunit by an RNA aptamer",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "28325839",
+    "year": "2017",
+    "authors": "Jaremko, W. J., Huang, Z., Wen, W., Wu, A., Karl, N., & Niu, L.",
+    "title": "Identification and characterization of RNA aptamers: A long aptamer blocks the AMPA receptor and a short aptamer blocks both AMPA and kainate receptors",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "34509496",
+    "year": "2021",
+    "authors": "Huang, Z., & Niu, L.",
+    "title": "RNA aptamers for AMPA receptors",
+    "journal": "Neuropharmacology"
+  },
+  {
+    "pmid": "6375662",
+    "year": "1984",
+    "authors": "Glennera, G. G., & Wong, C. W.",
+    "title": "Alzheimer’s disease: initial report of the purification and characterization of a novel cerebrovascular amyloid protein",
+    "journal": "Biochemical and biophysical research communications"
+  },
+  {
+    "pmid": "3159021",
+    "year": "1985",
+    "authors": "Masters, C. L., Simms, G., Weinman, N. A., Multhaup, G.",
+    "title": "Amyloid plaque core protein in Alzheimer disease and Down syndrome",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "9190286",
+    "year": "1997",
+    "authors": "Harper, J. D., Wong, S. S., Lieber, C. M., & Lansbury, P. T.",
+    "title": "Observation of metastable Aβ amyloid protofibrils by atomic force microscopy",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "9268388",
+    "year": "1997",
+    "authors": "Walsh, D. M., Lomakin, A., Benedek, G. B., Condron, M. M.",
+    "title": "Amyloid beta-protein fibrillogenesis. Detection of a protofibrillar intermediate",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "9600986",
+    "year": "1998",
+    "authors": "Lambert, M. P., Barlow, A. K., Chromy, B. A., Edwards, C., Freed, R.",
+    "title": "Diffusible, nonfibrillar ligands derived from Abeta1-42 are potent central nervous system neurotoxins",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "12750461",
+    "year": "2003",
+    "authors": "Hoshi, M., Sato, M., Matsumoto, S., Noguchi, A., Yasutake, K.",
+    "title": "Spherical aggregates of beta-amyloid (amylospheroid) show high neurotoxicity and activate tau protein kinase I/glycogen synthase kinase-3beta",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "17245412",
+    "year": "2007",
+    "authors": "Haass, C., & Selkoe, D. J.",
+    "title": "Soluble protein oligomers in neurodegeneration: lessons from the Alzheimer's amyloid beta-peptide",
+    "journal": "Nature reviews. Molecular cell biology"
+  },
+  {
+    "pmid": "18845536",
+    "year": "2009",
+    "authors": "Roychaudhuri, R., Yang, M., Hoshi, M. M., & Teplow, D. B.",
+    "title": "Amyloid β-protein assembly and Alzheimer disease",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "27162352",
+    "year": "2016",
+    "authors": "Watanabe-Nakayama, T., Ono, K., Itami, M., Takahashi, R.",
+    "title": "High-speed atomic force microscopy reveals structural dynamics of amyloid β1-42 aggregates",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "16868550",
+    "year": "2006",
+    "authors": "Waldmann T. A.",
+    "title": "The biology of interleukin-2 and interleukin-15: implications for cancer therapy and vaccine design",
+    "journal": "Nature reviews. Immunology"
+  },
+  {
+    "pmid": "20732639",
+    "year": "2010",
+    "authors": "Malek, T. R., & Castro, I.",
+    "title": "Interleukin-2 receptor signaling: at the interface between tolerance and immunity",
+    "journal": "Immunity"
+  },
+  {
+    "pmid": "23675235",
+    "year": "2011",
+    "authors": "Ito, M., Zhao, N., Zeng, Z., Zhou, X., Chang, C. C., & Zu, Y.",
+    "title": "Interleukin-2 functions in anaplastic large cell lymphoma cells through augmentation of extracellular signal-regulated kinases 1/2 activation",
+    "journal": "International journal of biomedical science : IJBS"
+  },
+  {
+    "pmid": "21719603",
+    "year": "2011",
+    "authors": "Yang, Z. Z., Grote, D. M., Ziesmer, S. C., Manske, M. K.",
+    "title": "Soluble IL-2Ralpha facilitates IL-2-mediated immune responses and predicts reduced survival in follicular B-cell non-Hodgkin lymphoma",
+    "journal": "Blood"
+  },
+  {
+    "pmid": "22849383",
+    "year": "2012",
+    "authors": "Whiteside TL, Schuler P, Schilling B.",
+    "title": "Induced and natural regulatory T cells in human cancer",
+    "journal": "Expert opinion on biological therapy"
+  },
+  {
+    "pmid": "25422100",
+    "year": "2015",
+    "authors": "Mir, M. A., Maurer, M. J., Ziesmer, S. C., Slager, S. L.",
+    "title": "Elevated serum levels of IL-2R, IL-1RA, and CXCL9 are associated with a poor prognosis in follicular lymphoma",
+    "journal": "Blood"
+  },
+  {
+    "pmid": "26205340",
+    "year": "2015",
+    "authors": "Melero, I., Berman, D. M., Aznar, M. A., Korman, A. J.",
+    "title": "Evolving synergistic combinations of targeted immunotherapies to combat cancer.",
+    "journal": "Nature reviews. Cancer"
+  },
+  {
+    "pmid": "25561050",
+    "year": "2015",
+    "authors": "Ma, H., Liu, J., Ali, M. M., Mahmood, M. A., Labanieh, L.",
+    "title": "Nucleic acid aptamers in cancer research, diagnosis and therapy",
+    "journal": "Nucleic acid aptamers in cancer research"
+  },
+  {
+    "pmid": "28383112",
+    "year": "2017",
+    "authors": "Binder, M., O'Byrne, M. M., Maurer, M. J., Ansell, S.",
+    "title": "Associations between elevated pre-treatment serum cytokines and peripheral blood cellular markers of immunosuppression in patients with lymphoma",
+    "journal": "American journal of hematology"
+  },
+  {
+    "pmid": "31383650",
+    "year": "2019",
+    "authors": "Veeramani, S., Blackwell, S. E., Thiel, W. H., Yang, Z. Z.",
+    "title": "An RNA Aptamer-Based Biomarker Platform Demonstrates High Soluble CD25 Occupancy by IL2 in the Serum of Follicular Lymphoma Patients",
+    "journal": "Cancer immunology research"
+  },
+  {
+    "pmid": "12453418",
+    "year": "2002",
+    "authors": "Milne, T. A., Briggs, S. D., Brock, H. W., Martin, M. E.",
+    "title": "MLL targets SET domain methyltransferase activity to Hox gene promoters",
+    "journal": "Mol. Cell"
+  },
+  {
+    "pmid": "12482972",
+    "year": "2003",
+    "authors": "Hsieh, J. J., Ernst, P., Erdjument-Bromage, H., Tempst, P.",
+    "title": "Proteolytic cleavage of MLL generates a complex of N- and C-terminal fragments that confers protein stability and subnuclear localization",
+    "journal": "Mol. Cell. Biol."
+  },
+  {
+    "pmid": "16199523",
+    "year": "2005",
+    "authors": "Milne, T. A., Dou, Y., Martin, M. E., Brock, H. W.",
+    "title": "MLL associates specifically with a subset of transcriptionally active target genes",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "15949446",
+    "year": "2005",
+    "authors": "Morillon, A., Karabetsou, N., Nair, A., & Mellor, J.",
+    "title": "Dynamic lysine methylation on histone H3 defines the regulatory phase of gene transcription",
+    "journal": "Mol. Cell"
+  },
+  {
+    "pmid": "18224408",
+    "year": "2008",
+    "authors": "Dou, Y., & Hess, J. L.",
+    "title": "Mechanisms of transcriptional regulation by MLL and its disruption in acute leukemia",
+    "journal": "International journal of hematology"
+  },
+  {
+    "pmid": "16878130",
+    "year": "2008",
+    "authors": "Dou, Y., Milne, T. A., Ruthenburg, A. J., Lee, S., Lee, J. W.",
+    "title": "Regulation of MLL1 H3K4 methyltransferase activity by its core components",
+    "journal": "Nat. Struct. Mol. Biol."
+  },
+  {
+    "pmid": "19187761",
+    "year": "2009",
+    "authors": "Southall, S. M., Wong, P. S., Odho, Z., Roe, S. M., & Wilson, J. R.",
+    "title": "Structural basis for the requirement of additional factors for MLL1 SET domain activity and recognition of epigenetic marks",
+    "journal": "Mol. Cell"
+  },
+  {
+    "pmid": "24288367",
+    "year": "2013",
+    "authors": "Jeong, K. W., Andreu-Vieyra, C., You, J. S., Jones, P. A.",
+    "title": "Establishment of active chromatin structure at enhancer elements by mixed-lineage leukemia 1 to initiate estrogendependent gene expression",
+    "journal": "Nucleic Acids Res."
+  },
+  {
+    "pmid": "23210835",
+    "year": "2013",
+    "authors": "Karatas, H., Townsend, E. C., Cao, F., Chen, Y., Bernard, D.",
+    "title": "High-affinity, small-molecule peptidomimetic inhibitors of MLL1/WDR5 protein-protein interaction",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "24389101",
+    "year": "2014",
+    "authors": "Cao, F., Townsend, E. C., Karatas, H., Xu, J., Li, L., Lee, S.",
+    "title": "Targeting MLL1 H3K4 methyltransferase activity in mixed-lineage leukemia",
+    "journal": "Molecular cell"
+  },
+  {
+    "pmid": "30419633",
+    "year": "2019",
+    "authors": "Ul-Haq, A., Jin, M. L., Jeong, K. W., Kim, H. M., & Chun, K. H.",
+    "title": "Isolation of MLL1 Inhibitory RNA Aptamers",
+    "journal": "Biomolecules & therapeutics"
+  },
+  {
+    "pmid": "18776253",
+    "year": "2008",
+    "authors": "Maasch, C., Buchner, K., Eulberg, D., Vonhoff, S., & Klussmann, S.",
+    "title": "Physicochemical stability of NOX-E36, a 40mer L-RNA (Spiegelmer) for therapeutic applications",
+    "journal": "Nucleic acids symposium series"
+  },
+  {
+    "pmid": "18258851",
+    "year": "2008",
+    "authors": "Ninichuk, V., Clauss, S., Kulkarni, O., Schmid, H., Segerer, S.",
+    "title": "Late onset of Ccl2 blockade with the Spiegelmer mNOX-E36-3'PEG prevents glomerulosclerosis and improves glomerular filtration rate in db/db mice",
+    "journal": "The American journal of pathology"
+  },
+  {
+    "pmid": "19156777",
+    "year": "2009",
+    "authors": "Clauss, S., Gross, O., Kulkarni, O., Avila-Ferrufino, A.",
+    "title": "Ccl2/Mcp-1 blockade reduces glomerular and interstitial macrophages but does not ameliorate renal pathology in collagen4A3-deficient mice with autosomal recessive Alport nephropathy",
+    "journal": "The Journal of pathology"
+  },
+  {
+    "pmid": "21813474",
+    "year": "2012",
+    "authors": "Baeck, C., Wehr, A., Karlmark, K. R., Heymann, F., Vucur, M.",
+    "title": "Pharmacological inhibition of the chemokine CCL2 (MCP-1) diminishes liver macrophage infiltration and steatohepatitis in chronic hepatic injury",
+    "journal": "Gut"
+  },
+  {
+    "pmid": "24561613",
+    "year": "2014",
+    "authors": "Ehling, J., Bartneck, M., Wei, X., Gremse, F., Fech, V.",
+    "title": "CCL2-dependent infiltrating macrophages promote angiogenesis in progressive liver fibrosis",
+    "journal": "Gut"
+  },
+  {
+    "pmid": "24481979",
+    "year": "2014",
+    "authors": "Baeck, C., Wei, X., Bartneck, M., Fech, V., Heymann, F.",
+    "title": "Pharmacological inhibition of the chemokine C-C motif chemokine ligand 2 (monocyte chemoattractant protein 1) accelerates liver fibrosis regression by suppressing Ly-6C(+) macrophage infiltration in mice",
+    "journal": "Hepatology"
+  },
+  {
+    "pmid": "25901662",
+    "year": "2015",
+    "authors": "Oberthür D, Achenbach J, Gabdulkhakov A, Buchner K, Maasch C",
+    "title": "Crystal structure of a mirror-image L-RNA aptamer (Spiegelmer) in complex with the natural L-protein target CCL2",
+    "journal": "Nat Commun"
+  },
+  {
+    "pmid": "25970072",
+    "year": "2015",
+    "authors": "Kalnins, A., Thomas, M. N., Andrassy, M., Müller, S., Wagner, A.",
+    "title": "Spiegelmer Inhibition of MCP-1/CCR2--Potential as an Adjunct Immunosuppressive Therapy in Transplantation",
+    "journal": "Scandinavian journal of immunology"
+  },
+  {
+    "pmid": "28186566",
+    "year": "2017",
+    "authors": "Menne, J., Eulberg, D., Beyer, D., Baumann, M., Saudek, F.",
+    "title": "C-C motif-ligand 2 inhibition with emapticap pegol (NOX-E36) in type 2 diabetic patients with albuminuria",
+    "journal": "Nephrology"
+  },
+  {
+    "pmid": "28837800",
+    "year": "2017",
+    "authors": "Boels, M. G. S., Koudijs, A., Avramut, M. C., Sol, W. M. P. J.",
+    "title": "Systemic Monocyte Chemotactic Protein-1 Inhibition Modifies Renal Macrophages and Restores Glomerular Endothelial Glycocalyx and Barrier Function in Diabetic Nephropathy",
+    "journal": "The American journal of pathology"
+  },
+  {
+    "pmid": "9346949",
+    "year": "1997",
+    "authors": "Thomas, M., Chédin, S., Carles, C., Riva, M., Famulok, M.",
+    "title": "Selective targeting and inhibition of yeast RNA polymerase II by RNA aptamers",
+    "journal": "The Journal of biological chemistry"
+  },
+  {
+    "pmid": "16341226",
+    "year": "2006",
+    "authors": "Kettenberger, H., Eisenführ, A., Brueckner, F., Theis, M.",
+    "title": "Structure of an RNA polymerase II-RNA inhibitor complex elucidates transcription regulation by noncoding RNAs",
+    "journal": "Nature structural & molecular biology"
+  },
+  {
+    "pmid": "29570714",
+    "year": "2018",
+    "authors": "Klopf, E., Moes, M., Amman, F., Zimmermann, B., von Pelchrzim, F.",
+    "title": "Nascent RNA signaling to yeast RNA Pol II during transcription elongation",
+    "journal": "PloS one"
+  },
+  {
+    "pmid": "32663063",
+    "year": "2020",
+    "authors": "Boots, J. L., von Pelchrzim, F., Weiss, A., Zimmermann, B.",
+    "title": "RNA polymerase II-binding aptamers in human ACRO1 satellites disrupt transcription in cis",
+    "journal": "Transcription"
+  },
+  {
+    "pmid": "9772167",
+    "year": "1998",
+    "authors": "Wilson, C., Nix, J., & Szostak, J.",
+    "title": "Functional requirements for specific ligand recognition by a biotin-binding RNA pseudoknot",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "10089439",
+    "year": "1999",
+    "authors": "Nix, J. C., Newhoff, A. R., & Wilson, C.",
+    "title": "Preliminary crystallographic characterization of an in vitro evolved biotin-binding RNA pseudoknot",
+    "journal": "Acta crystallographica. Section D"
+  },
+  {
+    "pmid": "10698630",
+    "year": "2000",
+    "authors": "Nix, J., Sussman, D., & Wilson, C.",
+    "title": "The 1.3 A crystal structure of a biotin-binding pseudoknot and the basis for RNA molecular recognition",
+    "journal": "Journal of molecular biology"
+  },
+  {
+    "pmid": "26903199",
+    "year": "2016",
+    "authors": "Sung, T. C., Chen, W. Y., Shah, P., & Chen, C. S.",
+    "title": "A replaceable liposomal aptamer for the ultrasensitive and rapid detection of biotin",
+    "journal": "Scientific reports"
+  },
+  {
+    "pmid": "35340298",
+    "year": "2022",
+    "authors": "Uppala, J. K., Ghosh, C., Sabat, G., & Dey, M.",
+    "title": "Pull-down of Biotinylated RNA and Associated Proteins",
+    "journal": "Bio-protocol"
+  },
+  {
+    "pmid": "8289245",
+    "year": "1994",
+    "authors": "Jensen KB, Green L, MacDougal-Waugh S, Tuerk C.",
+    "title": "Characterization of an in vitro-selected RNA ligand to the HIV-1 Rev protein",
+    "journal": "J Mol Biol"
+  },
+  {
+    "pmid": "10467126",
+    "year": "1999",
+    "authors": "Ye X, Gorin A, Frederick R, et al",
+    "title": "RNA architecture dictates the conformations of a bound peptide",
+    "journal": "Chem Biol"
+  },
+  {
+    "pmid": "10647177",
+    "year": "1999",
+    "authors": "Jiang F, Gorin A, Hu W, et al.",
+    "title": "Anchoring an extended HTLV-1 Rex peptide within an RNA major groove containing junctional base triples",
+    "journal": "Structure"
+  },
+  {
+    "pmid": "18922466",
+    "year": "2008",
+    "authors": "Daugherty MD, D'Orso I, Frankel AD.",
+    "title": "A solution to limited genomic capacity: using adaptable binding surfaces to assemble the functional HIV Rev oligomer on RNA",
+    "journal": "Mol Cell"
+  },
+  {
+    "pmid": "23972852",
+    "year": "2013",
+    "authors": "Casu F, Duggan BM, Hennig M",
+    "title": "The arginine-rich RNA-binding motif of HIV-1 Rev is intrinsically disordered and folds upon RRE binding",
+    "journal": "Biophys J"
+  },
+  {
+    "pmid": "25486594",
+    "year": "2014",
+    "authors": "Jayaraman B, Crosby DC, Homer C, Ribeiro I, Mavor D, Frankel AD",
+    "title": "RNA-directed remodeling of the HIV-1 protein Rev orchestrates assembly of the Rev-Rev response element complex",
+    "journal": "Elife"
+  },
+  {
+    "pmid": "10233958",
+    "year": "1999",
+    "authors": "Baskerville, S., Zapp, M., & Ellington, A. D.",
+    "title": "Anti-Rex aptamers as mimics of the Rex-binding element",
+    "journal": "Journal of virology"
+  },
+  {
+    "pmid": "12925996",
+    "year": "2003",
+    "authors": "Luedtke, N. W., & Tor, Y.",
+    "title": "Fluorescence-based methods for evaluating the RNA affinity and specificity of HIV-1 Rev-RRE inhibitors",
+    "journal": "Biopolymers"
+  },
+  {
+    "pmid": "18351707",
+    "year": "2008",
+    "authors": "Sugaya, M., Nishino, N., Katoh, A., & Harada, K.",
+    "title": "Amino acid requirement for the high affinity binding of a selected arginine-rich peptide with the HIV Rev-response element RNA",
+    "journal": "Journal of peptide science : an official publication of the European Peptide Society"
+  },
+  {
+    "pmid": "26896646",
+    "year": "2016",
+    "authors": "Prado, S., Beltrán, M., Coiras, M., Bedoya, L. M., Alcamí, J.",
+    "title": "Bioavailable inhibitors of HIV-1 RNA biogenesis identified through a Rev-based screen",
+    "journal": "Biochemical pharmacology"
+  },
+  {
+    "pmid": "12604126",
+    "year": "2003",
+    "authors": "Asou N.",
+    "title": "The role of a Runt domain transcription factor AML1/RUNX1 in leukemogenesis and its clinical implications.",
+    "journal": "Critical reviews in oncology/hematology"
+  },
+  {
+    "pmid": "20140822",
+    "year": "2010",
+    "authors": "Mongelard, F., & Bouvet, P",
+    "title": "AS-1411, a guanosine-rich oligonucleotide aptamer targeting nucleolin for the potential treatment of cancer, including acute myeloid leukemia.",
+    "journal": "Current opinion in molecular therapeutics"
+  },
+  {
+    "pmid": "23997091",
+    "year": "2013",
+    "authors": "Nomura, Y., Tanaka, Y., Fukunaga, J., Fujiwara, K., Chiba, M.",
+    "title": "Solution structure of a DNA mimicking motif of an RNA aptamer against transcription factor AML1 Runt domain",
+    "journal": "Journal of biochemistry"
+  },
+  {
+    "pmid": "26204224",
+    "year": "2015",
+    "authors": "Zhao, N., Pei, S. N., Qi, J., Zeng, Z., Iyer, S. P., Lin, P.",
+    "title": "Oligonucleotide aptamer-drug conjugates for targeted therapy of acute myeloid leukemia",
+    "journal": "Biomaterials"
+  },
+  {
+    "pmid": "27514505",
+    "year": "2016",
+    "authors": "Zaimy, M. A., Jebali, A., Bazrafshan, B., Mehrtashfar, S., Shabani, S.",
+    "title": "Coinhibition of overexpressed genes in acute myeloid leukemia subtype M2 by gold nanoparticles functionalized with five antisense oligonucleotides and one anti-CD33(+)/CD34(+) aptamer",
+    "journal": "Cancer gene therapy"
+  },
+  {
+    "pmid": "27766833",
+    "year": "2016",
+    "authors": "Amano, R., Takada, K., Tanaka, Y., Nakamura, Y., Kawai, G., Kozu, T., & Sakamoto, T",
+    "title": "Kinetic and Thermodynamic Analyses of Interaction between a High-Affinity RNA Aptamer and Its Target Protein",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "26972431",
+    "year": "2016",
+    "authors": "Kadioglu, O., & Efferth, T",
+    "title": "Peptide aptamer identified by molecular docking targeting translationally controlled tumor protein in leukemia cells",
+    "journal": "Investigational new drugs"
+  },
+  {
+    "pmid": "30519686",
+    "year": "2019",
+    "authors": "Yang, C., , Wang, Y., , Ge, M. H., , Fu, Y. J., , Hao, R., , Islam, K.",
+    "title": "Rapid identification of specific DNA aptamers precisely targeting CD33 positive leukemia cells through a paired cell-based approach",
+    "journal": "Biomaterials science"
+  },
+  {
+    "pmid": "31824168",
+    "year": "2019",
+    "authors": "Tan, Y., Li, Y., & Tang, F",
+    "title": "Nucleic Acid Aptamer: A Novel Potential Diagnostic and Therapeutic Tool for Leukemia",
+    "journal": "OncoTargets and therapy"
+  },
+  {
+    "pmid": "9383458",
+    "year": "1995",
+    "authors": "Wallis, M. G., von Ahsen, U., Schroeder, R., & Famulok, M.",
+    "title": "A novel RNA motif for neomycin recognition",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "10425683",
+    "year": "1999",
+    "authors": "Jiang, L., Majumdar, A., Hu, W., Jaishree, T. J., Xu, W.",
+    "title": "Saccharide-RNA recognition in a complex formed between neomycin B and an RNA aptamer",
+    "journal": "Structure"
+  },
+  {
+    "pmid": "10908357",
+    "year": "2000",
+    "authors": "Cowan, J. A., Ohyama, T., Wang, D., & Natarajan, K",
+    "title": "Recognition of a cognate RNA aptamer by neomycin B: quantitative evaluation of hydrogen bonding and electrostatic interactions",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "18000033",
+    "year": "2008",
+    "authors": "Weigand, J. E., Sanchez, M., Gunnesch, E. B., Zeiher, S., Schroeder, R.",
+    "title": "Screening for engineered neomycin riboswitches that control translation initiation",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "19217276",
+    "year": "2009",
+    "authors": "de-los-Santos-Alvarez, N., Lobo-Castañón, M. J., Miranda-Ordieres, A. J., & Tuñón-Blanco, P.",
+    "title": "SPR sensing of small molecules with modified RNA aptamers: detection of neomycin B",
+    "journal": "Biosensors & bioelectronics"
+  },
+  {
+    "pmid": "20478079",
+    "year": "2010",
+    "authors": "Wilhelmsson L. M.",
+    "title": "Fluorescent nucleic acid base analogues",
+    "journal": "Quarterly reviews of biophysics"
+  },
+  {
+    "pmid": "22951899",
+    "year": "2012",
+    "authors": "Jeon, J., Lee, K. H., & Rao, J.",
+    "title": "A strategy to enhance the binding affinity of fluorophore-aptamer pairs for RNA tagging with neomycin conjugation",
+    "journal": "Chemical communications"
+  },
+  {
+    "pmid": "24757168",
+    "year": "2014",
+    "authors": "Ilgu, M., Fulton, D. B., Yennamalli, R. M., Lamm, M. H.",
+    "title": "An adaptable pentaloop defines a robust neomycin-B RNA aptamer with conditional ligand-bound structures",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "26661511",
+    "year": "2016",
+    "authors": "Duchardt-Ferner, E., Gottstein-Schmidtke, S. R., Weigand, J. E.",
+    "title": "What a Difference an OH Makes: Conformational Dynamics as the Basis for the Ligand Specificity of the Neomycin-Sensing Riboswitch",
+    "journal": "Angewandte Chemie"
+  },
+  {
+    "pmid": "26942739",
+    "year": "2016",
+    "authors": "Ling, K., Jiang, H., Zhang, L., Li, Y., Yang, L., Qiu, C., & Li, F. R.",
+    "title": "A self-assembling RNA aptamer-based nanoparticle sensor for fluorometric detection of Neomycin B in milk",
+    "journal": "Analytical and bioanalytical chemistry"
+  },
+  {
+    "pmid": "30462266",
+    "year": "2019",
+    "authors": "Gustmann, H., Segler, A. J., Gophane, D. B., Reuss, A. J.",
+    "title": "Structure guided fluorescence labeling reveals a two-step binding mechanism of neomycin to its RNA aptamer",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "33237073",
+    "year": "2020",
+    "authors": "Bastian, A. A., Gruszka, A., Jung, P., & Herrmann, A",
+    "title": "Aptamer protective groups tolerate different reagents and reactions for regioselective modification of neomycin B",
+    "journal": "Organic & biomolecular chemistry"
+  },
+  {
+    "pmid": "9436913",
+    "year": "1998",
+    "authors": "Wallace, S. T., & Schroeder, R.",
+    "title": "In vitro selection and characterization of streptomycin-binding RNAs: recognition discrimination between antibiotics",
+    "journal": "RNA (New York"
+  },
+  {
+    "pmid": "12618190",
+    "year": "2003",
+    "authors": "Tereshko, V., Skripkin, E., & Patel, D. J.",
+    "title": "Encapsulating streptomycin within a small 40-mer RNA",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "16621675",
+    "year": "2006",
+    "authors": "Lee, J. F., Stovall, G. M., & Ellington, A. D.",
+    "title": "Aptamer therapeutics advance",
+    "journal": "Current opinion in chemical biology"
+  },
+  {
+    "pmid": "17355135",
+    "year": "2007",
+    "authors": "de-los-Santos-Alvarez, N., Lobo-Castañón, M. J., Miranda-Ordieres, A. J.",
+    "title": "Modified-RNA aptamer-based sensor for competitive impedimetric assay of neomycin B",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "18388495",
+    "year": "2008",
+    "authors": "Windbichler, N., von Pelchrzim, F., Mayer, O., Csaszar, E., & Schroeder, R.",
+    "title": "Isolation of small RNA-binding proteins from E. coli: evidence for frequent interaction of RNAs with RNA polymerase",
+    "journal": "RNA biology"
+  },
+  {
+    "pmid": "20426747",
+    "year": "2010",
+    "authors": "Tombelli, S., & Mascini, M.",
+    "title": "Aptamers biosensors for pharmaceutical compounds",
+    "journal": "Combinatorial chemistry & high throughput screening"
+  },
+  {
+    "pmid": "22173871",
+    "year": "2012",
+    "authors": "Bose, D., Jayaraj, G., Suryawanshi, H., Agarwala, P., Pore, S. K.",
+    "title": "The tuberculosis drug streptomycin as a potential cancer therapeutic: inhibition of miR-21 function by directly targeting its precursor",
+    "journal": "Angewandte Chemie"
+  },
+  {
+    "pmid": "22793869",
+    "year": "2012",
+    "authors": "Derbyshire, N., White, S. J., Bunka, D. H., Song, L., Stead, S., Tarbin, J.",
+    "title": "Toggled RNA aptamers against aminoglycosides allowing facile detection of antibiotics using gold nanoparticle assays",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "23601877",
+    "year": "2013",
+    "authors": "Zhou, N., Wang, J., Zhang, J., Li, C., Tian, Y., & Wang, J.",
+    "title": "Selection and identification of streptomycin-specific single-stranded DNA aptamers and the application in the detection of streptomycin in honey",
+    "journal": "Talanta"
+  },
+  {
+    "pmid": "23192876",
+    "year": "2013",
+    "authors": "Nicholson, B. L., Zaslaver, O., Mayberry, L. K., Browning, K. S.",
+    "title": "Tombusvirus Y-shaped translational enhancer forms a complex with eIF4F and can be functionally replaced by heterologous translational enhancers",
+    "journal": "Journal of virology"
+  },
+  {
+    "pmid": "27281393",
+    "year": "2016",
+    "authors": "Nick, T. A., de Oliveira, T. E., Pilat, D. W., Spenkuch, F., Butt, H. J.",
+    "title": "Stability of a Split Streptomycin Binding Aptamer",
+    "journal": "The journal of physical chemistry. B"
+  },
+  {
+    "pmid": "28965053",
+    "year": "2018",
+    "authors": "Lin, B., Yu, Y., Cao, Y., Guo, M., Zhu, D., Dai, J., & Zheng, M.",
+    "title": "Point-of-care testing for streptomycin based on aptamer recognizing and digital image colorimetry by smartphone",
+    "journal": "Biosensors & bioelectronics"
+  },
+  {
+    "pmid": "31757139",
+    "year": "2019",
+    "authors": "Baptista, L. A., & Netz, P. A.",
+    "title": "Single molecule force spectroscopy of a streptomycin-binding RNA aptamer: An out-of-equilibrium molecular dynamics study.",
+    "journal": "The Journal of chemical physics"
+  },
+  {
+    "pmid": "35297324",
+    "year": "2023",
+    "authors": "Nosrati, M., & Roushani, M.",
+    "title": "Three-dimensional modeling of streptomycin binding single-stranded DNA for aptamer-based biosensors, a molecular dynamics simulation approach",
+    "journal": "Journal of biomolecular structure & dynamics"
+  },
+  {
+    "pmid": "11557342",
+    "year": "2001",
+    "authors": "Berens, C., Thain, A. & Schroeder, R.",
+    "title": "A tetracycline-binding RNA aptamer.",
+    "journal": "Bioorganic & medicinal chemistry"
+  },
+  {
+    "pmid": "12950926",
+    "year": "2003",
+    "authors": "Hanson, S., Berthelot, K., Fink, B., McCarthy, J. E. G. & Suess, B.",
+    "title": "Tetracycline-aptamer-mediated translational regulation in yeast",
+    "journal": "Molecular microbiology"
+  },
+  {
+    "pmid": "15769877",
+    "year": "2005",
+    "authors": "Hanson, S., Bauer, G., Fink, B. & Suess, B",
+    "title": "Molecular analysis of a synthetic tetracycline-binding riboswitch",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "15723047",
+    "year": "2005",
+    "authors": "Bayer, T. S. & Smolke, C. D.",
+    "title": "Programmable ligand-controlled riboregulators of eukaryotic gene expression",
+    "journal": "Nature biotechnology"
+  },
+  {
+    "pmid": "16707663",
+    "year": "2006",
+    "authors": "Müller, M., Weigand, J., Weichenrieder, O. & Suess, B",
+    "title": "Thermodynamic characterization of an engineered tetracyline-binding riboswitch",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "17567606",
+    "year": "2007",
+    "authors": "Weigand, J. E. & Suess, B",
+    "title": "Tetracycline aptamer-controlled regulation of pre-mRNA splicing in yeast",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "18940672",
+    "year": "2008",
+    "authors": "Xiao, H., Edwards, T. E. & Ferré-D'Amaré, A. R.",
+    "title": "Structural basis for specific, high-affinity tetracycline binding by an in vitro evolved aptamer and artificial riboswitch",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "19592423",
+    "year": "2009",
+    "authors": "Xiao, H., Edwards, T. E. & Ferré-D'Amaré, A. R.",
+    "title": "A fast and efficient translational control system for conditional expression of yeast genes",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "21603688",
+    "year": "2011",
+    "authors": "Wittmann, A. & Suess, B",
+    "title": "Selection of tetracycline inducible self-cleaving ribozymes as synthetic devices for gene regulation in yeast",
+    "journal": "Molecular bioSystems"
+  },
+  {
+    "pmid": "24678266",
+    "year": "2014",
+    "authors": "Demolli, S., Geist, M. M., Weigand, J. E., Matschiavelli, N., Suess, B.",
+    "title": "Development of β -lactamase as a tool for monitoring conditional gene expression by a tetracycline-riboswitch in Methanosarcina acetivorans",
+    "journal": "Archaea (Vancouver"
+  },
+  {
+    "pmid": "25517161",
+    "year": "2014",
+    "authors": "Reuss, A. J., Vogel, M., Weigand, J. E., Suess, B. & Wachtveitl, J",
+    "title": "Tetracycline determines the conformation of its aptamer at physiological magnesium concentrations",
+    "journal": "Biophysical journal"
+  },
+  {
+    "pmid": "25265236",
+    "year": "2015",
+    "authors": "Beilstein, K., Wittmann, A., Grez, M., & Suess, B",
+    "title": "Conditional control of mammalian gene expression by tetracycline-dependent hammerhead ribozymes",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "27595406",
+    "year": "2016",
+    "authors": "Liu, Y., Zhan, Y., Chen, Z., He, A., Li, J., Wu, H., Liu, L., Zhuang, C.",
+    "title": "Directing cellular information flow via CRISPR signal conductors",
+    "journal": "Nature methods"
+  },
+  {
+    "pmid": "27994029",
+    "year": "2017",
+    "authors": "Domin, G., Findeiß, S., Wachsmuth, M., Will, S., Stadler, P. F., & Mörl, M",
+    "title": "Applicability of a computational design approach for synthetic riboswitches",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "29420816",
+    "year": "2018",
+    "authors": "Vogel, M., Weigand, J. E., Kluge, B., Grez, M., & Suess, B",
+    "title": "A small, portable RNA device for the control of exon skipping in mammalian cells",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "30337459",
+    "year": "2019",
+    "authors": "Hetzke, T., Vogel, M., Gophane, D. B., Weigand, J. E., Suess, B.",
+    "title": "Influence of Mg2+ on the conformational flexibility of a tetracycline aptamer",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "30513199",
+    "year": "2019",
+    "authors": "Groher, A. C., Jager, S., Schneider, C., Groher, F., Hamacher, K., & Suess, B",
+    "title": "Tuning the Performance of Synthetic Riboswitches using Machine Learning",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "32024835",
+    "year": "2020",
+    "authors": "Strobel, B., Spöring, M., Klein, H., Blazevic, D., Rust, W., Sayols, S.",
+    "title": "High-throughput identification of synthetic riboswitches by barcode-free amplicon-sequencing in human cells",
+    "journal": "Nature communications"
+  },
+  {
+    "pmid": "37459466",
+    "year": "2023",
+    "authors": "Kelvin, D. & Suess, B",
+    "title": "Tapping the potential of synthetic riboswitches: reviewing the versatility of the tetracycline aptamer",
+    "journal": "RNA biology"
+  },
+  {
+    "pmid": "38168982",
+    "year": "2024",
+    "authors": "Luo, L., Jea, J. D., Wang, Y., Chao, P. W., & Yen, L",
+    "title": "Control of mammalian gene expression by modulation of polyA signal cleavage at 5' UTR",
+    "journal": "Nature biotechnology"
+  },
+  {
+    "pmid": "7510417",
+    "year": "1994",
+    "authors": "Jenison, R. D., Gill, S. C., Pardi, A., & Polisky, B.",
+    "title": "High-resolution molecular discrimination by RNA",
+    "journal": "Science"
+  },
+  {
+    "pmid": "9224568",
+    "year": "1997",
+    "authors": "Tang, J., & Breaker, R. R.",
+    "title": "Rational design of allosteric ribozymes",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "9253414",
+    "year": "1997",
+    "authors": "Zimmermann, G. R., Jenison, R. D., Wick, C. L., Simorre, J. P., & Pardi, A.",
+    "title": "Interlocking structural motifs mediate molecular discrimination by a theophylline-binding RNA",
+    "journal": "Nature structural biology"
+  },
+  {
+    "pmid": "9636066",
+    "year": "1998",
+    "authors": "Zimmermann, G. R., Shields, T. P., Jenison, R. D., Wick, C. L., & Pardi, A.",
+    "title": "A semiconserved residue inhibits complex formation by stabilizing interactions in the free state of a theophylline-binding RNA",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "10097080",
+    "year": "1999",
+    "authors": "Soukup, G. A., & Breaker, R. R.",
+    "title": "Engineering precision RNA molecular switches",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "10425680",
+    "year": "1999",
+    "authors": "Soukup, G. A., & Breaker, R. R.",
+    "title": "Design of allosteric hammerhead ribozymes activated by ligand-induced structure stabilization",
+    "journal": "Structure"
+  },
+  {
+    "pmid": "10836787",
+    "year": "2000",
+    "authors": "Zimmermann, G. R., Wick, C. L., Shields, T. P., Jenison, R. D., & Pardi, A.",
+    "title": "Molecular interactions and metal binding in the theophylline-binding core of an RNA aptamer",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "11266567",
+    "year": "2001",
+    "authors": "Jose, A. M., Soukup, G. A., & Breaker, R. R.",
+    "title": "Cooperative binding of effectors by an allosteric ribozyme",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "15109659",
+    "year": "2004",
+    "authors": "Endo, M., Mitsui, T., Okuni, T., Kimoto, M., Hirao, I., & Yokoyama, S.",
+    "title": "Unnatural base pairs mediate the site-specific incorporation of an unnatural hydrophobic component into RNA transcripts.",
+    "journal": "Bioorganic & medicinal chemistry letters"
+  },
+  {
+    "pmid": "15004248",
+    "year": "2004",
+    "authors": "Suess, B., Fink, B., Berens, C., Stentz, R., & Hillen, W.",
+    "title": "A theophylline responsive riboswitch based on helix slipping controls gene expression in vivo.",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "15826145",
+    "year": "2005",
+    "authors": "Anderson, P. C., & Mecozzi, S.",
+    "title": "Unusually short RNA sequences: design of a 13-mer RNA that selectively binds and recognizes theophylline",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "16996258",
+    "year": "2007",
+    "authors": "Hall, B., Hesselberth, J. R., & Ellington, A. D.",
+    "title": "Computational selection of nucleic acid biosensors via a slip structure model",
+    "journal": "Biosensors & bioelectronics"
+  },
+  {
+    "pmid": "17317571",
+    "year": "2007",
+    "authors": "Lynch, S. A., Desai, S. K., Sajja, H. K., & Gallivan, J. P.",
+    "title": "A high-throughput screen for synthetic riboswitches reveals mechanistic insights into their function",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "19033367",
+    "year": "2009",
+    "authors": "Lynch, S. A., & Gallivan, J. P.",
+    "title": "A flow cytometry-based screen for synthetic riboswitches",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "20041206",
+    "year": "2009",
+    "authors": "Chen, X., & Ellington, A. D.",
+    "title": "Design principles for ligand-sensing, conformation-switching ribozymes",
+    "journal": "PLoS computational biology"
+  },
+  {
+    "pmid": "22733807",
+    "year": "2012",
+    "authors": "Kobori, S., Ichihashi, N., Kazuta, Y., Matsuura, T., & Yomo, T.",
+    "title": "Kinetic analysis of aptazyme-regulated gene expression in a cell-free translation system: modeling of ligand-dependent and -independent expression",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "23452219",
+    "year": "2013",
+    "authors": "Penchovsky R.",
+    "title": "Computational design and biosensor applications of small molecule-sensing allosteric ribozymes",
+    "journal": "Biomacromolecules"
+  },
+  {
+    "pmid": "23969558",
+    "year": "2013",
+    "authors": "Nakahira, Y., Ogawa, A., Asano, H., Oyama, T., & Tozawa, Y.",
+    "title": "Theophylline-dependent riboswitch as a novel genetic tool for strict regulation of protein expression in Cyanobacterium Synechococcus elongatus PCC 7942",
+    "journal": "Plant & cell physiology"
+  },
+  {
+    "pmid": "23654267",
+    "year": "2013",
+    "authors": "Ceres, P., Garst, A. D., Marcano-Velázquez, J. G., & Batey, R. T.",
+    "title": "Modularity of select riboswitch expression platforms enables facile engineering of novel genetic regulatory devices",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "25726466",
+    "year": "2015",
+    "authors": "Badelt, S., Hammer, S., Flamm, C., & Hofacker, I. L.",
+    "title": "Thermodynamic and kinetic folding of riboswitches",
+    "journal": "Methods in enzymology"
+  },
+  {
+    "pmid": "26594238",
+    "year": "2015",
+    "authors": "Wei, K. Y., & Smolke, C. D",
+    "title": "Engineering dynamic cell cycle control with synthetic small molecule-responsive RNA devices",
+    "journal": "Journal of biological engineering"
+  },
+  {
+    "pmid": "26642994",
+    "year": "2015",
+    "authors": "Zhou, Q., Xia, X., Luo, Z., Liang, H., & Shakhnovich, E.",
+    "title": "Searching the Sequence Space for Potent Aptamers Using SELEX in Silico",
+    "journal": "Journal of chemical theory and computation"
+  },
+  {
+    "pmid": "29319503",
+    "year": "2018",
+    "authors": "Liu, Y., Li, J., Chen, Z., Huang, W., & Cai, Z.",
+    "title": "ynthesizing artificial devices that redirect cellular information at will",
+    "journal": "eLife"
+  },
+  {
+    "pmid": "30119599",
+    "year": "2018",
+    "authors": "Page, K., Shaffer, J., Lin, S., Zhang, M., & Liu, J. M.",
+    "title": "Engineering Riboswitches in Vivo Using Dual Genetic Selection and Fluorescence-Activated Cell Sorting",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "30773480",
+    "year": "2019",
+    "authors": "You, M., Litke, J. L., Wu, R., & Jaffrey, S. R.",
+    "title": "Detection of Low-Abundance Metabolites in Live Cells Using an RNA Integrator",
+    "journal": "Cell chemical biology"
+  },
+  {
+    "pmid": "31490060",
+    "year": "2019",
+    "authors": "Tamiev, D., Lantz, A., Vezeau, G., Salis, H., & Reuel, N. F.",
+    "title": "Controlling Heterogeneity and Increasing Titer from Riboswitch-Regulated Bacillus subtilis Spores for Time-Delayed Protein Expression Applications",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "32142605",
+    "year": "2020",
+    "authors": "Wrist, A., Sun, W., & Summers, R. M.",
+    "title": "The Theophylline Aptamer: 25 Years as an Important Tool in Cellular Engineering Research.",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "9383430",
+    "year": "1995",
+    "authors": "Wang, Y., & Rando, R. R.",
+    "title": "Specific binding of aminoglycoside antibiotics to RNA",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "9070426",
+    "year": "1997",
+    "authors": "Jiang, L., Suri, A. K., Fiala, R., & Patel, D. J.",
+    "title": "Accharide-RNA recognition in an aminoglycoside antibiotic-RNA aptamer complex.",
+    "journal": "SChemistry & biology"
+  },
+  {
+    "pmid": "9731769",
+    "year": "1998",
+    "authors": "Jiang, L., & Patel, D. J.",
+    "title": "Solution structure of the tobramycin-RNA aptamer complex",
+    "journal": "Nature structural biology"
+  },
+  {
+    "pmid": "14769995",
+    "year": "2004",
+    "authors": "Hartmuth, K., Vornlocher, H. P., & Lührmann, R.",
+    "title": "Tobramycin affinity tag purification of spliceosomes",
+    "journal": "Methods in molecular biology"
+  },
+  {
+    "pmid": "16217837",
+    "year": "2005",
+    "authors": "Keller, K. M., Breeden, M. M., Zhang, J., Ellington, A. D., & Brodbelt, J. S.",
+    "title": "Electrospray ionization of nucleic acid aptamer/small molecule complexes for screening aptamer selectivity.",
+    "journal": "Journal of mass spectrometry : JMS"
+  },
+  {
+    "pmid": "25337781",
+    "year": "2014",
+    "authors": "Liu, J., Wagan, S., Dávila Morris, M., Taylor, J., & White, R. J.",
+    "title": "Achieving reproducible performance of electrochemical, folding aptamer-based sensors on microelectrodes: challenges and prospects",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "25835184",
+    "year": "2015",
+    "authors": "Schoukroun-Barnes, L. R., & White, R. J.",
+    "title": "Rationally designing aptamer sequences with reduced affinity for controlled sensor performance",
+    "journal": "Sensors"
+  },
+  {
+    "pmid": "29594665",
+    "year": "2017",
+    "authors": "Han, X., Zhang, Y., Nie, J., Zhao, S., Tian, Y., & Zhou, N.",
+    "title": "Gold nanoparticle based photometric determination of tobramycin by using new specific DNA aptamers",
+    "journal": "Mikrochimica acta"
+  },
+  {
+    "pmid": "30356136",
+    "year": "2018",
+    "authors": "Auwardt, S. L., Seo, Y. J., Ilgu, M., Ray, J., Feldges, R. R., Shubham, S.",
+    "title": "Aptamer-enabled uptake of small molecule ligands",
+    "journal": "Scientific reports"
+  },
+  {
+    "pmid": "30268963",
+    "year": "2018",
+    "authors": "Nie, J., Yuan, L., Jin, K., Han, X., Tian, Y., & Zhou, N.",
+    "title": "Electrochemical detection of tobramycin based on enzymes-assisted dual signal amplification by using a novel truncated aptamer with high affinity",
+    "journal": "Biosensors & bioelectronics"
+  },
+  {
+    "pmid": "31625087",
+    "year": "2020",
+    "authors": "Zhou, N., Cai, R., & Han, X.  S.",
+    "title": "Creening, Post-SELEX Optimization and Application of DNA Aptamers Specific for Tobramycin",
+    "journal": "Methods in molecular biology"
+  },
+  {
+    "pmid": "35217273",
+    "year": "2022",
+    "authors": "Wang, J., Li, H., Du, C., Li, Y., Ma, X., Yang, C., Xu, W., & Sun, C.",
+    "title": "Structure-switching aptamer triggering signal amplification strategy for tobramycin detection based on hybridization chain reaction and fluorescence synergism.",
+    "journal": "Talanta"
+  },
+  {
+    "pmid": "37791877",
+    "year": "2023",
+    "authors": "Kraus, L., Duchardt-Ferner, E., Bräuchle, E., Fürbacher, S., Kelvin, D., Marx, H.",
+    "title": "Development of a novel tobramycin dependent riboswitch",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "8504070",
+    "year": "1993",
+    "authors": "Connell, G. J., Illangesekare, M., & Yarus, M.",
+    "title": "Three small ribooligonucleotides with specific arginine sites",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "12124337",
+    "year": "2002",
+    "authors": "Lupold, S. E., Hicke, B. J., Lin, Y., & Coffey, D. S.",
+    "title": "Identification and characterization of nuclease-stabilized RNA molecules that bind human prostate cancer cells via the prostate-specific membrane antigen",
+    "journal": "Cancer research"
+  },
+  {
+    "pmid": "16740739",
+    "year": "2006",
+    "authors": "Chu, T. C., Twu, K. Y., Ellington, A. D., & Levy, M.",
+    "title": "Aptamer mediated siRNA delivery",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "20550178",
+    "year": "2010",
+    "authors": "Kim, D., Jeong, Y. Y., & Jon, S.",
+    "title": "A drug-loaded aptamer-gold nanoparticle bioconjugate for combined CT imaging and therapy of prostate cancer",
+    "journal": "ACS nano"
+  },
+  {
+    "pmid": "22004414",
+    "year": "2011",
+    "authors": "Rockey, W. M., Hernandez, F. J., Huang, S. Y., Cao, S., Howell, C. A., Thomas, G. S.",
+    "title": "Rational truncation of an RNA aptamer to prostate-specific membrane antigen using computational structural modeling",
+    "journal": "Nucleic acid therapeutics"
+  },
+  {
+    "pmid": "25450401",
+    "year": "2014",
+    "authors": "Baek, S. E., Lee, K. H., Park, Y. S., Oh, D. K., Oh, S., Kim, K. S., & Kim, D. E.",
+    "title": "RNA aptamer-conjugated liposome as an efficient anticancer drug delivery vehicle targeting cancer cells in vivo",
+    "journal": "Journal of controlled release : official journal of the Controlled Release Society"
+  },
+  {
+    "pmid": "32525981",
+    "year": "2020",
+    "authors": "Ptacek, J., Zhang, D., Qiu, L., Kruspe, S., Motlova, L., Kolenko, P., Novakova, Z.",
+    "title": "Structural basis of prostate-specific membrane antigen recognition by the A9g RNA aptamer",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "8532517",
+    "year": "1995",
+    "authors": "P Burgstaller, M Kochoyan, M Famulok",
+    "title": "Structural probing and damage selection of citrulline- and arginine-specific RNA aptamers identify base positions required for binding",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "8650546",
+    "year": "1996",
+    "authors": "Y Yang, M Kochoyan, P Burgstaller, E Westhof, M Famulok",
+    "title": "Structural basis of ligand discrimination by two related RNA aptamers resolved by NMR spectroscopy",
+    "journal": "Science"
+  },
+  {
+    "pmid": "15801729",
+    "year": "2005",
+    "authors": "Agnès Brumbt, Corinne Ravelet, Catherine Grosset, Anne Ravel, Annick Villet, Eric Peyrin",
+    "title": "Chiral stationary phase based on a biostable L-RNA aptamer",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "7508262",
+    "year": "1994",
+    "authors": "Lorsch JR, Szostak JW",
+    "title": "In vitro selection of RNA aptamers specific for cyanocobalamin",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "10089440",
+    "year": "1999",
+    "authors": "Sussman D, Greensides D, Reilly K, Wilson C",
+    "title": "Preliminary characterization of crystals of an in vitro evolved cyanocobalamin (vitamin B12) binding RNA",
+    "journal": "Acta crystallographica"
+  },
+  {
+    "pmid": "10625428",
+    "year": "2000",
+    "authors": "Sussman D, Nix JC, Wilson C",
+    "title": "The structural basis for molecular recognition by the vitamin B 12 RNA aptamer",
+    "journal": "Nature structural biology"
+  },
+  {
+    "pmid": "10903943",
+    "year": "2000",
+    "authors": "Sussman D, Wilson C",
+    "title": "A water channel in the core of the vitamin B(12) RNA aptamer",
+    "journal": "Structure"
+  },
+  {
+    "pmid": "18672888",
+    "year": "2008",
+    "authors": "Gopinath SC, Awazu K, Fujimaki M, Sugimoto K, Ohki Y, Komatsubara T",
+    "title": "Influence of nanometric holes on the sensitivity of a waveguide-mode sensor: label-free nanosensor for the analysis of RNA aptamer-ligand interactions",
+    "journal": "Analytical chemistry"
+  },
+  {
+    "pmid": "22658959",
+    "year": "2012",
+    "authors": "Selvakumar LS, Thakur MS",
+    "title": "Nano RNA aptamer wire for analysis of vitamin B₁₂",
+    "journal": "Analytical biochemistry"
+  },
+  {
+    "pmid": "29863725",
+    "year": "2018",
+    "authors": "Gunaratne, R., Kumar, S., Frederiksen, J. W., Stayrook, S., Lohrmann, J. L., Perry, K.",
+    "title": "Combination of aptamer and drug for reversible anticoagulation in cardiopulmonary bypass",
+    "journal": "Nature biotechnology"
+  },
+  {
+    "pmid": "35021888",
+    "year": "2022",
+    "authors": "Chabata, C. V., Frederiksen, J. W., Olson, L. B., Naqvi, I. A., Hall, S. E., Gunaratne, R.",
+    "title": "Combining Heparin and a FX/Xa Aptamer to Reduce Thrombin Generation in Cardiopulmonary Bypass and COVID-19",
+    "journal": "Nucleic acid therapeutics"
+  },
+  {
+    "pmid": "8642604",
+    "year": "1996",
+    "authors": "Fan P, Suri AK, Fiala R, Live D, Patel DJ.",
+    "title": "Molecular recognition in the FMN-RNA aptamer complex",
+    "journal": "J Mol Biol"
+  },
+  {
+    "pmid": "10397790",
+    "year": "1999",
+    "authors": "Schneider C, Sühnel J.",
+    "title": "A molecular dynamics simulation of the flavin mononucleotide-RNA aptamer complex",
+    "journal": "Biopolymers"
+  },
+  {
+    "pmid": "12903340",
+    "year": "2000",
+    "authors": "Jiang, F., Patel, D. J., Zhang, X., Zhao, H., & Jones, R. A",
+    "title": "Specific labeling approaches to guanine and adenine imino and amino proton assignments in the AMP-RNA aptamer complex.",
+    "journal": "Journal of biomolecular NMR"
+  },
+  {
+    "pmid": "11377174",
+    "year": "2001",
+    "authors": "Araki M, Okuno Y, Sugiura Y.",
+    "title": "Expression mechanism of the allosteric interactions in a ribozyme catalysis",
+    "journal": "Nucleic Acids Symp Ser"
+  },
+  {
+    "pmid": "14588007",
+    "year": "2003",
+    "authors": "Clark SL, Remcho VT.",
+    "title": "Electrochromatographic retention studies on a flavin-binding RNA aptamer sorbent",
+    "journal": "Anal Chem"
+  },
+  {
+    "pmid": "16377778",
+    "year": "2005",
+    "authors": "Anderson PC, Mecozzi S",
+    "title": "Identification of a 14mer RNA that recognizes and binds flavin mononucleotide with high affinity",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "16199761",
+    "year": "2005",
+    "authors": "Najafi-Shoushtari SH, Famulok M",
+    "title": "Competitive regulation of modular allosteric aptazymes by a small molecule and oligonucleotide effector",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "25173759",
+    "year": "2014",
+    "authors": "Sengupta A, Gavvala K, Koninti RK, Hazra P.",
+    "title": "Role of Mg²⁺ ions in flavin recognition by RNA aptamer",
+    "journal": "J Photochem Photobiol B"
+  },
+  {
+    "pmid": "15099096",
+    "year": "2004",
+    "authors": "James M. Carothers, Stephanie C. Oestreich‡, Jonathan H. Davis, and Jack W. Szostak.",
+    "title": "Informational Complexity and Functional Activity of RNA Structures",
+    "journal": "JACS"
+  },
+  {
+    "pmid": "16510427",
+    "year": "2006",
+    "authors": "Carothers, J. M., Davis, J. H., Chou, J. J., & Szostak, J. W.",
+    "title": "Solution structure of an informationally complex high-affinity RNA aptamer to GTP",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "23601641",
+    "year": "2013",
+    "authors": "Curtis, E. A., & Liu, D. R.",
+    "title": "Discovery of widespread GTP-binding motifs in genomic DNA and RNA",
+    "journal": "Chemistry & biology"
+  },
+  {
+    "pmid": "24824832",
+    "year": "2014",
+    "authors": "Curtis, Edward A., and David R. Liu",
+    "title": "A naturally occurring, noncanonical GTP aptamer made of simple tandem repeats.",
+    "journal": "RNA biology"
+  },
+  {
+    "pmid": "27659052",
+    "year": "2016",
+    "authors": "Nasiri, A. H., Wurm, J. P., Immer, C., Weickhmann, A. K., & Wöhnert, J.",
+    "title": "An intermolecular G-quadruplex as the basis for GTP recognition in the class V–GTP aptamer",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "27885761",
+    "year": "2017",
+    "authors": "Wolter, A. C., Weickhmann, A. K., Nasiri, A. H., Hantke, K., Ohlenschläger, O.",
+    "title": "A stably protonated adenine nucleotide with a highly shifted pKa value stabilizes the tertiary structure of a GTP‐binding RNA aptamer",
+    "journal": "Angewandte Chemie International Edition"
+  },
+  {
+    "pmid": "31030336",
+    "year": "2019",
+    "authors": "Wolter, A. C., Pianu, A., Kremser, J., Strebitzer, E., Schnieders, R., Fürtig, B.& Wöhnert, J.",
+    "title": "NMR resonance assignments for the GTP-binding RNA aptamer 9-12 in complex with GTP",
+    "journal": "Biomolecular NMR Assignments"
+  },
+  {
+    "pmid": "38074198",
+    "year": "2023",
+    "authors": "Wachowius, F., Porebski, B. T., Johnson, C. M., & Holliger, P.",
+    "title": "Emergence of ATP‐and GTP‐Binding Aptamers from Single RNA Sequences by Error‐Prone Replication and Selection",
+    "journal": "ChemSystemsChem"
+  },
+  {
+    "pmid": "10212256",
+    "year": "1999",
+    "authors": "Boiziau, C., Dausse, E., Yurchenko, L., & Toulmé, J. J.",
+    "title": "DNA aptamers selected against the HIV-1 trans-activation-responsive RNA element form RNA-DNA kissing complexes",
+    "journal": "J Biol Chem"
+  },
+  {
+    "pmid": "10606271",
+    "year": "1999",
+    "authors": "Ducongé, F., & Toulmé, J. J.",
+    "title": "In vitro selection identifies key determinants for loop-loop interactions: RNA aptamers selective for the TAR RNA element of HIV-1",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "10954609",
+    "year": "2000",
+    "authors": "Collin, D., van, Heijenoort, C., Boiziau, C., Toulmé, J. J., & Guittet, E.",
+    "title": "NMR characterization of a kissing complex formed between the TAR RNA element of HIV-1 and a DNA aptamer",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "12052182",
+    "year": "2002",
+    "authors": "Darfeuille, F., Sekkai, D., Dausse, E., Kolb, G., Yurchenko, L., Boiziau, C., & Toulmé, J. J.",
+    "title": "Driving in vitro selection of anti-HIV-1 TAR aptamers by magnesium concentration and temperature",
+    "journal": "Comb Chem High Throughput Screen"
+  },
+  {
+    "pmid": "12853646",
+    "year": "2003",
+    "authors": "Beaurain, F, .Di, Primo, C., Toulmé, J. J., & Laguerre, M.",
+    "title": "Molecular dynamics reveals the stabilizing role of loop closing residues in kissing interactions: comparison between TAR-TAR* and TAR-aptamer",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "15181175",
+    "year": "2004",
+    "authors": "Darfeuille, F., Hansen, JB., Orum, H., Di, Primo, C., & Toulmé, J. J.",
+    "title": "LNA/DNA chimeric oligomers mimic RNA aptamers targeted to the TAR RNA element of HIV-1",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "15723535",
+    "year": "2005",
+    "authors": "Kolb,G., Reigadas, S., Boiziau, C., van Aerschot, A., Arzumanov, A., Gait, MJ.",
+    "title": "Hexitol nucleic acid-containing aptamers are efficient ligands of HIV-1 TAR RNA",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "16445294",
+    "year": "2006",
+    "authors": "Boucard, D., Toulmé, J. J, Di., & Primo, C.",
+    "title": "Bimodal loop-loop interactions increase the affinity of RNA aptamers for HIV-1 RNA structures",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "17312962",
+    "year": "2006",
+    "authors": "Bugaut, A., Toulmé , J. J., & Rayner, B.",
+    "title": "SELEX and dynamic combinatorial chemistry interplay for the selection of conjugated RNA aptamers",
+    "journal": "Org Biomol Chem"
+  },
+  {
+    "pmid": "17768146",
+    "year": "2007",
+    "authors": "Lebars, I., Richard, T., Di Primo, C., & Toulmé, J. J.",
+    "title": "NMR structure of a kissing complex formed between the TAR RNA element of HIV-1 and a LNA-modified aptamer",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "18996893",
+    "year": "2008",
+    "authors": "Lebars, I., Legrand, P., Aimé, A., Pinaud, N., Fribourg, S., & Di Primo, C.",
+    "title": "Exploring TAR–RNA aptamer loop–loop interaction by X-ray crystallography, UV spectroscopy and surface plasmon resonance",
+    "journal": "Nucleic Acids Res"
+  },
+  {
+    "pmid": "19496624",
+    "year": "2009",
+    "authors": "Watrin, M., Von Pelchrzim, F., Dausse, E., Schroeder, R., & Toulmé, J. J.",
+    "title": "In vitro selection of RNA aptamers derived from a genomic human library against the TAR RNA element of HIV-1",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "31548726",
+    "year": "2019",
+    "authors": "Chen, X., Zhang, D., Su, N., Bao, B., Xie, X.",
+    "title": "Visualizing RNA dynamics in live cells with bright and stable fluorescent RNAs",
+    "journal": "Nature Biotechnology"
+  },
+  {
+    "pmid": "34725509",
+    "year": "2021",
+    "authors": "Huang, K., Chen, X., Li, C., Song, Q., Li, H., Zhu, L., Yang, Y., Ren, A.",
+    "title": "Structure-based investigation of fluorogenic Pepper aptamer",
+    "journal": "Nature Chemical Biology"
+  },
+  {
+    "pmid": "35759696",
+    "year": "2022",
+    "authors": "Rees, H. C., Gogacz, W., Li, N.-S., Koirala, D., Piccirilli, J. A.",
+    "title": "Structural basis for fluorescence activation by Pepper RNA",
+    "journal": "ACS chemical biology"
+  },
+  {
+    "pmid": "35580055",
+    "year": "2022",
+    "authors": "Wang, Q., Xiao, F., Su, H., Liu, H., Xu, J.",
+    "title": "Inert Pepper aptamer-mediated endogenous mRNA recognition and imaging in living cells",
+    "journal": "Nucleic Acids Research"
+  },
+  {
+    "pmid": "35921263",
+    "year": "2022",
+    "authors": "Dionisi, S., Piera, K., Baumschlager, A., Khammash, M.",
+    "title": "Implementation of a novel optogenetic tool in mammalian cells based on a split t7 RNA polymerase",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "37192858",
+    "year": "2022",
+    "authors": "Yang, L.-Z., Gao, B.-Q., Huang, Y., Wang, Y., Yang, L., Chen, L.-L.",
+    "title": "Multi-color RNA imaging with CRISPR-Cas13b systems in living cells",
+    "journal": "Cell Insight"
+  },
+  {
+    "pmid": "36999628",
+    "year": "2023",
+    "authors": "Sampedro Vallina, N., McRae, E. K. S., Hansen, B. K., Boussebayle, A., Andersen, E. S.",
+    "title": "RNA origami scaffolds facilitate cryo-EM characterization of a Broccoli-Pepper aptamer FRET pair",
+    "journal": "Nucleic Acids Research"
+  },
+  {
+    "pmid": "37236014",
+    "year": "2023",
+    "authors": "Fang, M., Li, H., Xie, X., Wang, H., Jiang, Y.",
+    "title": "Imaging intracellular metabolite and protein changes in live mammalian cells with bright fluorescent RNA-based genetically encoded sensors",
+    "journal": "Biosensors & Bioelectronics"
+  },
+  {
+    "pmid": "37486780",
+    "year": "2023",
+    "authors": "Chen, Z., Chen, W., Reheman, Z., Jiang, H., Wu, J., Li, X.",
+    "title": "Genetically encoded RNA-based sensors with Pepper fluorogenic aptamer",
+    "journal": "Nucleic Acids Research"
+  },
+  {
+    "pmid": "38098702",
+    "year": "2023",
+    "authors": "Yin, P., Ge, M., Xie, S., Zhang, L., Kuang, S., Nie, Z.",
+    "title": "A universal orthogonal imaging platform for living-cell RNA detection using fluorogenic RNA aptamers",
+    "journal": "Chemical Science"
+  },
+  {
+    "pmid": "38105499",
+    "year": "2024",
+    "authors": "Ying, X., Huang, C., Li, T., Li, T., Gao, M., Wang, F., Cao, J., Liu, J.",
+    "title": "An RNA Methylation-Sensitive AIEgen-Aptamer reporting system for quantitatively evaluating m6A methylase and demethylase activities",
+    "journal": "ACS chemical biology"
+  },
+  {
+    "pmid": "38295291",
+    "year": "2024",
+    "authors": "Tang, A. A., Afasizheva, A., Cano, C. T., Plath, K., Black, D., Franco, E.",
+    "title": "Optimization of RNA Pepper sensors for the detection of arbitrary RNA targets",
+    "journal": "ACS synthetic biology"
+  },
+  {
+    "pmid": "20445260",
+    "year": "2010",
+    "authors": "Baba, S., Someya, T., Kawai, G., Nakamura, K., & Kumasaka, T.",
+    "title": "Expression, crystallization and preliminary crystallographic analysis of RNA-binding protein Hfq (YmaH) from Bacillus subtilis in complex with an RNA aptamer",
+    "journal": "Acta crystallographica. Section F"
+  },
+  {
+    "pmid": "22053080",
+    "year": "2012",
+    "authors": "Someya, T., Baba, S., Fujimoto, M., Kawai, G., Kumasaka, T., & Nakamura, K.",
+    "title": "Crystal structure of Hfq from Bacillus subtilis in complex with SELEX-derived RNA aptamer: insight into RNA-binding properties of bacterial Hfq",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "22965117",
+    "year": "2012",
+    "authors": "Horstmann, N., Orans, J., Valentin-Hansen, P., Shelburne, S. A., 3rd, & Brennan, R. G.",
+    "title": "Structural mechanism of Staphylococcus aureus Hfq binding to an RNA A-tract",
+    "journal": "Structural mechanism of Staphylococcus aureus Hfq binding to an RNA A-tract. Nucleic acids research"
+  },
+  {
+    "pmid": "24828406",
+    "year": "2014",
+    "authors": "Weichenrieder O.",
+    "title": "RNA binding by Hfq and ring-forming (L)Sm proteins: a trade-off between optimal sequence readout and RNA backbone conformation",
+    "journal": "RNA biology"
+  },
+  {
+    "pmid": "37942477",
+    "year": "2023",
+    "authors": "Watkins, D., & Arya, D.",
+    "title": "Models of Hfq interactions with small non-coding RNA in Gram-negative and Gram-positive bacteria",
+    "journal": "Frontiers in cellular and infection microbiology"
+  },
+  {
+    "pmid": "30916478",
+    "year": "2019",
+    "authors": "Iida, M., Mashima, T., Yamaoki, Y., So, M., Nagata, T., & Katahira, M.",
+    "title": "The anti-prion RNA aptamer R12 disrupts the Alzheimer's disease-related complex between prion and amyloid β",
+    "journal": "FEBS Journal"
+  },
+  {
+    "pmid": "22021209",
+    "year": "2011",
+    "authors": "Steber, M., Arora, A., Hofmann, J., Brutschy, B., & Suess, B.",
+    "title": "Mechanistic basis for RNA aptamer-based induction of TetR",
+    "journal": "Chembiochem : a European journal of chemical biology"
+  },
+  {
+    "pmid": "29036355",
+    "year": "2017",
+    "authors": "Atanasov, J., Groher, F., Weigand, J. E., & Suess, B.",
+    "title": "Design and implementation of a synthetic pre-miR switch for controlling miRNA biogenesis in mammals",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "32052019",
+    "year": "2020",
+    "authors": "Grau, F. C., Jaeger, J., Groher, F., Suess, B., & Muller, Y. A.",
+    "title": "The complex formed between a synthetic RNA aptamer and the transcription repressor TetR is a structural and functional twin of the operator DNA-TetR regulator complex",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "22727813",
+    "year": "2012",
+    "authors": "Tesmer, V. M., Lennarz, S., Mayer, G., & Tesmer, J. J.",
+    "title": "Molecular mechanism for inhibition of g protein-coupled receptor kinase 2 by a selective RNA aptamer",
+    "journal": "Structure"
+  },
+  {
+    "pmid": "26552823",
+    "year": "2016",
+    "authors": "Tesmer J. J.",
+    "title": "Crystallographic Pursuit of a Protein-RNA Aptamer Complex",
+    "journal": "Methods in molecular biology"
+  },
+  {
+    "pmid": "16027048",
+    "year": "2005",
+    "authors": "Tombelli, S., Minunni, M., Luzi, E., & Mascini, M.",
+    "title": "Aptamer-based biosensors for the detection of HIV-1 Tat protein",
+    "journal": "Bioelectrochemistry (Amsterdam"
+  },
+  {
+    "pmid": "22975093",
+    "year": "2013",
+    "authors": "Rahim Ruslinda, A., Tanabe, K., Ibori, S., Wang, X., & Kawarada, H.",
+    "title": "Effects of diamond-FET-based RNA aptamer sensing for detection of real sample of HIV-1 Tat protein",
+    "journal": "Biosensors & bioelectronics"
+  },
+  {
+    "pmid": "18441054",
+    "year": "2008",
+    "authors": "Miyakawa, S., Nomura, Y., Sakamoto, T., Yamaguchi, Y., Kato, K., Yamazaki, S., & Nakamura, Y.",
+    "title": "Structural and molecular basis for hyperspecificity of RNA aptamer to human immunoglobulin G",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "18931441",
+    "year": "2008",
+    "authors": "Sugiyama, S., Nomura, Y., Sakamoto, T., Kitatani, T., Kobayashi, A., Miyakawa, S.",
+    "title": "Crystallization and preliminary X-ray diffraction studies of an RNA aptamer in complex with the human IgG Fc fragment",
+    "journal": "Acta crystallographica. Section F"
+  },
+  {
+    "pmid": "20675355",
+    "year": "2010",
+    "authors": "Nomura, Y., Sugiyama, S., Sakamoto, T., Miyakawa, S., Adachi, H., Takano, K., Murakami, S.",
+    "title": "Conformational plasticity of RNA for target recognition as revealed by the 2.15 A crystal structure of a human IgG-aptamer complex",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "22924890",
+    "year": "2012",
+    "authors": "Lee, S. H., Hoshino, Y., Randall, A., Zeng, Z., Baldi, P., Doong, R. A., & Shea, K. J.",
+    "title": "Engineered synthetic polymer nanoparticles as IgG affinity ligands",
+    "journal": "Journal of the American Chemical Society"
+  },
+  {
+    "pmid": "23661463",
+    "year": "2013",
+    "authors": "Ma, J., Wang, M. G., Mao, A. H., Zeng, J. Y., Liu, Y. Q.",
+    "title": "Target replacement strategy for selection of DNA aptamers against the Fc region of mouse IgG",
+    "journal": "Genetics and molecular research : GMR"
+  },
+  {
+    "pmid": "10074372",
+    "year": "1999",
+    "authors": "Lebruska, L. L., & Maher, L. J., 3rd.",
+    "title": "Selection and characterization of an RNA decoy for transcription factor NF-kappa B",
+    "journal": "Biochemistry"
+  },
+  {
+    "pmid": "12886018",
+    "year": "2003",
+    "authors": "Huang, D. B., Vu, D., Cassiday, L. A., Zimmerman, J. M., Maher, L. J., 3rd, & Ghosh, G.",
+    "title": "Crystal structure of NF-kappaB (p50)2 complexed to a high-affinity RNA aptamer",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "12637683",
+    "year": "2003",
+    "authors": "Cassiday, L. A., & Maher, L. J., 3rd.",
+    "title": "Yeast genetic selections to optimize RNA decoys for transcription factor NF-kappa B",
+    "journal": "Proceedings of the National Academy of Sciences of the United States of America"
+  },
+  {
+    "pmid": "15263062",
+    "year": "2004",
+    "authors": "Hoshika, S., Minakawa, N., & Matsuda, A.",
+    "title": "Synthesis and physical and physiological properties of 4'-thioRNA: application to post-modification of RNA aptamer toward NF-kappaB",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "16517938",
+    "year": "2006",
+    "authors": "Chan, R., Gilbert, M., Thompson, K. M., Marsh, H. N., Epstein, D. M., & Pendergrast, P. S.",
+    "title": "Co-expression of anti-NFkappaB RNA aptamers and siRNAs leads to maximal suppression of NFkappaB activity in mammalian cells",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "18160411",
+    "year": "2008",
+    "authors": "Reiter, N. J., Maher, L. J., 3rd, & Butcher, S. E.",
+    "title": "DNA mimicry by a high-affinity anti-NF-kappaB RNA aptamer",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "18426920",
+    "year": "2008",
+    "authors": "Wurster, S. E., & Maher, L. J., 3rd.",
+    "title": "Selection and characterization of anti-NF-kappaB p65 RNA aptamers",
+    "journal": "RNA (New York"
+  },
+  {
+    "pmid": "19696077",
+    "year": "2009",
+    "authors": "Wurster, S. E., Bida, J. P., Her, Y. F., & Maher, L. J., 3rd.",
+    "title": "Characterization of anti-NF-kappaB RNA aptamer-binding specificity in vitro and in the yeast three-hybrid system",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "7518917",
+    "year": "1994",
+    "authors": "Kubik, M. F., Stephens, A. W., Schneider, D., Marlar, R. A., & Tasset, D.",
+    "title": "High-affinity RNA ligands to human alpha-thrombin",
+    "journal": "Nucleic acids research"
+  },
+  {
+    "pmid": "11735341",
+    "year": "2001",
+    "authors": "White, R., Rusconi, C., Scardino, E., Wolberg, A., Lawson, J., Hoffman, M., & Sullenger, B.",
+    "title": "Generation of species cross-reactive aptamers using \"toggle\" SELEX",
+    "journal": "Molecular therapy : the journal of the American Society of Gene Therapy"
+  },
+  {
+    "pmid": "12214238",
+    "year": "2002",
+    "authors": "Rusconi, C. P., Scardino, E., Layzer, J., Pitoc, G. A., Ortel, T. L., Monroe, D., & Sullenger, B. A.",
+    "title": "RNA aptamers as reversible antagonists of coagulation factor IXa",
+    "journal": "Nature"
+  },
+  {
+    "pmid": "15196911",
+    "year": "2004",
+    "authors": "Jeter, M. L., Ly, L. V., Fortenberry, Y. M., Whinna, H. C., White, R. R.",
+    "title": "RNA aptamer to thrombin binds anion-binding exosite-2 and alters protease inhibition by heparin-binding serpins",
+    "journal": "FEBS letters"
+  },
+  {
+    "pmid": "18971322",
+    "year": "2008",
+    "authors": "Long, S. B., Long, M. B., White, R. R., & Sullenger, B. A.",
+    "title": "Crystal structure of an RNA aptamer bound to thrombin",
+    "journal": "RNA"
+  },
+  {
+    "pmid": "27566147",
+    "year": "2016",
+    "authors": "Abeydeera, N. D., Egli, M., Cox, N., Mercier, K., Conde, J. N., Pallan, P. S.",
+    "title": "Evoking picomolar binding in RNA by a single phosphorodithioate linkage",
+    "journal": "Nucleic acids research"
+  }
+]

--- a/scripts/extract_refs.py
+++ b/scripts/extract_refs.py
@@ -1,0 +1,50 @@
+import re
+import json
+from pathlib import Path
+
+POSTS_DIR = Path('_posts')
+PUBLICATION_PAGE = Path('_pages/publications.md')
+
+post_refs = []
+
+# Extract references from posts
+for md in POSTS_DIR.glob('*.md'):
+    text = md.read_text(encoding='utf-8')
+    # pattern for reference blocks
+    pattern = re.compile(r'<a id="ref\d+"></a><font><strong>\[(\d+)\]([^<]+)</strong></font><br />\n([^<]+)<br />\n<a href="https://pubmed\.ncbi\.nlm\.nih\.gov/(\d+)/"[^>]*>([^<]+)</a>', re.S)
+    for m in pattern.finditer(text):
+        post_refs.append({
+            'pmid': m.group(4),
+            'title': m.group(2).strip(),
+            'authors': m.group(3).strip(),
+            'journal': m.group(5).strip(),
+            'source_file': str(md)
+        })
+
+(Path('postRef.json')).write_text(json.dumps(post_refs, indent=2, ensure_ascii=False), encoding='utf-8')
+
+# Extract references from publication table
+pub_refs = []
+html = PUBLICATION_PAGE.read_text(encoding='utf-8')
+row_pattern = re.compile(r'<tr>\s*<td name="td0"><a href="https://pubmed\.ncbi\.nlm\.nih\.gov/(\d+)/"[^>]*><b>(\d+)</b></a></td>\s*<td name="td1">([^<]*)</td>\s*<td name="td2">([^<]*)</td>\s*<td name="td3">([^<]*)</td>', re.S)
+for m in row_pattern.finditer(html):
+    pub_refs.append({
+        'pmid': m.group(1),
+        'year': m.group(2),
+        'authors': m.group(3).strip(),
+        'title': m.group(4).strip(),
+        'journal': m.group(5).strip()
+    })
+
+(Path('publicationRef.json')).write_text(json.dumps(pub_refs, indent=2, ensure_ascii=False), encoding='utf-8')
+
+# Combine by PMID
+combined = {}
+for r in pub_refs:
+    combined[r['pmid']] = {'pmid': r['pmid'], 'publication': r, 'posts': []}
+
+for r in post_refs:
+    entry = combined.setdefault(r['pmid'], {'pmid': r['pmid'], 'publication': None, 'posts': []})
+    entry['posts'].append(r['source_file'])
+
+(Path('combinedRef.json')).write_text(json.dumps(list(combined.values()), indent=2, ensure_ascii=False), encoding='utf-8')


### PR DESCRIPTION
## Summary
- restyle publications page with colors and table styles matching aptamer posts
- make publication tables responsive and easier to navigate
- add script `extract_refs.py` to collect references from posts and publication page
- store extracted references in `postRef.json`, `publicationRef.json`, and combined `combinedRef.json`

## Testing
- `python3 scripts/extract_refs.py`

------
https://chatgpt.com/codex/tasks/task_e_684c04eb64cc832abc30ab7f9ed14018