### PR TITLE
Fix sequences page search loading issues

### DIFF
--- a/_pages/sequences.md
+++ b/_pages/sequences.md
@@ -13,7 +13,9 @@ permalink: /sequences/
   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.min.css">
   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/2.2.3/css/buttons.dataTables.min.css">
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
+  <script>window.jQuery || document.write('<script src="{{ site.baseurl }}/js/jquery.js"><\\/script>')</script>
   <script type="text/javascript" src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.min.js"></script>
+  <script>window.jQuery && !jQuery.fn.DataTable && document.write('<script src="{{ site.baseurl }}/js/jquery.dataTables.js"><\\/script>')</script>
   <link rel="stylesheet" href="/css/dashboard.css">
   <script type="text/javascript" src="https://cdn.datatables.net/buttons/2.2.3/js/dataTables.buttons.min.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>

--- a/js/sequences.js
+++ b/js/sequences.js
@@ -423,20 +423,22 @@ class SequenceTableManager {
         }
         
         try {
-            // 初始化DataTable
-            this.table = jQuery('#sequences-datatable').DataTable({
-                dom: 'Bfrtip',
-                buttons: [
-                    'copy', 'csv', 'excel', 'pdf', 'print'
-                ],
+            const hasButtons = jQuery.fn.dataTable && jQuery.fn.dataTable.Buttons;
+            const options = {
+                dom: hasButtons ? 'Bfrtip' : 'frtip',
                 pageLength: 25,
                 lengthMenu: [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
                 scrollX: true,
                 searching: true,
                 columnDefs: [
-                    { orderable: false, targets: 0 } // 禁止第一列（复选框）排序
+                    { orderable: false, targets: 0 }
                 ]
-            });
+            };
+            if (hasButtons) {
+                options.buttons = ['copy', 'csv', 'excel', 'pdf', 'print'];
+            }
+            // 初始化DataTable
+            this.table = jQuery('#sequences-datatable').DataTable(options);
             
             // 隐藏DataTable默认搜索框，使用自定义搜索框
             jQuery('.dataTables_filter').hide();


### PR DESCRIPTION
## Summary
- ensure `sequences.md` falls back to local jQuery and DataTables
- handle missing DataTables Buttons extension in `sequences.js`

## Testing
- `python test_json.py`
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852344eec58832a9c4838407930bdcd