### PR TITLE
style: colorize filter tags and denote node level

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -120,24 +120,53 @@
 }
 
 .filter-tag {
-    background: #4A90E2;
-    color: white;
-    padding: 6px 12px;
-    border-radius: 20px;
-    font-size: 12px;
     display: flex;
     align-items: center;
-    gap: 8px;
+    cursor: default;
+    border-radius: 16px;
+    padding: 4px 10px 4px 4px;
+    background: #f8f9fa;
+    transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
+}
+
+.filter-tag:hover {
+    box-shadow: 0 2px 8px rgba(80,0,73,0.10);
+    filter: brightness(1.1);
+}
+
+.filter-tag.active {
+    box-shadow: 0 0 0 2px var(--legend-border, rgba(82,0,73,0.2));
+}
+
+.filter-tag .legend-color {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    margin-right: 7px;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 1px #ccc;
 }
 
 .filter-tag-text {
+    font-size: 13px;
+    color: inherit;
     font-weight: 500;
+}
+
+.filter-tag-level {
+    margin-left: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 0 4px;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.3);
 }
 
 .filter-tag-remove {
     background: none;
     border: none;
-    color: white;
+    color: #666;
     font-size: 16px;
     line-height: 1;
     cursor: pointer;
@@ -152,7 +181,7 @@
 }
 
 .filter-tag-remove:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.1);
 }
 
 /* 图表区域 */

--- a/js/dashboard-aptamer.js
+++ b/js/dashboard-aptamer.js
@@ -695,34 +695,58 @@ const originalUpdateFilterTags = FilterModule.updateFilterTags;
 FilterModule.updateFilterTags = function() {
     const tagsContainer = document.getElementById('filterTags');
     if (!tagsContainer) return;
-    
+
     tagsContainer.innerHTML = '';
-    
+
+    // 颜色映射
+    const allYears = [...new Set(originalData.map(d => d.year))].sort();
+    const yearColorMap = {};
+    allYears.forEach((year, i) => {
+        yearColorMap[year] = morandiColors[i % morandiColors.length];
+    });
+
+    const allCategories = [...new Set(originalData.map(d => d.category))];
+    const categoryColorMap = {};
+    allCategories.forEach((cat, i) => {
+        if (categoryPaletteMap && categoryPaletteMap[cat]) {
+            categoryColorMap[cat] = categoryPaletteMap[cat];
+        } else {
+            categoryColorMap[cat] = morandiColors[i % morandiColors.length];
+        }
+    });
+
+    const typeColorMap = {};
+    if (typeof displayTypes !== 'undefined') {
+        displayTypes.forEach((type, i) => {
+            typeColorMap[type] = morandiColors[i % morandiColors.length];
+        });
+    }
+
     // Year tags
     activeFilters.years.forEach(year => {
-        const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year));
+        const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year), yearColorMap[year], 'yearChart');
         tagsContainer.appendChild(tag);
     });
-    
+
     // Category tags
     activeFilters.categories.forEach(category => {
-        const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category));
+        const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category), categoryColorMap[category], 'ligandChart');
         tagsContainer.appendChild(tag);
     });
-    
+
     // Type tags
     if (activeFilters.types) {
         activeFilters.types.forEach(type => {
-            const tag = createFilterTag(`Type: ${type}`, () => this.toggleTypeFilter(type));
+            const tag = createFilterTag(`Type: ${type}`, () => this.toggleTypeFilter(type), typeColorMap[type], 'typeChart');
             tagsContainer.appendChild(tag);
         });
     }
-    
+
     // Scatter plot filter tag
     if (activeFilters.scatterSelection) {
         const sel = activeFilters.scatterSelection;
         const text = `Range: ${sel.xrange[0].toFixed(0)}-${sel.xrange[1].toFixed(0)}bp, ${sel.yrange[0].toFixed(1)}-${sel.yrange[1].toFixed(1)}%`;
-        const tag = createFilterTag(text, () => this.clearScatterSelection());
+        const tag = createFilterTag(text, () => this.clearScatterSelection(), morandiHighlight, 'scatterChart');
         tagsContainer.appendChild(tag);
     }
     

--- a/js/dashboard-config.js
+++ b/js/dashboard-config.js
@@ -212,15 +212,43 @@ function hideAmirTooltip() {
     tooltip.style.opacity = '0';
 }
 
