### PR TITLE
style: sync filter tag colors with dashboard

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -120,8 +120,8 @@
 }
 
 .filter-tag {
-    background: #4A90E2;
-    color: white;
+    background: #e0e0e0;
+    color: #333;
     padding: 6px 12px;
     border-radius: 20px;
     font-size: 12px;
@@ -137,7 +137,7 @@
 .filter-tag-remove {
     background: none;
     border: none;
-    color: white;
+    color: inherit;
     font-size: 16px;
     line-height: 1;
     cursor: pointer;
@@ -152,7 +152,7 @@
 }
 
 .filter-tag-remove:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.1);
 }
 
 /* 图表区域 */

--- a/js/dashboard-aptamer.js
+++ b/js/dashboard-aptamer.js
@@ -695,34 +695,58 @@ const originalUpdateFilterTags = FilterModule.updateFilterTags;
 FilterModule.updateFilterTags = function() {
     const tagsContainer = document.getElementById('filterTags');
     if (!tagsContainer) return;
-    
+
     tagsContainer.innerHTML = '';
-    
+
+    // 颜色映射
+    const allYears = [...new Set(originalData.map(d => d.year))].sort();
+    const yearColorMap = {};
+    allYears.forEach((year, i) => {
+        yearColorMap[year] = morandiColors[i % morandiColors.length];
+    });
+
+    const allCategories = [...new Set(originalData.map(d => d.category))];
+    const categoryColorMap = {};
+    allCategories.forEach((cat, i) => {
+        if (categoryPaletteMap && categoryPaletteMap[cat]) {
+            categoryColorMap[cat] = categoryPaletteMap[cat];
+        } else {
+            categoryColorMap[cat] = morandiColors[i % morandiColors.length];
+        }
+    });
+
+    const typeColorMap = {};
+    if (typeof displayTypes !== 'undefined') {
+        displayTypes.forEach((type, i) => {
+            typeColorMap[type] = morandiColors[i % morandiColors.length];
+        });
+    }
+
     // Year tags
     activeFilters.years.forEach(year => {
-        const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year));
+        const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year), yearColorMap[year]);
         tagsContainer.appendChild(tag);
     });
-    
+
     // Category tags
     activeFilters.categories.forEach(category => {
-        const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category));
+        const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category), categoryColorMap[category]);
         tagsContainer.appendChild(tag);
     });
-    
+
     // Type tags
     if (activeFilters.types) {
         activeFilters.types.forEach(type => {
-            const tag = createFilterTag(`Type: ${type}`, () => this.toggleTypeFilter(type));
+            const tag = createFilterTag(`Type: ${type}`, () => this.toggleTypeFilter(type), typeColorMap[type]);
             tagsContainer.appendChild(tag);
         });
     }
-    
+
     // Scatter plot filter tag
     if (activeFilters.scatterSelection) {
         const sel = activeFilters.scatterSelection;
         const text = `Range: ${sel.xrange[0].toFixed(0)}-${sel.xrange[1].toFixed(0)}bp, ${sel.yrange[0].toFixed(1)}-${sel.yrange[1].toFixed(1)}%`;
-        const tag = createFilterTag(text, () => this.clearScatterSelection());
+        const tag = createFilterTag(text, () => this.clearScatterSelection(), morandiHighlight);
         tagsContainer.appendChild(tag);
     }
     

--- a/js/dashboard-config.js
+++ b/js/dashboard-config.js
@@ -212,15 +212,30 @@ function hideAmirTooltip() {
     tooltip.style.opacity = '0';
 }
 
