### PR TITLE
Fix pie slice highlight and unify filter tag styling

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -126,6 +126,7 @@
     border-radius: 16px;
     padding: 4px 10px 4px 4px;
     background: #f8f9fa;
+    box-shadow: 0 0 0 2px var(--legend-border, rgba(82,0,73,0.2));
     transition: box-shadow 0.2s, transform 0.2s, filter 0.2s;
 }
 
@@ -133,10 +134,6 @@
     box-shadow: 0 2px 8px rgba(80,0,73,0.10);
     filter: brightness(1.1);
 
-}
-
-.filter-tag.active {
-    box-shadow: 0 0 0 2px var(--legend-border, rgba(82,0,73,0.2));
 }
 
 .filter-tag .legend-color {


### PR DESCRIPTION
## Summary
- Restore scaling and shadow when highlighting pie slices by applying styles after animation in data order
- Colorize filter tag borders without filling backgrounds to keep styles consistent across pages
- Remove generic active class from filter tags so external styles no longer grey them out

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:minify`


------
https://chatgpt.com/codex/tasks/task_e_6895c0ae632c832a90851499906762a0