-// 创建筛选标签
-function createFilterTag(text, onRemove) {
+// 根据背景色计算对比文字颜色
+function getContrastColor(color) {
+    if (!color) return '#333';
+    const hex = color.replace('#', '');
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+    const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+    return yiq >= 128 ? '#333' : '#fff';
+}
+
+// 获取节点层级标签（A/B/C...）
+function getNodeLevel(nodeId) {
+    const index = nodeInteractionOrder.indexOf(nodeId);
+    const labels = ['A', 'B', 'C', 'D'];
+    return index >= 0 ? labels[index] : '';
+}
+
+// 创建筛选标签，使用图例风格展示颜色
+function createFilterTag(text, onRemove, color, nodeId) {
     const tag = document.createElement('div');
-    tag.className = 'filter-tag';
+    tag.className = 'filter-tag active';
+    let textColor = '#333';
+    if (color) {
+        tag.style.setProperty('--legend-border', color);
+        tag.style.backgroundColor = color;
+        textColor = getContrastColor(color);
+        tag.style.color = textColor;
+    }
+    const levelLabel = getNodeLevel(nodeId);
     tag.innerHTML = `
+        <span class="legend-color" style="background:${color || '#e0e0e0'}"></span>
         <span class="filter-tag-text">${text}</span>
+        ${levelLabel ? `<span class="filter-tag-level">${levelLabel}</span>` : ''}
         <button class="filter-tag-remove" type="button">×</button>
     `;
-    
+
     tag.querySelector('.filter-tag-remove').addEventListener('click', onRemove);
     return tag;
 }

--- a/js/dashboard-main.js
+++ b/js/dashboard-main.js
@@ -981,24 +981,41 @@ const FilterModule = {
     updateFilterTags() {
         const tagsContainer = document.getElementById('filterTags');
         tagsContainer.innerHTML = '';
-        
+
+        // 颜色映射
+        const allYears = [...new Set(originalData.map(d => d.year))].sort();
+        const yearColorMap = {};
+        allYears.forEach((year, i) => {
+            yearColorMap[year] = morandiColors[i % morandiColors.length];
+        });
+
+        const allCategories = [...new Set(originalData.map(d => d.category))];
+        const categoryColorMap = {};
+        allCategories.forEach((cat, i) => {
+            if (categoryPaletteMap && categoryPaletteMap[cat]) {
+                categoryColorMap[cat] = categoryPaletteMap[cat];
+            } else {
+                categoryColorMap[cat] = morandiColors[i % morandiColors.length];
+            }
+        });
+
         // Year tags
         activeFilters.years.forEach(year => {
-            const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year));
+            const tag = createFilterTag(`Year: ${year}`, () => this.toggleYearFilter(year), yearColorMap[year], 'yearChart');
             tagsContainer.appendChild(tag);
         });
-        
+
         // Category tags
         activeFilters.categories.forEach(category => {
-            const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category));
+            const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category), categoryColorMap[category], 'ligandChart');
             tagsContainer.appendChild(tag);
         });
-        
+
         // Scatter plot filter tag
         if (activeFilters.scatterSelection) {
             const sel = activeFilters.scatterSelection;
             const text = `Range: ${sel.xrange[0].toFixed(0)}-${sel.xrange[1].toFixed(0)}bp, ${sel.yrange[0].toFixed(1)}-${sel.yrange[1].toFixed(1)}%`;
-            const tag = createFilterTag(text, () => this.clearScatterSelection());
+            const tag = createFilterTag(text, () => this.clearScatterSelection(), morandiHighlight, 'scatterChart');
             tagsContainer.appendChild(tag);
         }
         

--- a/js/dashboard-structures.js
+++ b/js/dashboard-structures.js
@@ -796,15 +796,32 @@
             }
             tagsContainer.innerHTML = '';
 
+            // 颜色映射
+            const allMethods = [...new Set(originalData.map(d => d.method))].sort();
+            const methodColorMap = {};
+            allMethods.forEach((m, i) => {
+                methodColorMap[m] = morandiColors[i % morandiColors.length];
+            });
+
+            const allCategories = [...new Set(originalData.map(d => d.category))];
+            const categoryColorMap = {};
+            allCategories.forEach((cat, i) => {
+                if (categoryPaletteMap && categoryPaletteMap[cat]) {
+                    categoryColorMap[cat] = categoryPaletteMap[cat];
+                } else {
+                    categoryColorMap[cat] = morandiColors[i % morandiColors.length];
+                }
+            });
+
             // 将年份筛选标签前缀改为 Methods
             activeFilters.years.forEach(year => {
-                const tag = createFilterTag(`Methods: ${year}`, () => this.toggleYearFilter(year));
+                const tag = createFilterTag(`Methods: ${year}`, () => this.toggleYearFilter(year), methodColorMap[year], 'yearChart');
                 tagsContainer.appendChild(tag);
             });
 
             // 类别筛选标签保持不变
             activeFilters.categories.forEach(category => {
-                const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category));
+                const tag = createFilterTag(`Category: ${category}`, () => this.toggleCategoryFilter(category), categoryColorMap[category], 'ligandChart');
                 tagsContainer.appendChild(tag);
             });
 
@@ -812,7 +829,7 @@
             if (activeFilters.scatterSelection) {
                 const sel = activeFilters.scatterSelection;
                 const text = `Range: ${sel.xrange[0].toFixed(0)}-${sel.xrange[1].toFixed(0)}bp, ${sel.yrange[0].toFixed(1)}-${sel.yrange[1].toFixed(1)}%`;
-                const tag = createFilterTag(text, () => this.clearScatterSelection());
+                const tag = createFilterTag(text, () => this.clearScatterSelection(), morandiHighlight, 'scatterChart');
                 tagsContainer.appendChild(tag);
             }
 


### PR DESCRIPTION
## Summary
- color filter tags with palette-matched backgrounds and auto-contrast text
- label each active filter with its node level (A/B/C)
- link structure dashboard filters to chart colors for correct visualization

## Testing
- `npm run test:minify`


------
https://chatgpt.com/codex/tasks/task_e_6895a033b718832a90f953ce3c7e1a49