-// 创建筛选标签
-function createFilterTag(text, onRemove) {
+// 计算给定背景色的对比文本色
+function getContrastColor(hex) {
+    if (!hex) return '#333';
+    const c = hex.replace('#', '');
+    const r = parseInt(c.substr(0, 2), 16);
+    const g = parseInt(c.substr(2, 2), 16);
+    const b = parseInt(c.substr(4, 2), 16);
+    const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+    return yiq >= 150 ? '#333' : '#fff';
+}
+
+// 创建筛选标签，支持自定义颜色
+function createFilterTag(text, onRemove, color) {
     const tag = document.createElement('div');
     tag.className = 'filter-tag';
+    if (color) {
+        tag.style.background = color;
+        tag.style.color = getContrastColor(color);
+    }
     tag.innerHTML = `
         <span class="filter-tag-text">${text}</span>
         <button class="filter-tag-remove" type="button">×</button>
     `;
-    
+
     tag.querySelector('.filter-tag-remove').addEventListener('click', onRemove);
     return tag;
 }

--- a/js/dashboard-main.js
+++ b/js/dashboard-main.js
@@ -981,24 +981,41 @@ const FilterModule = {
     updateFilterTags() {
         const tagsContainer = document.getElementById('filterTags');
         tagsContainer.innerHTML = '';
-        
+
+        // 颜色映射
+        const allYears = [...new Set(originalData.map(d => d.year))].sort();
+        const yearColorMap = {};
+        allYears.forEach((year, i) => {
+            yearColorMap[year] = morandiColors[i % morandiColors.length];
+        });
+
+        const allCategories = [...new Set(originalData.map(d => d.category))];
+        const categoryColorMap = {};
+        allCategories.forEach((cat, i) => {
+            if (categoryPaletteMap && categoryPaletteMap[cat]) {
+                categoryColorMap[cat] = categoryPaletteMap[cat];
+            } else {
+                categoryColorMap[cat] = morandiColors[i % morandiColors.length];
+            }
+        });
+
         // Year tags
         activeFilters.years.forEach(year => {
-            const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year));
+            const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year), yearColorMap[year]);
             tagsContainer.appendChild(tag);
         });
-        
+
         // Category tags
         activeFilters.categories.forEach(category => {
-            const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category));
+            const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category), categoryColorMap[category]);
             tagsContainer.appendChild(tag);
         });
-        
+
         // Scatter plot filter tag
         if (activeFilters.scatterSelection) {
             const sel = activeFilters.scatterSelection;
             const text = `Range: ${sel.xrange[0].toFixed(0)}-${sel.xrange[1].toFixed(0)}bp, ${sel.yrange[0].toFixed(1)}-${sel.yrange[1].toFixed(1)}%`;
-            const tag = createFilterTag(text, () => this.clearScatterSelection());
+            const tag = createFilterTag(text, () => this.clearScatterSelection(), morandiHighlight);
             tagsContainer.appendChild(tag);
         }
         

--- a/js/dashboard-structures.js
+++ b/js/dashboard-structures.js
@@ -796,15 +796,32 @@
             }
             tagsContainer.innerHTML = '';
 
+            // 颜色映射
+            const allMethods = [...new Set(originalData.map(d => d.method))].sort();
+            const methodColorMap = {};
+            allMethods.forEach((m, i) => {
+                methodColorMap[m] = morandiColors[i % morandiColors.length];
+            });
+
+            const allCategories = [...new Set(originalData.map(d => d.category))];
+            const categoryColorMap = {};
+            allCategories.forEach((cat, i) => {
+                if (categoryPaletteMap && categoryPaletteMap[cat]) {
+                    categoryColorMap[cat] = categoryPaletteMap[cat];
+                } else {
+                    categoryColorMap[cat] = morandiColors[i % morandiColors.length];
+                }
+            });
+
             // 将年份筛选标签前缀改为 Methods
             activeFilters.years.forEach(year => {
-                const tag = createFilterTag(`Methods: ${year}`, () => this.toggleYearFilter(year));
+                const tag = createFilterTag(`Methods: ${year}`, () => this.toggleYearFilter(year), methodColorMap[year]);
                 tagsContainer.appendChild(tag);
             });
 
             // 类别筛选标签保持不变
             activeFilters.categories.forEach(category => {
-                const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category));
+                const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category), categoryColorMap[category]);
                 tagsContainer.appendChild(tag);
             });
 
@@ -812,7 +829,7 @@
             if (activeFilters.scatterSelection) {
                 const sel = activeFilters.scatterSelection;
                 const text = `Range: ${sel.xrange[0].toFixed(0)}-${sel.xrange[1].toFixed(0)}bp, ${sel.yrange[0].toFixed(1)}-${sel.yrange[1].toFixed(1)}%`;
-                const tag = createFilterTag(text, () => this.clearScatterSelection());
+                const tag = createFilterTag(text, () => this.clearScatterSelection(), morandiHighlight);
                 tagsContainer.appendChild(tag);
             }
 


### PR DESCRIPTION
## Summary
- match filter tag backgrounds with dashboard color palette
- compute tag text contrast automatically
- color-code filtering tags across aptamer and structure dashboards

## Testing
- `npm run test:minify`


------
https://chatgpt.com/codex/tasks/task_e_6895a033b718832a90f953ce3c7e1a49