### PR TITLE
fix: prevent duplicate table page opening

### DIFF
--- a/js/aptamer-table-generator.js
+++ b/js/aptamer-table-generator.js
@@ -405,10 +405,11 @@ class AptamerTableGenerator {
      * 初始化交互功能
      */
     initializeInteractions() {
-        // 点击单元格打开链接
+        // 点击单元格打开链接。避免与单元格内的<a>标签重复触发
         this.container.addEventListener('click', (e) => {
             const cell = e.target.closest('.aptamer-cell');
-            if (cell) {
+            // 如果点击发生在<a>标签内，则交由默认行为处理
+            if (cell && !e.target.closest('a')) {
                 const link = cell.getAttribute('data-link');
                 if (link) {
                     window.open(link, '_blank');


### PR DESCRIPTION
## Summary
- avoid duplicate page opens when clicking aptamer tables by ignoring clicks on existing links

## Testing
- `npm run test:minify`


------
https://chatgpt.com/codex/tasks/task_e_68a1e3f194bc832a9d57fd76f79f20fe