### PR TITLE
Fix pie chart highlight regression

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -199,11 +199,15 @@
     background: white;
     border-radius: 12px;
     border: 1px solid #e9ecef;
-    overflow: hidden;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 }
 
+.chart-wrapper {
+    overflow: visible;
+}
+
 .analysis-wrapper {
+    overflow: hidden;
     grid-column: 1 / -1;
 }
 
@@ -499,8 +503,9 @@ body[data-page="aptamer"] .amir-tooltip {
     cursor: pointer !important;
 }
 
-/* 散点图特定优化 */
-#scatterChart .plotly .main-svg {
+/* 允许图表元素溢出以展示高亮效果 */
+#scatterChart .plotly .main-svg,
+#ligandChart .plotly .main-svg {
     overflow: visible;
 }
 

--- a/js/dashboard-main.js
+++ b/js/dashboard-main.js
@@ -529,9 +529,12 @@ const ChartModule = {
             }
         };
         
-        Plotly.newPlot('ligandChart', [trace], layout, pieChartConfig).then(() => {
+        const plotResult = Plotly.newPlot('ligandChart', [trace], layout, pieChartConfig);
+        if (plotResult && typeof plotResult.then === 'function') {
+            plotResult.then(() => applyPieHighlight('ligandChart', isFiltered));
+        } else {
             applyPieHighlight('ligandChart', isFiltered);
-        });
+        }
 
         document.getElementById('ligandChart').on('plotly_click', function(data) {
             const category = data.points[0].label;


### PR DESCRIPTION
## Summary
- Let chart cards show pulled pie slices by removing overflow clipping
- Ensure pie chart SVGs allow overflow so slice highlights are visible

## Testing
- `npm run test:minify`


------
https://chatgpt.com/codex/tasks/task_e_6896c87f3358832a9c6e22bef28e24cb