### PR TITLE
feat: improve dashboard highlight styling

### DIFF
--- a/js/dashboard-aptamer.js
+++ b/js/dashboard-aptamer.js
@@ -390,6 +390,9 @@ ChartModule.createTypeChart = function() {
         values: displayValues,
         type: 'pie',
         hole: 0.4,
+        pull: displayTypes.map((type, i) =>
+            isFiltered[i] ? highlightConfig.pie.selectedOffset : 0
+        ),
         marker: {
             colors: displayTypes.map((type, i) => {
                 // 如果该类型被选中，使用高亮效果（白色填充 + 原色边框）
@@ -408,7 +411,7 @@ ChartModule.createTypeChart = function() {
                 }),
                 width: displayTypes.map((type, i) => {
                     if (isFiltered[i]) {
-                        return 3;
+                        return highlightConfig.pie.borderWidth;
                     }
                     return 1;
                 })

--- a/js/dashboard-config.js
+++ b/js/dashboard-config.js
@@ -51,6 +51,19 @@ const morandiColors = [
 const morandiHighlight = '#7D807F'; // 柔和深灰，作为高亮边框
 const morandiDim = 'rgba(180,180,180,0.3)'; // 非高亮部分叠加的半透明灰
 
+// 选中状态样式配置
+const highlightConfig = {
+    bar: {
+        defaultWidth: 0.8,
+        selectedWidth: 0.72,
+        borderWidth: 3
+    },
+    pie: {
+        selectedOffset: 0.05,
+        borderWidth: 3
+    }
+};
+
 // 参考aptamer-legend.js的高亮效果：
 // 选中元素背景变为白色，并以内置的原始颜色作为内边框
 function applyHighlightStyle(elements, baseColor) {

--- a/js/dashboard-main.js
+++ b/js/dashboard-main.js
@@ -265,6 +265,11 @@ const ChartModule = {
             x: allYears,
             y: allYears.map(year => visualizationYearCounts[year] || 0), // 使用可视化数据源的计数
             type: 'bar',
+            width: allYears.map(year =>
+                hasYearFilter && activeFilters.years.has(year)
+                    ? highlightConfig.bar.selectedWidth
+                    : highlightConfig.bar.defaultWidth
+            ),
             marker: {
                 color: allYears.map((year, i) => {
                     // 如果该年份被选中，使用高亮效果（白色填充 + 原色边框）
@@ -282,7 +287,7 @@ const ChartModule = {
                 line: {
                     width: allYears.map(year => {
                         if (hasYearFilter && activeFilters.years.has(year)) {
-                            return 3;
+                            return highlightConfig.bar.borderWidth;
                         }
                         return 1;
                     }),
@@ -294,10 +299,10 @@ const ChartModule = {
                     })
                 }
             },
-            hovertemplate: '<b>Year: %{x}</b><br>' + 
+            hovertemplate: '<b>Year: %{x}</b><br>' +
                           'Count: %{y}<br>' +
                           'Click for multi-select filter<extra></extra>',
-            hoverlabel: { 
+            hoverlabel: {
                 bgcolor: 'white', 
                 bordercolor: morandiHighlight,
                 font: { size: 12, color: '#333' },
@@ -454,6 +459,9 @@ const ChartModule = {
             values: displayValues,
             type: 'pie',
             hole: 0.4,
+            pull: displayCategories.map((category, i) =>
+                isFiltered[i] ? highlightConfig.pie.selectedOffset : 0
+            ),
             marker: {
                 colors: displayCategories.map((category, i) => {
                     // 如果该类别被选中，使用高亮效果（白色填充 + 原色边框）
@@ -471,7 +479,7 @@ const ChartModule = {
                     }),
                     width: displayCategories.map((category, i) => {
                         if (isFiltered[i]) {
-                            return 3;
+                            return highlightConfig.pie.borderWidth;
                         }
                         return 1;
                     })

--- a/js/dashboard-structures.js
+++ b/js/dashboard-structures.js
@@ -356,6 +356,11 @@
             x: allMethods,
             y: allMethods.map(method => visualizationMethodCounts[method] || 0),
             type: 'bar',
+            width: allMethods.map(method =>
+                hasMethodFilter && activeFilters.years.has(method)
+                    ? highlightConfig.bar.selectedWidth
+                    : highlightConfig.bar.defaultWidth
+            ),
             marker: {
                 color: allMethods.map((method, i) => {
                     if (hasMethodFilter && activeFilters.years.has(method)) {
@@ -370,7 +375,7 @@
                 line: {
                     width: allMethods.map(method => {
                         if (hasMethodFilter && activeFilters.years.has(method)) {
-                            return 3;
+                            return highlightConfig.bar.borderWidth;
                         }
                         return 1;
                     }),
@@ -497,6 +502,9 @@
             values: displayValues,
             type: 'pie',
             hole: 0.4,
+            pull: displayPhases.map((phase, i) =>
+                isFiltered[i] ? highlightConfig.pie.selectedOffset : 0
+            ),
             marker: {
                 colors: displayPhases.map((phase, i) => {
                     if (isFiltered[i]) {
@@ -513,7 +521,7 @@
                     }),
                     width: displayPhases.map((phase, i) => {
                         if (isFiltered[i]) {
-                            return 3;
+                            return highlightConfig.pie.borderWidth;
                         }
                         return 1;
                     })


### PR DESCRIPTION
## Summary
- add centralized highlightConfig for selection styling
- narrow selected bars and pull out selected pie slices for clearer emphasis
- align type and phase charts with new highlight behavior

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68959d149188832ab880e6fd18e53ee5